### PR TITLE
Add flag to not open browser

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -42,6 +42,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,6 +504,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5caf74d17c3aec5495110c34cc3f78644bfa89af6c8993ed4de2790e49b6499"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "370daa45065b80218950227371916a1633217ae42b2715b2287b606dcd618e24"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+
+[[package]]
 name = "cocoa"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -481,6 +571,12 @@ dependencies = [
  "core-graphics-types",
  "objc",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "combine"
@@ -920,9 +1016,10 @@ dependencies = [
 
 [[package]]
 name = "esphome-desktop"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
+ "clap",
  "cocoa",
  "dirs 5.0.1",
  "log",
@@ -1806,6 +1903,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2470,6 +2573,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "open"
@@ -4808,6 +4917,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -43,6 +43,9 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 thiserror = "2.0"
 anyhow = "1.0"
 
+# CLI argument parsing
+clap = { version = "4.5", features = ["derive"] }
+
 # Open URLs/files with default application
 open = "5"
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@ mod tray;
 mod update;
 
 use anyhow::Result;
+use clap::Parser;
 use std::sync::Arc;
 use tauri::{
     async_runtime, AppHandle, Manager, RunEvent,
@@ -23,6 +24,16 @@ use daemon::DaemonManager;
 use settings::Settings;
 use tray::build_tray_menu;
 use update::UpdateChecker;
+
+/// ESPHome Desktop - System tray application for ESPHome
+#[derive(Parser, Debug, Clone)]
+#[command(name = "esphome-desktop")]
+#[command(about = "ESPHome Desktop Builder", long_about = None)]
+pub struct Cli {
+    /// Don't open the dashboard in browser on startup
+    #[arg(long = "no-open-dashboard")]
+    pub no_open_dashboard: bool,
+}
 
 /// Application state shared across the app
 pub struct AppState {
@@ -99,9 +110,13 @@ fn handle_tray_click(_app: &AppHandle, state: &AppState) {
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
-pub fn run() {
+pub fn run(cli: Cli) {
     init_logging();
     info!("Starting ESPHome Builder");
+    info!("CLI args: {:?}", cli);
+
+    // Capture CLI flags before closure
+    let no_open_dashboard = cli.no_open_dashboard;
 
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
@@ -119,7 +134,7 @@ pub fn run() {
                 open_dashboard(settings.port);
             }
         }))
-        .setup(|app| {
+        .setup(move |app| {
             info!("Setting up ESPHome Builder");
 
             // Ensure user venv exists (copy from bundled on first run)
@@ -226,8 +241,10 @@ pub fn run() {
 
             // Open dashboard on first start (after it's ready)
             let settings = async_runtime::block_on(state.settings.read());
-            if settings.open_on_start {
+            let should_open = settings.open_on_start && !no_open_dashboard;
+            if should_open {
                 let port = settings.port;
+                info!("Opening dashboard on startup");
                 // Wait for dashboard to be ready, then open browser
                 async_runtime::spawn(async move {
                     if wait_for_dashboard_ready(port, 60).await {
@@ -237,6 +254,8 @@ pub fn run() {
                         open_dashboard(port);
                     }
                 });
+            } else if no_open_dashboard {
+                info!("Dashboard opening suppressed by --no-open-dashboard flag");
             }
 
             Ok(())

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,6 +1,10 @@
 // Prevents additional console window on Windows in release
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+use clap::Parser;
+use esphome_desktop_lib::Cli;
+
 fn main() {
-    esphome_desktop_lib::run()
+    let cli = Cli::parse();
+    esphome_desktop_lib::run(cli)
 }


### PR DESCRIPTION
Introduce a command-line flag to suppress the automatic opening of the dashboard in the browser on startup. This enhancement allows users to control the application's behavior more effectively.