### PR TITLE
Fix .SRCINFO uploading

### DIFF
--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -72,6 +72,7 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: aur-pkg
+          include-hidden-files: true
           path: |
             aur-pkg/PKGBUILD
             aur-pkg/.SRCINFO


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow configuration for publishing to AUR. The change ensures that hidden files are included when uploading the `aur-pkg` artifact.

* Workflow configuration:
  * Added the `include-hidden-files: true` option to the `upload-artifact` step in `.github/workflows/publish-aur.yml`, ensuring hidden files in the `aur-pkg` directory are included in the artifact upload.