### PR TITLE
Fix documented data locations for Windows and ESPHome config

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,16 +56,22 @@ Right-click (or left-click on some platforms) the tray icon to access:
 
 ### Data Locations
 
+Application data (bundled Python, logs, settings):
+
 | Platform | Location |
 |----------|----------|
 | macOS | `~/Library/Application Support/io.esphome.builder/` |
-| Windows | `%LOCALAPPDATA%\ESPHome Builder\` |
+| Windows | `%APPDATA%\io.esphome.builder\` |
 | Linux | `~/.local/share/io.esphome.builder/` |
 
 This directory contains:
-- `config/` - Your ESPHome configuration files (default location)
+- `python/` - Bundled Python runtime
 - `logs/` - Application logs
 - `settings.json` - User preferences
+
+Your ESPHome configuration files are stored at `~/esphome/` on all platforms by default (configurable via `config_dir` in `settings.json`).
+
+On Windows, the application itself is installed to `%LOCALAPPDATA%\ESPHome Builder\`.
 
 ## Building from Source
 

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -17,8 +17,8 @@ use ::windows::Win32::System::Threading::CREATE_NO_WINDOW;
 
 /// Get the application data directory
 ///
-/// - macOS: `~/Library/Application Support/ESPHome Builder/`
-/// - Windows: `%LOCALAPPDATA%\ESPHome Builder\`
+/// - macOS: `~/Library/Application Support/io.esphome.builder/`
+/// - Windows: `%APPDATA%\io.esphome.builder\`
 /// - Linux: `~/.local/share/io.esphome.builder/`
 pub fn get_data_dir(app_handle: &AppHandle) -> Result<PathBuf> {
     let path = app_handle


### PR DESCRIPTION
# What does this implement/fix?

Fixes the documented data/config locations in the README and in the `get_data_dir` doc comment.

- Windows data dir is `%APPDATA%\io.esphome.builder\` (Roaming + bundle identifier), not `%LOCALAPPDATA%\ESPHome Builder\`. That's what Tauri's `app_data_dir()` returns; the README was describing the install location instead.
- ESPHome configs live at `~/esphome/` on all platforms — separate from the app data directory. The README previously listed `config/` inside the data dir.
- Updated the stale `get_data_dir` doc comment in `src-tauri/src/platform/mod.rs` to match.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes <link to issue>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).