### PR TITLE
Add RPM package artifact upload to Linux build workflow

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -69,6 +69,12 @@ jobs:
           name: linux-deb
           path: src-tauri/target/release/bundle/deb/*.deb
 
+      - name: Upload RPM
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-rpm
+          path: src-tauri/target/release/bundle/rpm/*.rpm
+
   release:
     needs: build
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds RPM package upload to the Linux build workflow alongside existing AppImage and .deb packages.

RPM files are now included in CI artifacts and releases for Fedora/RHEL/openSUSE users.