### PR TITLE
Enable macOS code signing and notarization

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -37,6 +37,26 @@ jobs:
       - name: Prepare Python bundle
         run: ./build-scripts/prepare_bundle.sh macos-arm64
 
+      - name: Import Apple certificate
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          CERT_FILE=$RUNNER_TEMP/certificate.p12
+          KEYCHAIN_PATH=$RUNNER_TEMP/signing.keychain-db
+          echo -n "$APPLE_CERTIFICATE" | base64 --decode -o $CERT_FILE
+          security create-keychain -p "${{ github.run_id }}" $KEYCHAIN_PATH
+          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+          security unlock-keychain -p "${{ github.run_id }}" $KEYCHAIN_PATH
+          security import $CERT_FILE -P "$APPLE_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+          security set-key-partition-list -S apple-tool:,apple: -k "${{ github.run_id }}" $KEYCHAIN_PATH
+          security list-keychain -d user -s $KEYCHAIN_PATH
+
+      - name: Sign Python bundle binaries
+        run: ./build-scripts/sign_python_bundle.sh
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+
       - name: Build
         run: cargo tauri build
         env:

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -39,14 +39,13 @@ jobs:
 
       - name: Build
         run: cargo tauri build
-        # env:
-        #   # For code signing (requires secrets to be set)
-        #   APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-        #   APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-        #   APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-        #   APPLE_ID: ${{ secrets.APPLE_ID }}
-        #   APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-        #   APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
       - name: Upload DMG
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Settings are stored in `settings.json`:
 
 ### macOS: "App is damaged and can't be opened"
 
-The app is not currently code-signed. macOS Gatekeeper may block it with a "damaged" message. To fix this, run:
+The app is code-signed and notarized. If you still encounter this message (e.g., from a development build), run:
 
 ```bash
 xattr -c "/Applications/ESPHome Builder.app"

--- a/build-scripts/entitlements.plist
+++ b/build-scripts/entitlements.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>

--- a/build-scripts/sign_python_bundle.sh
+++ b/build-scripts/sign_python_bundle.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Sign all Mach-O binaries in the Python bundle for macOS notarization
+#
+# This must run AFTER prepare_bundle.sh and BEFORE cargo tauri build.
+# All executables, dylibs, and .so files need to be individually signed
+# with hardened runtime and secure timestamps for Apple notarization.
+#
+# Required environment variable:
+#   APPLE_SIGNING_IDENTITY - The Developer ID identity to sign with
+
+set -e
+
+if [[ -z "$APPLE_SIGNING_IDENTITY" ]]; then
+    echo "APPLE_SIGNING_IDENTITY is not set, skipping bundle signing"
+    exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+BUNDLE_DIR="$PROJECT_DIR/src-tauri/python"
+ENTITLEMENTS="$SCRIPT_DIR/entitlements.plist"
+
+if [[ ! -d "$BUNDLE_DIR" ]]; then
+    echo "Error: Python bundle not found at $BUNDLE_DIR"
+    echo "Run prepare_bundle.sh first."
+    exit 1
+fi
+
+echo "=== Signing Python bundle binaries ==="
+echo "Identity: $APPLE_SIGNING_IDENTITY"
+echo "Entitlements: $ENTITLEMENTS"
+echo ""
+
+SIGNED=0
+
+# Find all Mach-O files (executables, dylibs, .so files)
+# Sign dylibs and .so files first (inside-out signing)
+echo "--- Signing shared libraries (.dylib and .so) ---"
+while IFS= read -r -d '' file; do
+    echo "Signing: ${file#$BUNDLE_DIR/}"
+    codesign --force --options runtime --timestamp \
+        --entitlements "$ENTITLEMENTS" \
+        --sign "$APPLE_SIGNING_IDENTITY" "$file"
+    SIGNED=$((SIGNED + 1))
+done < <(find "$BUNDLE_DIR" \( -name "*.dylib" -o -name "*.so" \) -print0)
+
+# Sign executables in bin/
+echo ""
+echo "--- Signing executables ---"
+while IFS= read -r -d '' file; do
+    # Only sign Mach-O binaries, skip scripts
+    if file "$file" | grep -q "Mach-O"; then
+        echo "Signing: ${file#$BUNDLE_DIR/}"
+        codesign --force --options runtime --timestamp \
+            --entitlements "$ENTITLEMENTS" \
+            --sign "$APPLE_SIGNING_IDENTITY" "$file"
+        SIGNED=$((SIGNED + 1))
+    fi
+done < <(find "$BUNDLE_DIR/bin" -type f -print0)
+
+echo ""
+echo "=== Signed $SIGNED binaries ==="


### PR DESCRIPTION
## Summary
- Uncomment Apple code signing secrets in the macOS build workflow now that repository secrets are configured
- Update README troubleshooting to reflect that releases are signed and notarized

## Changes
- `.github/workflows/build-macos.yml`: Enable `APPLE_CERTIFICATE`, `APPLE_CERTIFICATE_PASSWORD`, `APPLE_SIGNING_IDENTITY`, `APPLE_ID`, `APPLE_PASSWORD`, and `APPLE_TEAM_ID` environment variables for the build step
- `README.md`: Update the "App is damaged" troubleshooting section to note the app is now code-signed
