### PR TITLE
Add release channel choice

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -229,6 +229,7 @@ pub fn run(cli: Cli) {
             });
 
             // Start update checker (check after 30s, then every 24 hours)
+            // The dev channel skips automatic update checks entirely.
             let update_state = state.clone();
             let update_app = app.handle().clone();
             async_runtime::spawn(async move {
@@ -236,9 +237,13 @@ pub fn run(cli: Cli) {
                 let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(86400));
                 loop {
                     interval.tick().await;
+                    let channel = {
+                        let settings = update_state.settings.read().await;
+                        settings.release_channel
+                    };
                     update_state
                         .update_checker
-                        .check_and_notify(&update_app)
+                        .check_and_notify(&update_app, channel)
                         .await;
                 }
             });

--- a/src-tauri/src/settings/mod.rs
+++ b/src-tauri/src/settings/mod.rs
@@ -4,6 +4,7 @@
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
+use std::fmt;
 use std::path::PathBuf;
 use tauri::AppHandle;
 use tracing::{debug, info};
@@ -12,6 +13,34 @@ use crate::platform;
 
 /// Default dashboard port
 const DEFAULT_PORT: u16 = 6052;
+
+/// ESPHome release channel
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ReleaseChannel {
+    /// Latest stable release from PyPI
+    Stable,
+    /// Latest beta/pre-release from PyPI
+    Beta,
+    /// Latest development build from GitHub (no auto-updates)
+    Dev,
+}
+
+impl Default for ReleaseChannel {
+    fn default() -> Self {
+        Self::Stable
+    }
+}
+
+impl fmt::Display for ReleaseChannel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Stable => write!(f, "Stable"),
+            Self::Beta => write!(f, "Beta"),
+            Self::Dev => write!(f, "Dev"),
+        }
+    }
+}
 
 /// Application settings
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -31,6 +60,10 @@ pub struct Settings {
     /// Check for updates automatically
     #[serde(default = "default_true")]
     pub check_updates: bool,
+
+    /// Release channel (stable, beta, or dev)
+    #[serde(default)]
+    pub release_channel: ReleaseChannel,
 
     /// Installed ESPHome version (detected from venv)
     #[serde(skip)]
@@ -52,6 +85,7 @@ impl Default for Settings {
             config_dir: None,
             open_on_start: true,
             check_updates: true,
+            release_channel: ReleaseChannel::default(),
             installed_version: None,
         }
     }
