### PR TITLE
Use ESPHome logo in NSIS installer

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -37,7 +37,10 @@
     "windows": {
       "certificateThumbprint": null,
       "digestAlgorithm": "sha256",
-      "timestampUrl": ""
+      "timestampUrl": "",
+      "nsis": {
+        "installerIcon": "icons/icon.ico"
+      }
     },
     "linux": {
       "appimage": {


### PR DESCRIPTION
Configures the NSIS Windows installer to use the ESPHome logo (icon.ico) as the installer icon.