### PR TITLE
Add ESPHome Device Builder as an alternate backend

### DIFF
--- a/src-tauri/src/daemon/mod.rs
+++ b/src-tauri/src/daemon/mod.rs
@@ -32,6 +32,8 @@ pub struct DaemonManager {
     port: u16,
     /// Whether the daemon is running
     running: Arc<AtomicBool>,
+    /// Use `esphome-device-builder` instead of `esphome dashboard`
+    use_device_builder: Arc<AtomicBool>,
 }
 
 impl DaemonManager {
@@ -61,7 +63,22 @@ impl DaemonManager {
             logs_dir,
             port: settings.port,
             running: Arc::new(AtomicBool::new(false)),
+            use_device_builder: Arc::new(AtomicBool::new(settings.backend.is_builder())),
         })
+    }
+
+    /// Update the device-builder flag. Takes effect on the next daemon start.
+    pub fn set_use_device_builder(&self, value: bool) {
+        self.use_device_builder.store(value, Ordering::SeqCst);
+    }
+
+    /// Human-readable name of the current backend, for log messages.
+    fn backend_name(&self) -> &'static str {
+        if self.use_device_builder.load(Ordering::SeqCst) {
+            "ESPHome device builder"
+        } else {
+            "ESPHome dashboard"
+        }
     }
 
     /// Start the ESPHome dashboard
@@ -71,7 +88,9 @@ impl DaemonManager {
             return Ok(());
         }
 
-        info!("Starting ESPHome dashboard on port {}", self.port);
+        let use_device_builder = self.use_device_builder.load(Ordering::SeqCst);
+        let backend_name = self.backend_name();
+        info!("Starting {} on port {}", backend_name, self.port);
         debug!("Python path: {:?}", self.python_path);
         debug!("Python bin: {:?}", self.python_bin_dir);
         debug!("Config dir: {:?}", self.config_dir);
@@ -87,26 +106,42 @@ impl DaemonManager {
         let log_file = File::create(&log_path).context("Failed to create log file")?;
         let log_file_clone = log_file.try_clone().context("Failed to clone log file handle")?;
 
-        info!("Dashboard logs: {:?}", log_path);
+        info!("{} logs: {:?}", backend_name, log_path);
+
+        let config_arg = self.config_dir.to_str().unwrap_or(".");
+        let port_arg = self.port.to_string();
 
         // Build the command
         let mut cmd = Command::new(&self.python_path);
-        cmd.args([
-            "-m",
-            "esphome",
-            "dashboard",
-            self.config_dir.to_str().unwrap_or("."),
-            "--address",
-            "127.0.0.1",
-            "--port",
-            &self.port.to_string(),
-        ])
-        // Set working directory to config dir (required for PlatformIO)
-        .current_dir(&self.config_dir)
-        // Redirect stdout/stderr to single log file
-        .stdout(Stdio::from(log_file))
-        .stderr(Stdio::from(log_file_clone))
-        .kill_on_drop(true);
+        if use_device_builder {
+            cmd.args([
+                "-m",
+                "esphome_device_builder",
+                config_arg,
+                "--host",
+                "127.0.0.1",
+                "--port",
+                &port_arg,
+            ]);
+        } else {
+            cmd.args([
+                "-m",
+                "esphome",
+                "dashboard",
+                config_arg,
+                "--address",
+                "127.0.0.1",
+                "--port",
+                &port_arg,
+            ]);
+        }
+        cmd
+            // Set working directory to config dir (required for PlatformIO)
+            .current_dir(&self.config_dir)
+            // Redirect stdout/stderr to single log file
+            .stdout(Stdio::from(log_file))
+            .stderr(Stdio::from(log_file_clone))
+            .kill_on_drop(true);
 
         // Create new process group on Unix so we can kill all children
         #[cfg(unix)]
@@ -145,13 +180,13 @@ impl DaemonManager {
                 }
                 match health_check(port).await {
                     Ok(true) => debug!("Health check passed"),
-                    Ok(false) => warn!("Health check failed - dashboard may be starting"),
+                    Ok(false) => warn!("Health check failed - backend may be starting"),
                     Err(e) => warn!("Health check error: {}", e),
                 }
             }
         });
 
-        info!("ESPHome dashboard started");
+        info!("{} started", backend_name);
         Ok(())
     }
 
@@ -162,7 +197,8 @@ impl DaemonManager {
             return Ok(());
         }
 
-        info!("Stopping ESPHome dashboard");
+        let backend_name = self.backend_name();
+        info!("Stopping {}", backend_name);
         self.running.store(false, Ordering::SeqCst);
 
         let mut process = self.process.lock().await;