@@ -114,9 +148,7 @@ fn detect_installed_version(app_handle: &AppHandle) -> Result<String> {
     let output = cmd.output().context("Failed to run esphome version")?;
 
     if output.status.success() {
-        let version = String::from_utf8_lossy(&output.stdout)
-            .trim()
-            .to_string();
+        let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
         // Extract just the version number (e.g., "2024.1.0" from "Version: 2024.1.0")
         let version = version
             .strip_prefix("Version: ")

--- a/src-tauri/src/tray/mod.rs
+++ b/src-tauri/src/tray/mod.rs
@@ -6,24 +6,31 @@ use anyhow::Result;
 use std::sync::Arc;
 use tauri::{
     async_runtime,
-    menu::{Menu, MenuBuilder, MenuItem, MenuItemBuilder},
+    menu::{CheckMenuItem, CheckMenuItemBuilder, Menu, MenuBuilder, MenuItem, MenuItemBuilder, SubmenuBuilder},
     AppHandle,
 };
 use tauri_plugin_dialog::{DialogExt, MessageDialogKind};
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
+use crate::settings::ReleaseChannel;
 use crate::AppState;
 
 /// Menu item IDs
 mod ids {
     pub const OPEN_DASHBOARD: &str = "open_dashboard";
     pub const STATUS: &str = "status";
+    pub const VERSION: &str = "version";
     pub const PORT: &str = "port";
     pub const CHECK_UPDATES: &str = "check_updates";
     pub const VIEW_LOGS: &str = "view_logs";
     pub const OPEN_CONFIG: &str = "open_config";
     pub const RESTART: &str = "restart";
     pub const QUIT: &str = "quit";
+
+    // Release channel submenu items
+    pub const CHANNEL_STABLE: &str = "channel_stable";
+    pub const CHANNEL_BETA: &str = "channel_beta";
+    pub const CHANNEL_DEV: &str = "channel_dev";
 }
 
 /// Build the tray menu
@@ -41,6 +48,39 @@ pub fn build_tray_menu(app_handle: &AppHandle, state: &Arc<AppState>) -> Result<
         .build(app_handle)?;
     let _ = STATUS_ITEM.set(status_item.clone());
 
+    // Create version display item
+    let version_text = match &settings.installed_version {
+        Some(v) => format!("Version: {}", v),
+        None => "Version: unknown".to_string(),
+    };
+    let version_item = MenuItemBuilder::with_id(ids::VERSION, version_text)
+        .enabled(false)
+        .build(app_handle)?;
+    let _ = VERSION_ITEM.set(version_item.clone());
+
+    // Create release channel check items
+    let current_channel = settings.release_channel;
+    let channel_stable = CheckMenuItemBuilder::with_id(ids::CHANNEL_STABLE, "Stable")
+        .checked(current_channel == ReleaseChannel::Stable)
+        .build(app_handle)?;
+    let channel_beta = CheckMenuItemBuilder::with_id(ids::CHANNEL_BETA, "Beta")
+        .checked(current_channel == ReleaseChannel::Beta)
+        .build(app_handle)?;
+    let channel_dev = CheckMenuItemBuilder::with_id(ids::CHANNEL_DEV, "Dev")
+        .checked(current_channel == ReleaseChannel::Dev)
+        .build(app_handle)?;
+
+    // Store channel items for later updates
+    let _ = CHANNEL_STABLE_ITEM.set(channel_stable.clone());
+    let _ = CHANNEL_BETA_ITEM.set(channel_beta.clone());
+    let _ = CHANNEL_DEV_ITEM.set(channel_dev.clone());
+
+    let channel_submenu = SubmenuBuilder::with_id(app_handle, "release_channel", "Release Channel")
+        .item(&channel_stable)
+        .item(&channel_beta)
+        .item(&channel_dev)
+        .build()?;
+
     let menu = MenuBuilder::new(app_handle)
         .item(
             &MenuItemBuilder::with_id(ids::OPEN_DASHBOARD, "Open Dashboard")
@@ -49,12 +89,14 @@ pub fn build_tray_menu(app_handle: &AppHandle, state: &Arc<AppState>) -> Result<
         )
         .separator()
         .item(&status_item)
+        .item(&version_item)
         .item(
             &MenuItemBuilder::with_id(ids::PORT, format!("Port: {}", settings.port))
                 .enabled(false)
                 .build(app_handle)?,
         )
         .separator()
+        .item(&channel_submenu)
         .item(
             &MenuItemBuilder::with_id(ids::CHECK_UPDATES, "Check for Updates...")
                 .build(app_handle)?,
@@ -84,6 +126,17 @@ pub fn build_tray_menu(app_handle: &AppHandle, state: &Arc<AppState>) -> Result<
 /// Status menu item stored globally for updates
 static STATUS_ITEM: std::sync::OnceLock<MenuItem<tauri::Wry>> = std::sync::OnceLock::new();
 
+/// Version menu item stored globally for updates
+static VERSION_ITEM: std::sync::OnceLock<MenuItem<tauri::Wry>> = std::sync::OnceLock::new();
+
+/// Release channel check items stored globally for radio-button behavior
+static CHANNEL_STABLE_ITEM: std::sync::OnceLock<CheckMenuItem<tauri::Wry>> =
+    std::sync::OnceLock::new();
+static CHANNEL_BETA_ITEM: std::sync::OnceLock<CheckMenuItem<tauri::Wry>> =
+    std::sync::OnceLock::new();
+static CHANNEL_DEV_ITEM: std::sync::OnceLock<CheckMenuItem<tauri::Wry>> =
+    std::sync::OnceLock::new();
+
 /// Update the tray status text
 pub fn update_status(_app_handle: &AppHandle, running: bool) {
     let status_text = if running {
@@ -95,6 +148,33 @@ pub fn update_status(_app_handle: &AppHandle, running: bool) {
     if let Some(item) = STATUS_ITEM.get() {
         let _ = item.set_text(status_text);
     }
+}
+
+/// Update the version display in the tray menu.
+pub fn update_version(version: &str) {
+    if let Some(item) = VERSION_ITEM.get() {
+        let _ = item.set_text(format!("Version: {}", version));
+    }
+}
+
+/// Update the check marks on channel menu items to reflect the given channel
+fn update_channel_checks(channel: ReleaseChannel) {
+    if let Some(item) = CHANNEL_STABLE_ITEM.get() {
+        let _ = item.set_checked(channel == ReleaseChannel::Stable);
+    }
+    if let Some(item) = CHANNEL_BETA_ITEM.get() {
+        let _ = item.set_checked(channel == ReleaseChannel::Beta);
+    }
+    if let Some(item) = CHANNEL_DEV_ITEM.get() {
+        let _ = item.set_checked(channel == ReleaseChannel::Dev);
+    }
+}
+
+/// Re-detect the installed version and update the tray version display.
+fn refresh_version_display(app_handle: &AppHandle) {
+    let version = crate::update::get_installed_version(app_handle)
+        .unwrap_or_else(|_| "unknown".to_string());
+    update_version(&version);
 }
 
 /// Handle menu item clicks
@@ -111,57 +191,90 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>, _a
             let state = state.clone();
             let app = app_handle.clone();
             async_runtime::spawn(async move {
+                let channel = {
+                    let settings = state.settings.read().await;
+                    settings.release_channel
+                };
+
                 // Check for updates and get version if user wants to update
-                if let Some(version) = state.update_checker.check_for_user(&app).await {
+                if let Some(version) = state.update_checker.check_for_user(&app, channel).await {
                     info!("User requested update to version {}", version);
 
                     // Stop the dashboard
                     update_status(&app, false);
                     if let Err(e) = state.daemon.stop().await {
                         error!("Failed to stop dashboard for update: {}", e);
-                        app.dialog()
-                            .message(format!("Failed to stop dashboard: {}", e))
-                            .kind(MessageDialogKind::Error)
-                            .title("Update Failed")
-                            .blocking_show();
+                        let dialog_app = app.clone();
+                        let msg = format!("Failed to stop dashboard: {}", e);
+                        let _ = tokio::task::spawn_blocking(move || {
+                            dialog_app
+                                .dialog()
+                                .message(msg)
+                                .kind(MessageDialogKind::Error)
+                                .title("Update Failed")
+                                .blocking_show();
+                        })
+                        .await;
                         return;
                     }
 
                     // Perform the update
-                    match state.update_checker.update_to(&app, &version).await {
+                    match state.update_checker.update_to(&app, &version, channel).await {
                         Ok(()) => {
                             info!("Update completed successfully");
+
+                            // Update the version display in the tray menu
+                            refresh_version_display(&app);
 
                             // Restart the dashboard
                             if let Err(e) = state.daemon.start().await {
                                 error!("Failed to restart dashboard after update: {}", e);
-                                app.dialog()
-                                    .message(format!(
-                                        "ESPHome updated to {}, but failed to restart dashboard: {}",
-                                        version, e
-                                    ))
-                                    .kind(MessageDialogKind::Warning)
-                                    .title("Update Partially Complete")
-                                    .blocking_show();
+                                let dialog_app = app.clone();
+                                let msg = format!(
+                                    "ESPHome updated to {}, but failed to restart dashboard: {}",
+                                    version, e
+                                );
+                                let _ = tokio::task::spawn_blocking(move || {
+                                    dialog_app
+                                        .dialog()
+                                        .message(msg)
+                                        .kind(MessageDialogKind::Warning)
+                                        .title("Update Partially Complete")
+                                        .blocking_show();
+                                })
+                                .await;
                             } else {
                                 update_status(&app, true);
-                                app.dialog()
-                                    .message(format!(
-                                        "ESPHome has been updated to version {}.",
-                                        version
-                                    ))
-                                    .kind(MessageDialogKind::Info)
-                                    .title("Update Complete")
-                                    .blocking_show();
+                                let dialog_app = app.clone();
+                                let msg = if channel == ReleaseChannel::Dev {
+                                    "ESPHome has been updated to the latest dev version.".to_string()
+                                } else {
+                                    format!("ESPHome has been updated to version {}.", version)
+                                };
+                                let _ = tokio::task::spawn_blocking(move || {
+                                    dialog_app
+                                        .dialog()
+                                        .message(msg)
+                                        .kind(MessageDialogKind::Info)
+                                        .title("Update Complete")
+                                        .blocking_show();
+                                })
+                                .await;
                             }
                         }
                         Err(e) => {
                             error!("Update failed: {}", e);
-                            app.dialog()
-                                .message(format!("Failed to update ESPHome: {}", e))
-                                .kind(MessageDialogKind::Error)
-                                .title("Update Failed")
-                                .blocking_show();
+                            let dialog_app = app.clone();
+                            let msg = format!("Failed to update ESPHome: {}", e);
+                            let _ = tokio::task::spawn_blocking(move || {
+                                dialog_app
+                                    .dialog()
+                                    .message(msg)
+                                    .kind(MessageDialogKind::Error)
+                                    .title("Update Failed")
+                                    .blocking_show();
+                            })
+                            .await;
 
                             // Try to restart dashboard anyway
                             if let Err(restart_err) = state.daemon.start().await {
@@ -169,6 +282,169 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>, _a
                             } else {
                                 update_status(&app, true);
                             }
+                        }
+                    }
+                }
+            });
+        }
+        ids::CHANNEL_STABLE | ids::CHANNEL_BETA | ids::CHANNEL_DEV => {
+            let new_channel = match id {
+                ids::CHANNEL_STABLE => ReleaseChannel::Stable,
+                ids::CHANNEL_BETA => ReleaseChannel::Beta,
+                ids::CHANNEL_DEV => ReleaseChannel::Dev,
+                _ => unreachable!(),
+            };
+
+            let state = state.clone();
+            let app = app_handle.clone();
+            async_runtime::spawn(async move {
+                // Read the current channel
+                let old_channel = {
+                    let settings = state.settings.read().await;
+                    settings.release_channel
+                };
+
+                if new_channel == old_channel {
+                    // User clicked the already-selected channel; restore the check mark
+                    // (CheckMenuItem auto-toggled it off before we got here)
+                    update_channel_checks(old_channel);
+                    return;
+                }
+
+                // Confirm the channel switch with the user.
+                // Run the blocking dialog on a dedicated thread so it cannot
+                // starve the tokio runtime or the event-loop thread.
+                let warning = if new_channel == ReleaseChannel::Dev {
+                    "Warning: The dev channel installs ESPHome directly from GitHub and does NOT support automatic updates. You will need to manually check for updates.\n\n"
+                } else {
+                    ""
+                };
+
+                let dialog_app = app.clone();
+                let msg = format!(
+                    "{}Switch ESPHome from {} to {} channel?\n\nThis will stop the dashboard, install the appropriate version, and restart.",
+                    warning, old_channel, new_channel
+                );
+                let confirmed = tokio::task::spawn_blocking(move || {
+                    dialog_app
+                        .dialog()
+                        .message(msg)
+                        .title("Switch Release Channel")
+                        .buttons(tauri_plugin_dialog::MessageDialogButtons::OkCancelCustom(
+                            "Switch".to_string(),
+                            "Cancel".to_string(),
+                        ))
+                        .blocking_show()
+                })
+                .await
+                .unwrap_or(false);
+
+                if !confirmed {
+                    // Revert the check marks
+                    update_channel_checks(old_channel);
+                    return;
+                }
+
+                // Update the check marks immediately to show the new selection
+                update_channel_checks(new_channel);
+
+                // Stop the dashboard
+                update_status(&app, false);
+                if let Err(e) = state.daemon.stop().await {
+                    error!("Failed to stop dashboard for channel switch: {}", e);
+                    let dialog_app = app.clone();
+                    let msg = format!("Failed to stop dashboard: {}", e);
+                    let _ = tokio::task::spawn_blocking(move || {
+                        dialog_app
+                            .dialog()
+                            .message(msg)
+                            .kind(MessageDialogKind::Error)
+                            .title("Channel Switch Failed")
+                            .blocking_show();
+                    })
+                    .await;
+                    // Revert
+                    update_channel_checks(old_channel);
+                    return;
+                }
+
+                // Install the new channel's version
+                match state.update_checker.switch_channel(&app, new_channel).await {
+                    Ok(()) => {
+                        info!("Switched to {} channel successfully", new_channel);
+
+                        // Save the new channel to settings
+                        {
+                            let mut settings = state.settings.write().await;
+                            settings.release_channel = new_channel;
+                            if let Err(e) = settings.save(&app) {
+                                warn!("Failed to save settings: {}", e);
+                            }
+                        }
+
+                        // Update the version display in the tray menu
+                        refresh_version_display(&app);
+
+                        // Restart the dashboard
+                        if let Err(e) = state.daemon.start().await {
+                            error!("Failed to restart dashboard after channel switch: {}", e);
+                            let dialog_app = app.clone();
+                            let msg = format!(
+                                "Switched to {} channel, but failed to restart dashboard: {}",
+                                new_channel, e
+                            );
+                            let _ = tokio::task::spawn_blocking(move || {
+                                dialog_app
+                                    .dialog()
+                                    .message(msg)
+                                    .kind(MessageDialogKind::Warning)
+                                    .title("Channel Switch Partially Complete")
+                                    .blocking_show();
+                            })
+                            .await;
+                        } else {
+                            update_status(&app, true);
+                            let dialog_app = app.clone();
+                            let msg = format!(
+                                "Successfully switched to the {} release channel.",
+                                new_channel
+                            );
+                            let _ = tokio::task::spawn_blocking(move || {
+                                dialog_app
+                                    .dialog()
+                                    .message(msg)
+                                    .kind(MessageDialogKind::Info)
+                                    .title("Channel Switched")
+                                    .blocking_show();
+                            })
+                            .await;
+                        }
+                    }
+                    Err(e) => {
+                        error!("Channel switch failed: {}", e);
+                        let dialog_app = app.clone();
+                        let msg = format!("Failed to switch channel: {}", e);
+                        let _ = tokio::task::spawn_blocking(move || {
+                            dialog_app
+                                .dialog()
+                                .message(msg)
+                                .kind(MessageDialogKind::Error)
+                                .title("Channel Switch Failed")
+                                .blocking_show();
+                        })
+                        .await;
+
+                        // Revert settings
+                        update_channel_checks(old_channel);
+
+                        // Try to restart dashboard anyway
+                        if let Err(restart_err) = state.daemon.start().await {
+                            error!(
+                                "Failed to restart dashboard after failed channel switch: {}",
+                                restart_err
+                            );
+                        } else {
+                            update_status(&app, true);
                         }
                     }
                 }

--- a/src-tauri/src/update/mod.rs
+++ b/src-tauri/src/update/mod.rs
@@ -1,27 +1,34 @@
 //! Update checking functionality
 //!
 //! Queries PyPI for the latest ESPHome version and notifies the user
-//! if an update is available.
+//! if an update is available. Supports stable, beta, and dev release channels.
 
 use anyhow::{Context, Result};
 use serde::Deserialize;
+use std::collections::HashMap;
 use tauri::AppHandle;
 use tauri_plugin_dialog::{DialogExt, MessageDialogKind};
 use tauri_plugin_notification::NotificationExt;
 use tracing::{debug, error, info, warn};
 
 use crate::platform;
+use crate::settings::ReleaseChannel;
 
-/// PyPI package info response
+/// PyPI package info response (used for stable channel)
 #[derive(Debug, Deserialize)]
 struct PyPIResponse {
     info: PyPIInfo,
+    releases: HashMap<String, Vec<PyPIRelease>>,
 }
 
 #[derive(Debug, Deserialize)]
 struct PyPIInfo {
     version: String,
 }
+
+/// A single release file entry from PyPI (we only need it to check existence)
+#[derive(Debug, Deserialize)]
+struct PyPIRelease {}
 
 /// Update checker
 pub struct UpdateChecker {
@@ -39,64 +46,163 @@ impl UpdateChecker {
         }
     }
 
-    /// Check for updates and return the latest version if available
-    pub async fn check(&self) -> Result<Option<String>> {
-        debug!("Checking for ESPHome updates");
+    /// Check for updates and return the latest version string for the given channel.
+    ///
+    /// - Stable: returns the latest stable version from PyPI
+    /// - Beta: returns the latest pre-release (beta) version from PyPI
+    /// - Dev: always returns None (dev channel doesn't do version-based updates)
+    pub async fn check(&self, channel: ReleaseChannel) -> Result<Option<String>> {
+        match channel {
+            ReleaseChannel::Stable => {
+                debug!("Checking for stable ESPHome updates on PyPI");
+                let response: PyPIResponse = self
+                    .client
+                    .get("https://pypi.org/pypi/esphome/json")
+                    .send()
+                    .await
+                    .context("Failed to fetch PyPI info")?
+                    .json()
+                    .await
+                    .context("Failed to parse PyPI response")?;
 
-        let response: PyPIResponse = self
-            .client
-            .get("https://pypi.org/pypi/esphome/json")
-            .send()
-            .await
-            .context("Failed to fetch PyPI info")?
-            .json()
-            .await
-            .context("Failed to parse PyPI response")?;
+                let latest = response.info.version;
+                info!("Latest stable ESPHome version on PyPI: {}", latest);
+                Ok(Some(latest))
+            }
+            ReleaseChannel::Beta => {
+                debug!("Checking for beta ESPHome updates on PyPI");
+                let response: PyPIResponse = self
+                    .client
+                    .get("https://pypi.org/pypi/esphome/json")
+                    .send()
+                    .await
+                    .context("Failed to fetch PyPI info")?
+                    .json()
+                    .await
+                    .context("Failed to parse PyPI response")?;
 
-        let latest = response.info.version;
-        info!("Latest ESPHome version on PyPI: {}", latest);
+                // Find the latest beta/pre-release version from all releases.
+                // Beta versions contain 'b' (e.g., "2025.4.0b1").
+                // We want the newest version that is a pre-release, or fall
+                // back to the latest stable if no beta is newer.
+                let latest_beta = find_latest_beta(&response.releases);
 
-        Ok(Some(latest))
+                match latest_beta {
+                    Some(v) => {
+                        info!("Latest beta ESPHome version on PyPI: {}", v);
+                        Ok(Some(v))
+                    }
+                    None => {
+                        // No beta found that's newer; fall back to stable
+                        let stable = &response.info.version;
+                        info!(
+                            "No beta version found newer than stable ({}), using stable",
+                            stable
+                        );
+                        Ok(Some(stable.clone()))
+                    }
+                }
+            }
+            ReleaseChannel::Dev => {
+                // Dev channel doesn't use version-based update checks
+                debug!("Dev channel: skipping version-based update check");
+                Ok(None)
+            }
+        }
     }
 
     /// Check for updates (user-initiated) - always shows feedback via dialog
     /// Returns Some(version) if user wants to update, None otherwise
-    pub async fn check_for_user(&self, app_handle: &AppHandle) -> Option<String> {
+    pub async fn check_for_user(
+        &self,
+        app_handle: &AppHandle,
+        channel: ReleaseChannel,
+    ) -> Option<String> {
+        // Dev channel: offer to reinstall from git HEAD
+        if channel == ReleaseChannel::Dev {
+            let installed = get_installed_version(app_handle).ok();
+            let installed_str = installed
+                .as_deref()
+                .unwrap_or("unknown")
+                .to_string();
+
+            let dialog_app = app_handle.clone();
+            let should_update = tokio::task::spawn_blocking(move || {
+                dialog_app
+                    .dialog()
+                    .message(format!(
+                        "You are on the dev channel.\n\n\
+                         Currently installed: {}\n\n\
+                         This will reinstall ESPHome from the latest commit on GitHub.\n\n\
+                         Would you like to update now?",
+                        installed_str
+                    ))
+                    .title("Dev Channel Update")
+                    .buttons(tauri_plugin_dialog::MessageDialogButtons::OkCancelCustom(
+                        "Update Now".to_string(),
+                        "Cancel".to_string(),
+                    ))
+                    .blocking_show()
+            })
+            .await
+            .unwrap_or(false);
+
+            if should_update {
+                // Return a sentinel value that update_to will recognize
+                return Some("dev".to_string());
+            }
+            return None;
+        }
+
         // Get installed version
         let installed = match get_installed_version(app_handle) {
             Ok(v) => v,
             Err(e) => {
                 warn!("Could not detect installed version: {}", e);
-                app_handle
-                    .dialog()
-                    .message(format!("Could not detect installed version: {}", e))
-                    .kind(MessageDialogKind::Error)
-                    .title("Update Check Failed")
-                    .blocking_show();
+                let dialog_app = app_handle.clone();
+                let msg = format!("Could not detect installed version: {}", e);
+                let _ = tokio::task::spawn_blocking(move || {
+                    dialog_app
+                        .dialog()
+                        .message(msg)
+                        .kind(MessageDialogKind::Error)
+                        .title("Update Check Failed")
+                        .blocking_show();
+                })
+                .await;
                 return None;
             }
         };
 
         // Check for latest version
-        let latest = match self.check().await {
+        let latest = match self.check(channel).await {
             Ok(Some(v)) => v,
             Ok(None) => {
-                app_handle
-                    .dialog()
-                    .message("Could not determine latest version")
-                    .kind(MessageDialogKind::Error)
-                    .title("Update Check Failed")
-                    .blocking_show();
+                let dialog_app = app_handle.clone();
+                let _ = tokio::task::spawn_blocking(move || {
+                    dialog_app
+                        .dialog()
+                        .message("Could not determine latest version")
+                        .kind(MessageDialogKind::Error)
+                        .title("Update Check Failed")
+                        .blocking_show();
+                })
+                .await;
                 return None;
             }
             Err(e) => {
                 warn!("Update check failed: {}", e);
-                app_handle
-                    .dialog()
-                    .message(format!("Failed to check for updates: {}", e))
-                    .kind(MessageDialogKind::Error)
-                    .title("Update Check Failed")
-                    .blocking_show();
+                let dialog_app = app_handle.clone();
+                let msg = format!("Failed to check for updates: {}", e);
+                let _ = tokio::task::spawn_blocking(move || {
+                    dialog_app
+                        .dialog()
+                        .message(msg)
+                        .kind(MessageDialogKind::Error)
+                        .title("Update Check Failed")
+                        .blocking_show();
+                })
+                .await;
                 return None;
             }
         };
@@ -108,19 +214,31 @@ impl UpdateChecker {
                 installed, latest, installed
             );
 
+            let channel_label = match channel {
+                ReleaseChannel::Stable => "stable",
+                ReleaseChannel::Beta => "beta",
+                ReleaseChannel::Dev => unreachable!(),
+            };
+
             // Ask user if they want to update
-            let should_update = app_handle
-                .dialog()
-                .message(format!(
-                    "ESPHome {} is available.\n\nYou currently have version {}.\n\nWould you like to update now?",
-                    latest, installed
-                ))
-                .title("Update Available")
-                .buttons(tauri_plugin_dialog::MessageDialogButtons::OkCancelCustom(
-                    "Update Now".to_string(),
-                    "Later".to_string(),
-                ))
-                .blocking_show();
+            let dialog_app = app_handle.clone();
+            let msg = format!(
+                "ESPHome {} ({}) is available.\n\nYou currently have version {}.\n\nWould you like to update now?",
+                latest, channel_label, installed
+            );
+            let should_update = tokio::task::spawn_blocking(move || {
+                dialog_app
+                    .dialog()
+                    .message(msg)
+                    .title("Update Available")
+                    .buttons(tauri_plugin_dialog::MessageDialogButtons::OkCancelCustom(
+                        "Update Now".to_string(),
+                        "Later".to_string(),
+                    ))
+                    .blocking_show()
+            })
+            .await
+            .unwrap_or(false);
 
             if should_update {
                 return Some(latest);
@@ -128,19 +246,30 @@ impl UpdateChecker {
         } else {
             info!("ESPHome is up to date ({})", installed);
 
-            app_handle
-                .dialog()
-                .message(format!("ESPHome {} is the latest version.", installed))
-                .kind(MessageDialogKind::Info)
-                .title("No Updates Available")
-                .blocking_show();
+            let dialog_app = app_handle.clone();
+            let msg = format!("ESPHome {} is the latest version.", installed);
+            let _ = tokio::task::spawn_blocking(move || {
+                dialog_app
+                    .dialog()
+                    .message(msg)
+                    .kind(MessageDialogKind::Info)
+                    .title("No Updates Available")
+                    .blocking_show();
+            })
+            .await;
         }
 
         None
     }
 
-    /// Check for updates and notify the user if one is available (background check)
-    pub async fn check_and_notify(&self, app_handle: &AppHandle) {
+    /// Check for updates and notify the user if one is available (background check).
+    /// Does nothing for the dev channel.
+    pub async fn check_and_notify(&self, app_handle: &AppHandle, channel: ReleaseChannel) {
+        if channel == ReleaseChannel::Dev {
+            debug!("Dev channel: skipping background update check");
+            return;
+        }
+
         // Get installed version
         let installed = match get_installed_version(app_handle) {
             Ok(v) => v,
@@ -151,7 +280,7 @@ impl UpdateChecker {
         };
 
         // Check for latest version
-        let latest = match self.check().await {
+        let latest = match self.check(channel).await {
             Ok(Some(v)) => v,
             Ok(None) => return,
             Err(e) => {
@@ -167,14 +296,20 @@ impl UpdateChecker {
                 installed, latest, installed
             );
 
+            let channel_label = match channel {
+                ReleaseChannel::Stable => "stable",
+                ReleaseChannel::Beta => "beta",
+                ReleaseChannel::Dev => unreachable!(),
+            };
+
             // Show notification
             if let Err(e) = app_handle
                 .notification()
                 .builder()
                 .title("ESPHome Update Available")
                 .body(format!(
-                    "ESPHome {} is available (you have {}). Click 'Check for Updates' in the menu to update.",
-                    latest, installed
+                    "ESPHome {} ({}) is available (you have {}). Click 'Check for Updates' in the menu to update.",
+                    latest, channel_label, installed
                 ))
                 .show()
             {
@@ -185,30 +320,145 @@ impl UpdateChecker {
         }
     }
 
-    /// Perform an update to the specified version
-    pub async fn update_to(&self, app_handle: &AppHandle, version: &str) -> Result<()> {
-        info!("Updating ESPHome to version {}", version);
-
+    /// Perform an update to the specified version, or install from git for dev channel.
+    pub async fn update_to(
+        &self,
+        app_handle: &AppHandle,
+        version: &str,
+        channel: ReleaseChannel,
+    ) -> Result<()> {
         let python_path = platform::get_python_path(app_handle)?;
 
-        let mut cmd = tokio::process::Command::new(&python_path);
-        cmd.args(["-m", "pip", "install", &format!("esphome=={}", version)]);
-        platform::configure_no_window_tokio_command(&mut cmd);
+        if channel == ReleaseChannel::Dev || version == "dev" {
+            info!("Installing ESPHome from GitHub (dev channel)");
 
-        let output = cmd.output().await.context("Failed to run pip install")?;
+            let mut cmd = tokio::process::Command::new(&python_path);
+            cmd.args([
+                "-m",
+                "pip",
+                "install",
+                "--force-reinstall",
+                "https://github.com/esphome/esphome/archive/dev.zip",
+            ]);
+            platform::configure_no_window_tokio_command(&mut cmd);
 
-        if output.status.success() {
-            info!("ESPHome updated successfully to {}", version);
-            Ok(())
+            let output = cmd.output().await.context("Failed to run pip install")?;
+
+            if output.status.success() {
+                info!("ESPHome dev installed successfully from GitHub");
+                Ok(())
+            } else {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                anyhow::bail!("pip install from GitHub failed: {}", stderr)
+            }
         } else {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            anyhow::bail!("pip install failed: {}", stderr)
+            info!("Updating ESPHome to version {}", version);
+
+            let mut cmd = tokio::process::Command::new(&python_path);
+            cmd.args(["-m", "pip", "install", &format!("esphome=={}", version)]);
+            platform::configure_no_window_tokio_command(&mut cmd);
+
+            let output = cmd.output().await.context("Failed to run pip install")?;
+
+            if output.status.success() {
+                info!("ESPHome updated successfully to {}", version);
+                Ok(())
+            } else {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                anyhow::bail!("pip install failed: {}", stderr)
+            }
+        }
+    }
+
+    /// Switch to a new release channel by installing the appropriate version.
+    /// Returns Ok(()) on success.
+    pub async fn switch_channel(
+        &self,
+        app_handle: &AppHandle,
+        channel: ReleaseChannel,
+    ) -> Result<()> {
+        match channel {
+            ReleaseChannel::Stable => {
+                // Install the latest stable version
+                let latest = self
+                    .check(ReleaseChannel::Stable)
+                    .await?
+                    .context("Could not determine latest stable version")?;
+                self.update_to(app_handle, &latest, ReleaseChannel::Stable)
+                    .await
+            }
+            ReleaseChannel::Beta => {
+                // Install the latest beta version
+                let latest = self
+                    .check(ReleaseChannel::Beta)
+                    .await?
+                    .context("Could not determine latest beta version")?;
+                self.update_to(app_handle, &latest, ReleaseChannel::Beta)
+                    .await
+            }
+            ReleaseChannel::Dev => {
+                // Install from GitHub
+                self.update_to(app_handle, "dev", ReleaseChannel::Dev).await
+            }
         }
     }
 }
 
+/// Find the latest beta/pre-release version from PyPI releases.
+///
+/// Beta versions on PyPI look like "2025.4.0b1", "2025.4.0b2", etc.
+/// We find the highest version that contains a beta suffix.
+fn find_latest_beta(releases: &HashMap<String, Vec<PyPIRelease>>) -> Option<String> {
+    let mut best: Option<String> = None;
+
+    for version_str in releases.keys() {
+        // Only consider versions with a beta suffix (e.g. "2025.4.0b1").
+        // ESPHome beta releases always use bN naming.
+        if !has_beta_suffix(version_str) {
+            continue;
+        }
+
+        // Skip if not a valid-looking version
+        if !version_str
+            .chars()
+            .next()
+            .map_or(false, |c| c.is_ascii_digit())
+        {
+            continue;
+        }
+
+        match &best {
+            None => best = Some(version_str.clone()),
+            Some(current_best) => {
+                if is_newer_version(version_str, current_best) {
+                    best = Some(version_str.clone());
+                }
+            }
+        }
+    }
+
+    best
+}
+
+/// Check whether a version string has a beta suffix like "b1", "b2", etc.
+/// Matches patterns where a 'b' immediately follows a digit and is followed by
+/// one or more digits (e.g. "2025.4.0b1"), which distinguishes it from versions
+/// that merely contain the letter 'b' elsewhere.
+fn has_beta_suffix(version: &str) -> bool {
+    let bytes = version.as_bytes();
+    for i in 1..bytes.len().saturating_sub(1) {
+        if bytes[i] == b'b'
+            && bytes[i - 1].is_ascii_digit()
+            && bytes[i + 1].is_ascii_digit()
+        {
+            return true;
+        }
+    }
+    false
+}
+
 /// Get the installed ESPHome version
-fn get_installed_version(app_handle: &AppHandle) -> Result<String> {
+pub fn get_installed_version(app_handle: &AppHandle) -> Result<String> {
     let python_path = platform::get_python_path(app_handle)?;
 
     let mut cmd = std::process::Command::new(&python_path);
@@ -230,34 +480,62 @@ fn get_installed_version(app_handle: &AppHandle) -> Result<String> {
     }
 }
 
+/// A parsed version segment, e.g. "0b1" -> (0, 0, 1)
+/// Any pre-release suffix sorts below a stable release (no suffix).
+/// ESPHome uses "b" for betas (e.g. "2025.4.0b1") and "-dev" for dev
+/// builds (e.g. "2026.5.0-dev").
+fn prerelease_ord(tag: &str) -> u8 {
+    match tag {
+        "b" => 0,
+        "dev" => 0,
+        _ => 1,
+    }
+}
+
+/// Parse a version string like "2024.1.0b1" or "2026.5.0-dev" into a
+/// comparable representation.
+/// Each dot-separated segment becomes (numeric_part, prerelease_order, prerelease_num).
+/// A stable segment like "0" becomes (0, 255, 0) so it sorts higher than any pre-release.
+fn parse_version(s: &str) -> Vec<(u32, u8, u32)> {
+    s.split('.')
+        .filter_map(|part| {
+            // Split on pre-release tag boundaries: "0b1", "0-dev"
+            // Take the leading digits first
+            let num_end = part
+                .find(|c: char| !c.is_ascii_digit())
+                .unwrap_or(part.len());
+            let numeric: u32 = part[..num_end].parse().ok()?;
+
+            if num_end < part.len() {
+                // There's a pre-release suffix
+                let suffix = &part[num_end..];
+                // Strip a leading hyphen (e.g. "-dev" -> "dev")
+                let suffix = suffix.strip_prefix('-').unwrap_or(suffix);
+                // Find where the tag name ends and the pre-release number begins
+                let tag_end = suffix
+                    .find(|c: char| c.is_ascii_digit())
+                    .unwrap_or(suffix.len());
+                let tag = &suffix[..tag_end];
+                let pre_num: u32 = if tag_end < suffix.len() {
+                    suffix[tag_end..].parse().unwrap_or(0)
+                } else {
+                    0
+                };
+                Some((numeric, prerelease_ord(tag), pre_num))
+            } else {
+                // Stable segment — sorts higher than any pre-release
+                Some((numeric, 255, 0))
+            }
+        })
+        .collect()
+}
+
 /// Compare two version strings and return true if `latest` is newer than `installed`
 fn is_newer_version(latest: &str, installed: &str) -> bool {
-    let parse_version = |s: &str| -> Vec<u32> {
-        s.split('.')
-            .filter_map(|part| {
-                // Handle versions like "2024.1.0b1" by taking only the numeric part
-                part.chars()
-                    .take_while(|c| c.is_ascii_digit())
-                    .collect::<String>()
-                    .parse()
-                    .ok()
-            })
-            .collect()
-    };
-
     let latest_parts = parse_version(latest);
     let installed_parts = parse_version(installed);
 
-    for (l, i) in latest_parts.iter().zip(installed_parts.iter()) {
-        match l.cmp(i) {
-            std::cmp::Ordering::Greater => return true,
-            std::cmp::Ordering::Less => return false,
-            std::cmp::Ordering::Equal => continue,
-        }
-    }
-
-    // If all compared parts are equal, the one with more parts might be newer
-    latest_parts.len() > installed_parts.len()
+    latest_parts > installed_parts
 }
 
 #[cfg(test)]
@@ -271,6 +549,50 @@ mod tests {
         assert!(is_newer_version("2025.1.0", "2024.12.0"));
         assert!(!is_newer_version("2024.1.0", "2024.1.0"));
         assert!(!is_newer_version("2024.1.0", "2024.2.0"));
+        // Stable is newer than beta with same base version
         assert!(is_newer_version("2024.1.0", "2024.1.0b1"));
+        // Higher beta number is newer
+        assert!(is_newer_version("2024.1.0b2", "2024.1.0b1"));
+        // Beta is not newer than stable
+        assert!(!is_newer_version("2024.1.0b1", "2024.1.0"));
+        // Dev versions use hyphenated suffix: "2026.5.0-dev"
+        // Stable is newer than dev with same base version
+        assert!(is_newer_version("2026.5.0", "2026.5.0-dev"));
+        // Dev is not newer than stable with same base version
+        assert!(!is_newer_version("2026.5.0-dev", "2026.5.0"));
+        // A newer base version dev is still newer than an older stable
+        assert!(is_newer_version("2026.5.0-dev", "2026.4.0"));
+    }
+
+    #[test]
+    fn test_has_beta_suffix() {
+        assert!(has_beta_suffix("2025.4.0b1"));
+        assert!(has_beta_suffix("2025.4.0b12"));
+        assert!(!has_beta_suffix("2025.4.0"));
+        assert!(!has_beta_suffix("2025.4.0-dev"));
+        // Should not match 'b' that isn't a digit-b-digit pattern
+        assert!(!has_beta_suffix("abc"));
+    }
+
+    #[test]
+    fn test_find_latest_beta() {
+        let mut releases = HashMap::new();
+        releases.insert("2025.3.0".to_string(), vec![]);
+        releases.insert("2025.4.0b1".to_string(), vec![]);
+        releases.insert("2025.4.0b2".to_string(), vec![]);
+        releases.insert("2025.3.0b1".to_string(), vec![]);
+
+        let latest = find_latest_beta(&releases);
+        assert_eq!(latest, Some("2025.4.0b2".to_string()));
+    }
+
+    #[test]
+    fn test_find_latest_beta_none() {
+        let mut releases = HashMap::new();
+        releases.insert("2025.3.0".to_string(), vec![]);
+        releases.insert("2025.4.0".to_string(), vec![]);
+
+        let latest = find_latest_beta(&releases);
+        assert_eq!(latest, None);
     }
 }


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

This pull request introduces support for selecting the ESPHome release channel (Stable, Beta, or Dev) directly from the tray menu, and improves update handling and user feedback throughout the application. The main changes include the addition of a `ReleaseChannel` enum to settings, a tray menu submenu for selecting the release channel, and logic to handle switching channels with appropriate user confirmation and error handling. The update process and version display in the tray menu have also been enhanced.

**Release Channel Selection and Handling:**

* Added a `ReleaseChannel` enum (`Stable`, `Beta`, `Dev`) to `Settings`, persisted in the configuration and exposed in the tray menu as a radio-button submenu. The selected channel is used for all update checks and installations. [[1]](diffhunk://#diff-f7123304658f53029286716fc548fdfba6e113726cc998c138d98ad1340b84e5R17-R44) [[2]](diffhunk://#diff-f7123304658f53029286716fc548fdfba6e113726cc998c138d98ad1340b84e5R64-R67) [[3]](diffhunk://#diff-f7123304658f53029286716fc548fdfba6e113726cc998c138d98ad1340b84e5R88)
* Implemented logic to handle switching release channels from the tray menu, including user confirmation dialogs, updating settings, stopping/restarting the dashboard, and error handling with appropriate user feedback.

**Tray Menu and User Feedback Improvements:**

* Added a read-only version display to the tray menu, which updates after successful updates or channel switches. [[1]](diffhunk://#diff-6b99d5012fa23c96bf1daef8b57a9f6f157ee1d95ba2efe38969847ff45c7474R51-R83) [[2]](diffhunk://#diff-6b99d5012fa23c96bf1daef8b57a9f6f157ee1d95ba2efe38969847ff45c7474R92-R99) [[3]](diffhunk://#diff-6b99d5012fa23c96bf1daef8b57a9f6f157ee1d95ba2efe38969847ff45c7474R129-R139) [[4]](diffhunk://#diff-6b99d5012fa23c96bf1daef8b57a9f6f157ee1d95ba2efe38969847ff45c7474R153-R179)
* Improved dialogs for update and channel switch processes: all dialogs now run on a blocking thread to avoid stalling the event loop, and user feedback is more informative and context-aware (e.g., warnings for the Dev channel, success/error messages). [[1]](diffhunk://#diff-6b99d5012fa23c96bf1daef8b57a9f6f157ee1d95ba2efe38969847ff45c7474R194-R277) [[2]](diffhunk://#diff-6b99d5012fa23c96bf1daef8b57a9f6f157ee1d95ba2efe38969847ff45c7474R290-R452)

**Update Process Enhancements:**

* Update checks and installations now respect the selected release channel, including disabling automatic updates for the Dev channel. The update checker and related methods now accept a channel parameter. [[1]](diffhunk://#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cR232-R246) [[2]](diffhunk://#diff-6b99d5012fa23c96bf1daef8b57a9f6f157ee1d95ba2efe38969847ff45c7474R194-R277)
* The tray menu's update-related items and check marks are kept in sync with the current state, including reverting check marks if the user cancels or if an operation fails. [[1]](diffhunk://#diff-6b99d5012fa23c96bf1daef8b57a9f6f157ee1d95ba2efe38969847ff45c7474R153-R179) [[2]](diffhunk://#diff-6b99d5012fa23c96bf1daef8b57a9f6f157ee1d95ba2efe38969847ff45c7474R290-R452)

These changes provide users with greater control over which ESPHome release stream they are using, improve the reliability of update and channel switching operations, and enhance overall user experience through better feedback and error handling.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- Closes https://github.com/esphome/esphome-desktop/issues/48

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).
