### PR TITLE
Build RPM artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,12 @@ jobs:
           - platform: linux
             os: ubuntu-22.04
             target: linux-x64
-            bundles: appimage,deb
+            bundles: appimage,deb,rpm
+            tauri_branch: feat/truly-portable-appimage
+          - platform: linux
+            os: ubuntu-22.04
+            target: linux-x64
+            bundles: rpm
           - platform: macos
             os: macos-15
             target: macos-arm64
@@ -78,18 +83,15 @@ jobs:
           workspaces: src-tauri
           key: ${{ matrix.target }}
 
-      # Linux uses custom tauri-cli for portable AppImage
-      - name: Install Tauri CLI (Linux - custom branch for portable AppImage)
-        if: matrix.platform == 'linux'
-        run: |
-          # Use custom tauri-cli branch with truly portable AppImage format
-          # This avoids linuxdeploy issues with vendored Python libraries
-          cargo install tauri-cli --git https://github.com/tauri-apps/tauri --branch feat/truly-portable-appimage --locked --force
-
-      # Windows and macOS use standard tauri-cli
       - name: Install Tauri CLI
-        if: matrix.platform != 'linux'
-        run: cargo install tauri-cli --locked
+        run: |
+          if [[ -n "${{ matrix.tauri_branch }}" ]]; then
+            # Custom tauri-cli branch (e.g. for portable AppImage format)
+            cargo install tauri-cli --git https://github.com/tauri-apps/tauri --branch ${{ matrix.tauri_branch }} --locked --force
+          else
+            cargo install tauri-cli --locked
+          fi
+        shell: bash
 
       - name: Prepare Python bundle
         shell: bash
@@ -163,7 +165,7 @@ jobs:
       # resources. The build leaves the AppDir intact, so we inject Python into
       # it and repack with mkdwarfs + the uruntime header.
       - name: Inject Python into AppImage
-        if: matrix.platform == 'linux'
+        if: contains(matrix.bundles, 'appimage')
         run: |
           set -euo pipefail
 
@@ -203,28 +205,35 @@ jobs:
 
       # Upload artifacts
       - name: Upload NSIS
-        if: matrix.platform == 'windows'
+        if: contains(matrix.bundles, 'nsis')
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           path: src-tauri/target/release/bundle/nsis/*.exe
           archive: false
 
       - name: Upload AppImage
-        if: matrix.platform == 'linux'
+        if: contains(matrix.bundles, 'appimage')
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           path: src-tauri/target/release/bundle/appimage/*.AppImage
           archive: false
 
       - name: Upload deb
-        if: matrix.platform == 'linux'
+        if: contains(matrix.bundles, 'deb')
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           path: src-tauri/target/release/bundle/deb/*.deb
           archive: false
 
+      - name: Upload RPM
+        if: contains(matrix.bundles, 'rpm')
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          path: src-tauri/target/release/bundle/rpm/*.rpm
+          archive: false
+
       - name: Upload DMG
-        if: matrix.platform == 'macos'
+        if: contains(matrix.bundles, 'dmg')
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           path: src-tauri/target/${{ matrix.rust_target && format('{0}/', matrix.rust_target) || '' }}release/bundle/dmg/*.dmg
@@ -283,6 +292,7 @@ jobs:
 
           write_links "AppImage"
           write_links "deb"
+          write_links "rpm"
 
           cat >> comment.md <<'EOF'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,12 +34,12 @@ jobs:
           - platform: linux
             os: ubuntu-22.04
             target: linux-x64
-            bundles: appimage,deb,rpm
+            bundles: appimage
             tauri_branch: feat/truly-portable-appimage
           - platform: linux
             os: ubuntu-22.04
             target: linux-x64
-            bundles: rpm
+            bundles: deb,rpm
           - platform: macos
             os: macos-15
             target: macos-arm64


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

This pull request updates the GitHub Actions workflow in `.github/workflows/build.yml` to improve packaging and artifact handling, especially for Linux builds. The changes add RPM packaging support, generalize artifact upload conditions, and streamline the Tauri CLI installation process.

**Packaging and build matrix improvements:**

* Added RPM packaging to the Linux build matrix and included a dedicated job for building RPM packages.
* The workflow now uses a `tauri_branch` matrix variable for Linux jobs that require a custom Tauri CLI branch for truly portable AppImage support.

**Tauri CLI installation logic:**

* Unified Tauri CLI installation step: the workflow now conditionally installs either the custom branch or the default Tauri CLI based on the presence of the `tauri_branch` variable, simplifying the logic and reducing duplication.

**Artifact upload and workflow condition improvements:**

* Artifact upload steps now use `contains(matrix.bundles, ...)` conditions for all bundle types (AppImage, deb, rpm, nsis, dmg), making the workflow more robust and flexible for different packaging targets.
* Added a step to upload RPM artifacts when RPM packaging is selected.
* The "Inject Python into AppImage" step is now conditioned on AppImage being present in the bundle list, not just on the Linux platform.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- Closes https://github.com/esphome/esphome-desktop/issues/49

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).
