### PR TITLE
Set PYTHONIOENCODING=utf-8 when spawning the ESPHome dashboard on Windows

### DIFF
--- a/src-tauri/src/daemon/mod.rs
+++ b/src-tauri/src/daemon/mod.rs
@@ -118,6 +118,16 @@ impl DaemonManager {
         // Set environment variables
         cmd.env("ESPHOME_DASHBOARD", "1");
 
+        // On Windows, force the spawned Python (and any subprocesses it
+        // spawns for compile/logs) to use UTF-8 for stdin/stdout/stderr.
+        // Without this, Python falls back to the locale codec (cp1252 on
+        // Western installs) when stdout is a redirected pipe — which the
+        // dashboard always is — and any non-ASCII output (e.g. the wifi
+        // signal-bar block characters U+2582..U+2588) raises
+        // UnicodeEncodeError and drops the device's log connection.
+        #[cfg(target_os = "windows")]
+        cmd.env("PYTHONIOENCODING", "utf-8");
+
         let child = cmd.spawn().context("Failed to spawn ESPHome process")?;
 
         let mut process = self.process.lock().await;


### PR DESCRIPTION
# What does this implement/fix?

Fixes a Windows-only crash in the dashboard log view when streaming logs from a device whose output contains non-ASCII characters (most notably the wifi component's signal-bar block characters `U+2582..U+2588`):

```
File ".../esphome/components/api/client.py", line 85, in on_log
    print(parsed_msg.replace("\033", "\\033") if dashboard else parsed_msg)
...
File ".../encodings/cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode characters in position 75-78
INFO Processing unexpected disconnect from ESPHome API
```

The desktop spawns the bundled Python with `stdout`/`stderr` redirected to `dashboard.log` (a non-console pipe). On Windows, when stdout isn't a console, Python falls back to the locale codec (cp1252 on Western installs), which can't encode the block characters. The plain `print(...)` raises and the device's log connection drops.

Setting `PYTHONIOENCODING=utf-8` on the spawn forces the subprocess (and every subprocess it in turn spawns for compile / logs / etc., which inherit the env) to use UTF-8. The dashboard log view then renders the bars as actual `▂▄▆█` block characters.

Verified manually on Windows 11 against an `energy-monitor-6` device: with the env var set system-wide on the test VM the dashboard's `[wifi:443]: Signal strength: -48 dB ▂▄▆█` line renders correctly and the connection no longer drops. This PR makes that the default.

The change is wrapped in `#[cfg(target_os = "windows")]` because Linux and macOS already use UTF-8 by default for stdio.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes <link to issue>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tested on the relevant platform(s) (macOS, Windows, Linux).