@@ -183,7 +219,7 @@ impl DaemonManager {
             let timeout = tokio::time::timeout(tokio::time::Duration::from_secs(5), child.wait());
 
             match timeout.await {
-                Ok(Ok(status)) => info!("ESPHome dashboard exited with status: {}", status),
+                Ok(Ok(status)) => info!("{} exited with status: {}", backend_name, status),
                 Ok(Err(e)) => warn!("Error waiting for process: {}", e),
                 Err(_) => {
                     warn!("Timeout waiting for graceful shutdown, forcing kill");
@@ -201,7 +237,7 @@ impl DaemonManager {
             }
         }
 
-        info!("ESPHome dashboard stopped");
+        info!("{} stopped", backend_name);
         Ok(())
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -86,7 +86,7 @@ fn open_dashboard(port: u16) {
 }
 
 /// Wait for the dashboard to be ready by polling the health endpoint
-async fn wait_for_dashboard_ready(port: u16, timeout_secs: u64) -> bool {
+pub(crate) async fn wait_for_dashboard_ready(port: u16, timeout_secs: u64) -> bool {
     let client = match reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(2))
         .build()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -22,9 +22,18 @@ use tracing::{error, info, warn};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 use daemon::DaemonManager;
-use settings::Settings;
+use settings::{Backend, Settings};
 use tray::build_tray_menu;
 use update::UpdateChecker;
+
+/// CLI selector for the device-builder channel.
+/// Maps onto [`Backend::BuilderStable`]/[`Backend::BuilderBeta`].
+#[derive(clap::ValueEnum, Clone, Copy, Debug)]
+#[value(rename_all = "lowercase")]
+pub enum BuilderChannelArg {
+    Stable,
+    Beta,
+}
 
 /// ESPHome Desktop - System tray application for ESPHome
 #[derive(Parser, Debug, Clone)]
@@ -34,6 +43,17 @@ pub struct Cli {
     /// Don't open the dashboard in browser on startup
     #[arg(long = "no-open-dashboard")]
     pub no_open_dashboard: bool,
+
+    /// Switch to the ESPHome Device Builder backend instead of the classic
+    /// dashboard. Persists to settings — useful as a fallback when the tray
+    /// menu is unavailable.
+    #[arg(long = "use-builder")]
+    pub use_builder: bool,
+
+    /// Channel for the ESPHome Device Builder backend.
+    /// Only takes effect together with `--use-builder`.
+    #[arg(long = "builder-channel", value_enum, default_value_t = BuilderChannelArg::Beta)]
+    pub builder_channel: BuilderChannelArg,
 }
 
 /// Application state shared across the app
@@ -82,14 +102,14 @@ async fn wait_for_dashboard_ready(port: u16, timeout_secs: u64) -> bool {
     while start.elapsed() < timeout {
         if let Ok(response) = client.get(&url).send().await {
             if response.status().is_success() {
-                info!("Dashboard is ready");
+                info!("Backend is ready");
                 return true;
             }
         }
         tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
     }
 
-    warn!("Timeout waiting for dashboard to be ready");
+    warn!("Timeout waiting for backend to be ready");
     false
 }
 
@@ -118,6 +138,14 @@ pub fn run(cli: Cli) {
 
     // Capture CLI flags before closure
     let no_open_dashboard = cli.no_open_dashboard;
+    let cli_backend_override = if cli.use_builder {
+        Some(match cli.builder_channel {
+            BuilderChannelArg::Stable => Backend::BuilderStable,
+            BuilderChannelArg::Beta => Backend::BuilderBeta,
+        })
+    } else {
+        None
+    };
 
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
@@ -148,6 +176,30 @@ pub fn run(cli: Cli) {
             // Initialize app state
             let state = Arc::new(AppState::new(app.handle())?);
             app.manage(state.clone());
+
+            // Apply CLI backend override (persists to settings).
+            // This runs before the daemon starts so the new backend takes
+            // effect immediately, and before the tray menu is built so the
+            // radio buttons reflect the override.
+            let cli_override_needs_install = if let Some(new_backend) = cli_backend_override {
+                let mut settings = async_runtime::block_on(state.settings.write());
+                if settings.backend != new_backend {
+                    info!(
+                        "CLI override: switching backend from {} to {}",
+                        settings.backend, new_backend
+                    );
+                    settings.backend = new_backend;
+                    if let Err(e) = settings.save(app.handle()) {
+                        warn!("Failed to save settings after CLI override: {}", e);
+                    }
+                    state.daemon.set_use_device_builder(new_backend.is_builder());
+                    new_backend.is_builder()
+                } else {
+                    false
+                }
+            } else {
+                false
+            };
 
             // Build and set up the tray menu (if tray support is available)
             let tray_available = if platform::is_tray_supported() {
@@ -216,6 +268,20 @@ pub fn run(cli: Cli) {
             let daemon_state = state.clone();
             let daemon_app = app.handle().clone();
             async_runtime::spawn(async move {
+                // If a CLI override switched us into a builder backend, ensure
+                // the package is installed/upgraded before starting the daemon.
+                if cli_override_needs_install {
+                    let backend = daemon_state.settings.read().await.backend;
+                    info!("Installing/upgrading esphome-device-builder for CLI override");
+                    if let Err(e) = daemon_state
+                        .update_checker
+                        .install_device_builder(&daemon_app, backend)
+                        .await
+                    {
+                        error!("Failed to install esphome-device-builder: {}", e);
+                    }
+                }
+
                 match daemon_state.daemon.start().await {
                     Ok(()) => {
                         // Update tray status to show running
@@ -230,6 +296,8 @@ pub fn run(cli: Cli) {
 
             // Start update checker (check after 30s, then every 24 hours)
             // The dev channel skips automatic update checks entirely.
+            // When the active backend is a builder variant, the
+            // `esphome-device-builder` package is checked on the same schedule.
             let update_state = state.clone();
             let update_app = app.handle().clone();
             async_runtime::spawn(async move {
@@ -237,14 +305,20 @@ pub fn run(cli: Cli) {
                 let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(86400));
                 loop {
                     interval.tick().await;
-                    let channel = {
+                    let (channel, backend) = {
                         let settings = update_state.settings.read().await;
-                        settings.release_channel
+                        (settings.release_channel, settings.backend)
                     };
                     update_state
                         .update_checker
                         .check_and_notify(&update_app, channel)
                         .await;
+                    if backend.is_builder() {
+                        update_state
+                            .update_checker
+                            .check_and_notify_device_builder(&update_app, backend)
+                            .await;
+                    }
                 }
             });
 
@@ -285,7 +359,7 @@ pub fn run(cli: Cli) {
             let should_open = (settings.open_on_start || !tray_available) && !no_open_dashboard;
             if should_open {
                 let port = settings.port;
-                info!("Opening dashboard on startup");
+                info!("Opening backend in browser on startup");
                 // Wait for dashboard to be ready, then open browser
                 async_runtime::spawn(async move {
                     if wait_for_dashboard_ready(port, 60).await {
@@ -296,7 +370,7 @@ pub fn run(cli: Cli) {
                     }
                 });
             } else if no_open_dashboard {
-                info!("Dashboard opening suppressed by --no-open-dashboard flag");
+                info!("Browser opening suppressed by --no-open-dashboard flag");
             }
 
             Ok(())

--- a/src-tauri/src/settings/mod.rs
+++ b/src-tauri/src/settings/mod.rs
@@ -42,6 +42,41 @@ impl fmt::Display for ReleaseChannel {
     }
 }
 
+/// Which backend the daemon should run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Backend {
+    /// Classic ESPHome dashboard (`esphome dashboard`)
+    Classic,
+    /// ESPHome device builder, stable release from PyPI
+    BuilderStable,
+    /// ESPHome device builder, beta/pre-release from PyPI
+    BuilderBeta,
+}
+
+impl Default for Backend {
+    fn default() -> Self {
+        Self::Classic
+    }
+}
+
+impl fmt::Display for Backend {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Classic => write!(f, "Classic ESPHome Dashboard"),
+            Self::BuilderStable => write!(f, "ESPHome Builder (stable)"),
+            Self::BuilderBeta => write!(f, "ESPHome Builder (beta)"),
+        }
+    }
+}
+
+impl Backend {
+    /// True for any of the device-builder variants.
+    pub fn is_builder(self) -> bool {
+        matches!(self, Self::BuilderStable | Self::BuilderBeta)
+    }
+}
+
 /// Application settings
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Settings {
@@ -65,6 +100,10 @@ pub struct Settings {
     #[serde(default)]
     pub release_channel: ReleaseChannel,
 
+    /// Active backend (classic dashboard or device builder variant)
+    #[serde(default)]
+    pub backend: Backend,
+
     /// Installed ESPHome version (detected from venv)
     #[serde(skip)]
     pub installed_version: Option<String>,
@@ -86,6 +125,7 @@ impl Default for Settings {
             open_on_start: true,
             check_updates: true,
             release_channel: ReleaseChannel::default(),
+            backend: Backend::default(),
             installed_version: None,
         }
     }

--- a/src-tauri/src/tray/mod.rs
+++ b/src-tauri/src/tray/mod.rs
@@ -10,6 +10,7 @@ use tauri::{
     AppHandle,
 };
 use tauri_plugin_dialog::{DialogExt, MessageDialogKind};
+use tauri_plugin_notification::NotificationExt;
 use tracing::{error, info, warn};
 
 use crate::settings::{Backend, ReleaseChannel};
@@ -765,6 +766,27 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>, _a
                 } else {
                     update_status(&app, true);
                     info!("Switched backend to {}", new_backend);
+
+                    // Wait for the new backend to be reachable, then notify.
+                    let port = state.daemon.port();
+                    let ready = crate::wait_for_dashboard_ready(port, 60).await;
+                    let body = if ready {
+                        format!("{} is ready.", new_backend)
+                    } else {
+                        format!(
+                            "Switched to {}, but it didn't become ready in time. Check the logs.",
+                            new_backend
+                        )
+                    };
+                    if let Err(e) = app
+                        .notification()
+                        .builder()
+                        .title("Backend Switched")
+                        .body(body)
+                        .show()
+                    {
+                        warn!("Failed to show backend-switch notification: {}", e);
+                    }
                 }
             });
         }

--- a/src-tauri/src/tray/mod.rs
+++ b/src-tauri/src/tray/mod.rs
@@ -12,7 +12,7 @@ use tauri::{
 use tauri_plugin_dialog::{DialogExt, MessageDialogKind};
 use tracing::{error, info, warn};
 
-use crate::settings::ReleaseChannel;
+use crate::settings::{Backend, ReleaseChannel};
 use crate::AppState;
 
 /// Menu item IDs
@@ -31,6 +31,11 @@ mod ids {
     pub const CHANNEL_STABLE: &str = "channel_stable";
     pub const CHANNEL_BETA: &str = "channel_beta";
     pub const CHANNEL_DEV: &str = "channel_dev";
+
+    // Backend submenu items
+    pub const BACKEND_CLASSIC: &str = "backend_classic";
+    pub const BACKEND_BUILDER_STABLE: &str = "backend_builder_stable";
+    pub const BACKEND_BUILDER_BETA: &str = "backend_builder_beta";
 }
 
 /// Build the tray menu
@@ -60,11 +65,11 @@ pub fn build_tray_menu(app_handle: &AppHandle, state: &Arc<AppState>) -> Result<
 
     // Create release channel items
     let current_channel = settings.release_channel;
-    let channel_stable = MenuItemBuilder::with_id(ids::CHANNEL_STABLE, channel_label("Stable", current_channel == ReleaseChannel::Stable))
+    let channel_stable = MenuItemBuilder::with_id(ids::CHANNEL_STABLE, radio_label("Stable", current_channel == ReleaseChannel::Stable))
         .build(app_handle)?;
-    let channel_beta = MenuItemBuilder::with_id(ids::CHANNEL_BETA, channel_label("Beta", current_channel == ReleaseChannel::Beta))
+    let channel_beta = MenuItemBuilder::with_id(ids::CHANNEL_BETA, radio_label("Beta", current_channel == ReleaseChannel::Beta))
         .build(app_handle)?;
-    let channel_dev = MenuItemBuilder::with_id(ids::CHANNEL_DEV, channel_label("Dev", current_channel == ReleaseChannel::Dev))
+    let channel_dev = MenuItemBuilder::with_id(ids::CHANNEL_DEV, radio_label("Dev", current_channel == ReleaseChannel::Dev))
         .build(app_handle)?;
 
     // Store channel items for later updates
@@ -76,6 +81,41 @@ pub fn build_tray_menu(app_handle: &AppHandle, state: &Arc<AppState>) -> Result<
         .item(&channel_stable)
         .item(&channel_beta)
         .item(&channel_dev)
+        .build()?;
+
+    // Backend submenu items
+    let current_backend = settings.backend;
+    let backend_classic = MenuItemBuilder::with_id(
+        ids::BACKEND_CLASSIC,
+        radio_label("Classic ESPHome Dashboard", current_backend == Backend::Classic),
+    )
+    .build(app_handle)?;
+    let backend_builder_stable = MenuItemBuilder::with_id(
+        ids::BACKEND_BUILDER_STABLE,
+        radio_label(
+            "ESPHome Builder (stable)",
+            current_backend == Backend::BuilderStable,
+        ),
+    )
+    .enabled(false) // TODO: remove once a stable release of esphome-device-builder is out
+    .build(app_handle)?;
+    let backend_builder_beta = MenuItemBuilder::with_id(
+        ids::BACKEND_BUILDER_BETA,
+        radio_label(
+            "ESPHome Builder (beta)",
+            current_backend == Backend::BuilderBeta,
+        ),
+    )
+    .build(app_handle)?;
+
+    let _ = BACKEND_CLASSIC_ITEM.set(backend_classic.clone());
+    let _ = BACKEND_BUILDER_STABLE_ITEM.set(backend_builder_stable.clone());
+    let _ = BACKEND_BUILDER_BETA_ITEM.set(backend_builder_beta.clone());
+
+    let backend_submenu = SubmenuBuilder::with_id(app_handle, "backend", "Backend")
+        .item(&backend_classic)
+        .item(&backend_builder_stable)
+        .item(&backend_builder_beta)
         .build()?;
 
     let menu = MenuBuilder::new(app_handle)
@@ -93,6 +133,7 @@ pub fn build_tray_menu(app_handle: &AppHandle, state: &Arc<AppState>) -> Result<
                 .build(app_handle)?,
         )
         .separator()
+        .item(&backend_submenu)
         .item(&channel_submenu)
         .item(
             &MenuItemBuilder::with_id(ids::CHECK_UPDATES, "Check for Updates...")
@@ -134,6 +175,14 @@ static CHANNEL_BETA_ITEM: std::sync::OnceLock<MenuItem<tauri::Wry>> =
 static CHANNEL_DEV_ITEM: std::sync::OnceLock<MenuItem<tauri::Wry>> =
     std::sync::OnceLock::new();
 
+/// Backend menu items stored globally for radio-button behavior
+static BACKEND_CLASSIC_ITEM: std::sync::OnceLock<MenuItem<tauri::Wry>> =
+    std::sync::OnceLock::new();
+static BACKEND_BUILDER_STABLE_ITEM: std::sync::OnceLock<MenuItem<tauri::Wry>> =
+    std::sync::OnceLock::new();
+static BACKEND_BUILDER_BETA_ITEM: std::sync::OnceLock<MenuItem<tauri::Wry>> =
+    std::sync::OnceLock::new();
+
 /// Update the tray status text
 pub fn update_status(_app_handle: &AppHandle, running: bool) {
     let status_text = if running {
@@ -154,8 +203,8 @@ pub fn update_version(version: &str) {
     }
 }
 
-/// Format a channel menu item label with a radio-button prefix.
-fn channel_label(name: &str, selected: bool) -> String {
+/// Format a radio-style menu item label with a selection prefix.
+fn radio_label(name: &str, selected: bool) -> String {
     if selected {
         format!("● {}", name)
     } else {
@@ -166,13 +215,35 @@ fn channel_label(name: &str, selected: bool) -> String {
 /// Update the channel menu item labels to reflect the given channel
 fn update_channel_checks(channel: ReleaseChannel) {
     if let Some(item) = CHANNEL_STABLE_ITEM.get() {
-        let _ = item.set_text(channel_label("Stable", channel == ReleaseChannel::Stable));
+        let _ = item.set_text(radio_label("Stable", channel == ReleaseChannel::Stable));
     }
     if let Some(item) = CHANNEL_BETA_ITEM.get() {
-        let _ = item.set_text(channel_label("Beta", channel == ReleaseChannel::Beta));
+        let _ = item.set_text(radio_label("Beta", channel == ReleaseChannel::Beta));
     }
     if let Some(item) = CHANNEL_DEV_ITEM.get() {
-        let _ = item.set_text(channel_label("Dev", channel == ReleaseChannel::Dev));
+        let _ = item.set_text(radio_label("Dev", channel == ReleaseChannel::Dev));
+    }
+}
+
+/// Update the backend menu item labels to reflect the given backend.
+fn update_backend_checks(backend: Backend) {
+    if let Some(item) = BACKEND_CLASSIC_ITEM.get() {
+        let _ = item.set_text(radio_label(
+            "Classic ESPHome Dashboard",
+            backend == Backend::Classic,
+        ));
+    }
+    if let Some(item) = BACKEND_BUILDER_STABLE_ITEM.get() {
+        let _ = item.set_text(radio_label(
+            "ESPHome Builder (stable)",
+            backend == Backend::BuilderStable,
+        ));
+    }
+    if let Some(item) = BACKEND_BUILDER_BETA_ITEM.get() {
+        let _ = item.set_text(radio_label(
+            "ESPHome Builder (beta)",
+            backend == Backend::BuilderBeta,
+        ));
     }
 }
 
@@ -197,9 +268,9 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>, _a
             let state = state.clone();
             let app = app_handle.clone();
             async_runtime::spawn(async move {
-                let channel = {
+                let (channel, backend) = {
                     let settings = state.settings.read().await;
-                    settings.release_channel
+                    (settings.release_channel, settings.backend)
                 };
 
                 // Check for updates and get version if user wants to update
@@ -209,7 +280,7 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>, _a
                     // Stop the dashboard
                     update_status(&app, false);
                     if let Err(e) = state.daemon.stop().await {
-                        error!("Failed to stop dashboard for update: {}", e);
+                        error!("Failed to stop backend for update: {}", e);
                         let dialog_app = app.clone();
                         let msg = format!("Failed to stop dashboard: {}", e);
                         let _ = tokio::task::spawn_blocking(move || {
@@ -234,7 +305,7 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>, _a
 
                             // Restart the dashboard
                             if let Err(e) = state.daemon.start().await {
-                                error!("Failed to restart dashboard after update: {}", e);
+                                error!("Failed to restart backend after update: {}", e);
                                 let dialog_app = app.clone();
                                 let msg = format!(
                                     "ESPHome updated to {}, but failed to restart dashboard: {}",
@@ -284,9 +355,115 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>, _a
 
                             // Try to restart dashboard anyway
                             if let Err(restart_err) = state.daemon.start().await {
-                                error!("Failed to restart dashboard after failed update: {}", restart_err);
+                                error!("Failed to restart backend after failed update: {}", restart_err);
                             } else {
                                 update_status(&app, true);
+                            }
+                        }
+                    }
+                }
+
+                // Also check `esphome-device-builder` when it's the active
+                // backend. This is independent of the ESPHome release channel.
+                if backend.is_builder() {
+                    if let Some(builder_version) = state
+                        .update_checker
+                        .check_device_builder_for_user(&app, backend)
+                        .await
+                    {
+                        info!(
+                            "User requested device-builder update to version {}",
+                            builder_version
+                        );
+
+                        update_status(&app, false);
+                        if let Err(e) = state.daemon.stop().await {
+                            error!("Failed to stop backend for device-builder update: {}", e);
+                            let dialog_app = app.clone();
+                            let msg = format!("Failed to stop backend: {}", e);
+                            let _ = tokio::task::spawn_blocking(move || {
+                                dialog_app
+                                    .dialog()
+                                    .message(msg)
+                                    .kind(MessageDialogKind::Error)
+                                    .title("Update Failed")
+                                    .blocking_show();
+                            })
+                            .await;
+                            return;
+                        }
+
+                        match state
+                            .update_checker
+                            .install_device_builder(&app, backend)
+                            .await
+                        {
+                            Ok(()) => {
+                                info!(
+                                    "Device builder updated successfully to {}",
+                                    builder_version
+                                );
+
+                                if let Err(e) = state.daemon.start().await {
+                                    error!(
+                                        "Failed to restart backend after device-builder update: {}",
+                                        e
+                                    );
+                                    let dialog_app = app.clone();
+                                    let msg = format!(
+                                        "Device builder updated to {}, but failed to restart backend: {}",
+                                        builder_version, e
+                                    );
+                                    let _ = tokio::task::spawn_blocking(move || {
+                                        dialog_app
+                                            .dialog()
+                                            .message(msg)
+                                            .kind(MessageDialogKind::Warning)
+                                            .title("Update Partially Complete")
+                                            .blocking_show();
+                                    })
+                                    .await;
+                                } else {
+                                    update_status(&app, true);
+                                    let dialog_app = app.clone();
+                                    let msg = format!(
+                                        "ESPHome Device Builder has been updated to version {}.",
+                                        builder_version
+                                    );
+                                    let _ = tokio::task::spawn_blocking(move || {
+                                        dialog_app
+                                            .dialog()
+                                            .message(msg)
+                                            .kind(MessageDialogKind::Info)
+                                            .title("Update Complete")
+                                            .blocking_show();
+                                    })
+                                    .await;
+                                }
+                            }
+                            Err(e) => {
+                                error!("Device-builder update failed: {}", e);
+                                let dialog_app = app.clone();
+                                let msg = format!("Failed to update ESPHome Device Builder: {}", e);
+                                let _ = tokio::task::spawn_blocking(move || {
+                                    dialog_app
+                                        .dialog()
+                                        .message(msg)
+                                        .kind(MessageDialogKind::Error)
+                                        .title("Update Failed")
+                                        .blocking_show();
+                                })
+                                .await;
+
+                                // Try to restart backend anyway
+                                if let Err(restart_err) = state.daemon.start().await {
+                                    error!(
+                                        "Failed to restart backend after failed device-builder update: {}",
+                                        restart_err
+                                    );
+                                } else {
+                                    update_status(&app, true);
+                                }
                             }
                         }
                     }
@@ -354,7 +531,7 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>, _a
                 // Stop the dashboard
                 update_status(&app, false);
                 if let Err(e) = state.daemon.stop().await {
-                    error!("Failed to stop dashboard for channel switch: {}", e);
+                    error!("Failed to stop backend for channel switch: {}", e);
                     let dialog_app = app.clone();
                     let msg = format!("Failed to stop dashboard: {}", e);
                     let _ = tokio::task::spawn_blocking(move || {
@@ -390,7 +567,7 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>, _a
 
                         // Restart the dashboard
                         if let Err(e) = state.daemon.start().await {
-                            error!("Failed to restart dashboard after channel switch: {}", e);
+                            error!("Failed to restart backend after channel switch: {}", e);
                             let dialog_app = app.clone();
                             let msg = format!(
                                 "Switched to {} channel, but failed to restart dashboard: {}",
@@ -443,13 +620,151 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>, _a
                         // Try to restart dashboard anyway
                         if let Err(restart_err) = state.daemon.start().await {
                             error!(
-                                "Failed to restart dashboard after failed channel switch: {}",
+                                "Failed to restart backend after failed channel switch: {}",
                                 restart_err
                             );
                         } else {
                             update_status(&app, true);
                         }
                     }
+                }
+            });
+        }
+        ids::BACKEND_CLASSIC | ids::BACKEND_BUILDER_STABLE | ids::BACKEND_BUILDER_BETA => {
+            let new_backend = match id {
+                ids::BACKEND_CLASSIC => Backend::Classic,
+                ids::BACKEND_BUILDER_STABLE => Backend::BuilderStable,
+                ids::BACKEND_BUILDER_BETA => Backend::BuilderBeta,
+                _ => unreachable!(),
+            };
+
+            let state = state.clone();
+            let app = app_handle.clone();
+            async_runtime::spawn(async move {
+                let old_backend = {
+                    let settings = state.settings.read().await;
+                    settings.backend
+                };
+
+                if new_backend == old_backend {
+                    return;
+                }
+
+                // Confirm the switch with the user.
+                let dialog_app = app.clone();
+                let msg = if new_backend.is_builder() {
+                    format!(
+                        "Switch to {}?\n\n\
+                         This will install the `esphome-device-builder` Python package, \
+                         stop the current backend, and restart with the new one.",
+                        new_backend
+                    )
+                } else {
+                    "Switch back to the classic ESPHome dashboard?\n\n\
+                     This will stop the device builder and restart with the dashboard."
+                        .to_string()
+                };
+                let confirmed = tokio::task::spawn_blocking(move || {
+                    dialog_app
+                        .dialog()
+                        .message(msg)
+                        .title("Switch Backend")
+                        .buttons(tauri_plugin_dialog::MessageDialogButtons::OkCancelCustom(
+                            "Switch".to_string(),
+                            "Cancel".to_string(),
+                        ))
+                        .blocking_show()
+                })
+                .await
+                .unwrap_or(false);
+
+                if !confirmed {
+                    update_backend_checks(old_backend);
+                    return;
+                }
+
+                // Update the check marks immediately to show the new selection
+                update_backend_checks(new_backend);
+
+                // Stop the current backend
+                update_status(&app, false);
+                if let Err(e) = state.daemon.stop().await {
+                    error!("Failed to stop daemon for backend switch: {}", e);
+                    let dialog_app = app.clone();
+                    let msg = format!("Failed to stop backend: {}", e);
+                    let _ = tokio::task::spawn_blocking(move || {
+                        dialog_app
+                            .dialog()
+                            .message(msg)
+                            .kind(MessageDialogKind::Error)
+                            .title("Backend Switch Failed")
+                            .blocking_show();
+                    })
+                    .await;
+                    update_backend_checks(old_backend);
+                    return;
+                }
+
+                // When switching to a builder variant, install/upgrade the package first.
+                if new_backend.is_builder() {
+                    if let Err(e) = state
+                        .update_checker
+                        .install_device_builder(&app, new_backend)
+                        .await
+                    {
+                        error!("Failed to install esphome-device-builder: {}", e);
+                        let dialog_app = app.clone();
+                        let msg = format!("Failed to install esphome-device-builder: {}", e);
+                        let _ = tokio::task::spawn_blocking(move || {
+                            dialog_app
+                                .dialog()
+                                .message(msg)
+                                .kind(MessageDialogKind::Error)
+                                .title("Backend Switch Failed")
+                                .blocking_show();
+                        })
+                        .await;
+                        update_backend_checks(old_backend);
+                        // Try to restart the original backend.
+                        if let Err(restart_err) = state.daemon.start().await {
+                            error!(
+                                "Failed to restart backend after failed switch: {}",
+                                restart_err
+                            );
+                        } else {
+                            update_status(&app, true);
+                        }
+                        return;
+                    }
+                }
+
+                // Apply the new backend to the daemon and persist it.
+                state.daemon.set_use_device_builder(new_backend.is_builder());
+                {
+                    let mut settings = state.settings.write().await;
+                    settings.backend = new_backend;
+                    if let Err(e) = settings.save(&app) {
+                        warn!("Failed to save settings: {}", e);
+                    }
+                }
+
+                // Restart with the new backend.
+                if let Err(e) = state.daemon.start().await {
+                    error!("Failed to start daemon after backend switch: {}", e);
+                    let dialog_app = app.clone();
+                    let msg = format!("Failed to start backend: {}", e);
+                    let _ = tokio::task::spawn_blocking(move || {
+                        dialog_app
+                            .dialog()
+                            .message(msg)
+                            .kind(MessageDialogKind::Error)
+                            .title("Backend Switch Failed")
+                            .blocking_show();
+                    })
+                    .await;
+                } else {
+                    update_status(&app, true);
+                    info!("Switched backend to {}", new_backend);
                 }
             });
         }
@@ -466,7 +781,7 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>, _a
             }
         }
         ids::RESTART => {
-            info!("Restarting ESPHome dashboard");
+            info!("Restarting ESPHome backend");
             let state = state.clone();
             async_runtime::spawn(async move {
                 if let Err(e) = state.daemon.restart().await {

--- a/src-tauri/src/update/mod.rs
+++ b/src-tauri/src/update/mod.rs
@@ -12,7 +12,7 @@ use tauri_plugin_notification::NotificationExt;
 use tracing::{debug, error, info, warn};
 
 use crate::platform;
-use crate::settings::ReleaseChannel;
+use crate::settings::{Backend, ReleaseChannel};
 
 /// PyPI package info response (used for stable channel)
 #[derive(Debug, Deserialize)]
@@ -370,6 +370,196 @@ impl UpdateChecker {
         }
     }
 
+    /// Install or upgrade the `esphome-device-builder` package from PyPI.
+    /// Pass `Backend::BuilderBeta` to allow pre-releases (`pip install --pre`),
+    /// `Backend::BuilderStable` for stable-only. Calling with `Backend::Classic`
+    /// is a no-op.
+    pub async fn install_device_builder(
+        &self,
+        app_handle: &AppHandle,
+        backend: Backend,
+    ) -> Result<()> {
+        if !backend.is_builder() {
+            return Ok(());
+        }
+        let python_path = platform::get_python_path(app_handle)?;
+
+        info!("Installing/upgrading esphome-device-builder ({})", backend);
+
+        let mut args: Vec<&str> = vec!["-m", "pip", "install", "--upgrade"];
+        if backend == Backend::BuilderBeta {
+            args.push("--pre");
+        }
+        args.push("esphome-device-builder");
+
+        let mut cmd = tokio::process::Command::new(&python_path);
+        cmd.args(&args);
+        platform::configure_no_window_tokio_command(&mut cmd);
+
+        let output = cmd.output().await.context("Failed to run pip install")?;
+
+        if output.status.success() {
+            info!("esphome-device-builder installed/upgraded successfully");
+            Ok(())
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("pip install esphome-device-builder failed: {}", stderr)
+        }
+    }
+
+    /// Query PyPI for the latest available `esphome-device-builder` version.
+    /// `Backend::BuilderStable` returns the latest final release; `BuilderBeta`
+    /// returns the latest version including pre-releases. Returns `Ok(None)`
+    /// if the backend is not a builder variant.
+    pub async fn check_device_builder(&self, backend: Backend) -> Result<Option<String>> {
+        if !backend.is_builder() {
+            return Ok(None);
+        }
+        let response: PyPIResponse = self
+            .client
+            .get("https://pypi.org/pypi/esphome-device-builder/json")
+            .send()
+            .await
+            .context("Failed to fetch PyPI info for esphome-device-builder")?
+            .json()
+            .await
+            .context("Failed to parse PyPI response for esphome-device-builder")?;
+
+        let include_pre = backend == Backend::BuilderBeta;
+        let latest = if include_pre {
+            find_latest_any(&response.releases).unwrap_or(response.info.version)
+        } else {
+            response.info.version
+        };
+        info!(
+            "Latest esphome-device-builder version on PyPI ({}): {}",
+            backend, latest
+        );
+        Ok(Some(latest))
+    }
+
+    /// Background check for esphome-device-builder updates. Emits a
+    /// notification if a newer version is available. No-op for non-builder
+    /// backends.
+    pub async fn check_and_notify_device_builder(
+        &self,
+        app_handle: &AppHandle,
+        backend: Backend,
+    ) {
+        if !backend.is_builder() {
+            return;
+        }
+
+        let installed = match get_installed_device_builder_version(app_handle) {
+            Ok(v) => v,
+            Err(e) => {
+                debug!("esphome-device-builder version not detected: {}", e);
+                return;
+            }
+        };
+
+        let latest = match self.check_device_builder(backend).await {
+            Ok(Some(v)) => v,
+            Ok(None) => return,
+            Err(e) => {
+                warn!("Device-builder update check failed: {}", e);
+                return;
+            }
+        };
+
+        if is_newer_version(&latest, &installed) {
+            info!(
+                "Device-builder update available: {} -> {} (installed: {})",
+                installed, latest, installed
+            );
+
+            if let Err(e) = app_handle
+                .notification()
+                .builder()
+                .title("ESPHome Device Builder Update Available")
+                .body(format!(
+                    "ESPHome Device Builder {} is available (you have {}). \
+                     Click 'Check for Updates' in the menu to update.",
+                    latest, installed
+                ))
+                .show()
+            {
+                error!("Failed to show notification: {}", e);
+            }
+        } else {
+            debug!("ESPHome Device Builder is up to date ({})", installed);
+        }
+    }
+
+    /// User-initiated check for esphome-device-builder updates. Returns
+    /// `Some(version)` if the user wants to update, `None` otherwise.
+    /// Stays silent when there is no update — the caller is responsible
+    /// for the "everything is up to date" UX.
+    pub async fn check_device_builder_for_user(
+        &self,
+        app_handle: &AppHandle,
+        backend: Backend,
+    ) -> Option<String> {
+        if !backend.is_builder() {
+            return None;
+        }
+
+        let installed = match get_installed_device_builder_version(app_handle) {
+            Ok(v) => v,
+            Err(e) => {
+                warn!(
+                    "Could not detect installed esphome-device-builder version: {}",
+                    e
+                );
+                return None;
+            }
+        };
+
+        let latest = match self.check_device_builder(backend).await {
+            Ok(Some(v)) => v,
+            Ok(None) => return None,
+            Err(e) => {
+                warn!("Device-builder update check failed: {}", e);
+                return None;
+            }
+        };
+
+        if !is_newer_version(&latest, &installed) {
+            info!("ESPHome Device Builder is up to date ({})", installed);
+            return None;
+        }
+
+        info!(
+            "Device-builder update available: {} -> {} (installed: {})",
+            installed, latest, installed
+        );
+
+        let dialog_app = app_handle.clone();
+        let msg = format!(
+            "ESPHome Device Builder {} is available.\n\nYou currently have version {}.\n\nWould you like to update now?",
+            latest, installed
+        );
+        let should_update = tokio::task::spawn_blocking(move || {
+            dialog_app
+                .dialog()
+                .message(msg)
+                .title("Device Builder Update Available")
+                .buttons(tauri_plugin_dialog::MessageDialogButtons::OkCancelCustom(
+                    "Update Now".to_string(),
+                    "Later".to_string(),
+                ))
+                .blocking_show()
+        })
+        .await
+        .unwrap_or(false);
+
+        if should_update {
+            Some(latest)
+        } else {
+            None
+        }
+    }
+
     /// Switch to a new release channel by installing the appropriate version.
     /// Returns Ok(()) on success.
     pub async fn switch_channel(
@@ -455,6 +645,51 @@ fn has_beta_suffix(version: &str) -> bool {
         }
     }
     false
+}
+
+/// Find the highest version across all releases on PyPI, including
+/// pre-releases. Used for the "beta" device-builder channel where any
+/// pre-release counts (a/b/rc/dev), not just `bN` like ESPHome itself.
+fn find_latest_any(releases: &HashMap<String, Vec<PyPIRelease>>) -> Option<String> {
+    let mut best: Option<String> = None;
+    for v in releases.keys() {
+        if !v.chars().next().map_or(false, |c| c.is_ascii_digit()) {
+            continue;
+        }
+        match &best {
+            None => best = Some(v.clone()),
+            Some(curr) => {
+                if is_newer_version(v, curr) {
+                    best = Some(v.clone());
+                }
+            }
+        }
+    }
+    best
+}
+
+/// Get the installed `esphome-device-builder` package version.
+pub fn get_installed_device_builder_version(app_handle: &AppHandle) -> Result<String> {
+    let python_path = platform::get_python_path(app_handle)?;
+
+    let mut cmd = std::process::Command::new(&python_path);
+    cmd.args([
+        "-c",
+        "from importlib.metadata import version; print(version('esphome-device-builder'))",
+    ]);
+    platform::configure_no_window_command(&mut cmd);
+
+    let output = cmd.output().context("Failed to run python")?;
+
+    if output.status.success() {
+        let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if version.is_empty() {
+            anyhow::bail!("esphome-device-builder version is empty");
+        }
+        Ok(version)
+    } else {
+        anyhow::bail!("esphome-device-builder not installed")
+    }
 }
 
 /// Get the installed ESPHome version


### PR DESCRIPTION
# What does this implement/fix?

Adds the ESPHome Device Builder (PyPI `esphome-device-builder`) as a selectable backend, alongside the classic `esphome dashboard`.

A new **Backend** submenu in the tray lets the user pick between **Classic ESPHome Dashboard**, **ESPHome Builder (stable)** (disabled until a stable release exists), and **ESPHome Builder (beta)**. Selecting a builder variant pip-installs/upgrades `esphome-device-builder` (with `--pre` for beta), persists the choice, and restarts the daemon with `python -m esphome_device_builder <config> --host 127.0.0.1 --port <port>`.

Two new CLI flags — `--use-builder` and `--builder-channel <stable|beta>` — provide the same switch as a fallback when the tray icon isn't available (e.g. on Linux setups where libappindicator can't load). They persist to settings.

`esphome-device-builder` is queried on the same 24-hour update schedule and surfaced through the existing **Check for Updates...** menu, with version checks independent of the ESPHome release channel since the two packages have separate versioning.

Log lines that previously said "dashboard" now reflect the active backend or use a neutral term.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes <link to issue>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).