### PR TITLE
Unify desktop quit paths and stop force-killing the dashboard

### DIFF
--- a/src-tauri/src/daemon/mod.rs
+++ b/src-tauri/src/daemon/mod.rs
@@ -260,9 +260,18 @@ impl DaemonManager {
     /// Synchronously send SIGTERM to the dashboard's process group.
     /// Safe to call from any context (including a tauri `RunEvent::Exit`
     /// callback where the tokio runtime is already winding down) — no
-    /// async involvement. No-op if the daemon is not running. Used as
-    /// a last-resort guard so we never leave the dashboard orphaned,
-    /// regardless of which exit path Tauri dispatches us on.
+    /// async involvement. No-op if the daemon is not running or if a
+    /// previous call already fired the signal.
+    ///
+    /// Idempotent via an atomic swap on `dashboard_pid` — repeated
+    /// calls after the first are cheap no-ops, so it's safe to call
+    /// from both the `ExitRequested` and `Exit` branches of the tauri
+    /// run loop.
+    ///
+    /// Does NOT touch the `running` flag, so a concurrent / subsequent
+    /// `stop()` still runs its graceful 30 s wait. The PID atomic is
+    /// only used for the synchronous kill path; `stop()` reads
+    /// `child.id()` directly off the stored `Child` handle.
     ///
     /// SIGTERM only — the dashboard is expected to honor it and clean
     /// up its own state. If it doesn't, that's a dashboard-side bug.
@@ -271,7 +280,6 @@ impl DaemonManager {
         if pid == 0 {
             return;
         }
-        self.running.store(false, Ordering::SeqCst);
         #[cfg(unix)]
         {
             use nix::sys::signal::{killpg, Signal};

--- a/src-tauri/src/daemon/mod.rs
+++ b/src-tauri/src/daemon/mod.rs
@@ -34,7 +34,7 @@ pub struct DaemonManager {
     running: Arc<AtomicBool>,
     /// PID of the dashboard child, mirrored as an atomic so synchronous
     /// exit paths (e.g. macOS Dock-Quit, which fires `RunEvent::Exit`
-    /// without going through `ExitRequested`) can SIGKILL the process
+    /// without going through `ExitRequested`) can SIGTERM the process
     /// group without locking the tokio mutex. Zero when no child is
     /// running.
     dashboard_pid: Arc<AtomicI32>,
@@ -148,12 +148,20 @@ impl DaemonManager {
             // Redirect stdout/stderr to single log file
             .stdout(Stdio::from(log_file))
             .stderr(Stdio::from(log_file_clone));
-        // NOTE: not setting `kill_on_drop(true)`. That would have tokio
-        // send SIGKILL to the Child when it gets dropped (either when
-        // stop()'s wait times out, or when AppState drops at process
-        // teardown), which force-kills the dashboard and corrupts its
-        // state. Our shutdown is SIGTERM only — see `stop()` and
-        // `terminate_blocking()`.
+        // On Unix, intentionally NOT setting `kill_on_drop(true)`. That
+        // would have tokio send SIGKILL to the Child when it gets
+        // dropped (either when stop()'s wait times out, or when
+        // AppState drops at process teardown), which force-kills the
+        // dashboard and corrupts its state. Our Unix shutdown is
+        // SIGTERM only — see `stop()` and `terminate_blocking()`.
+        //
+        // On Windows there is no SIGTERM equivalent; the only way to
+        // stop the child reliably is TerminateProcess (what
+        // `Child::kill()` and `kill_on_drop(true)` invoke). Keep the
+        // drop-time safety net there so the dashboard doesn't orphan
+        // on Windows app exit.
+        #[cfg(windows)]
+        cmd.kill_on_drop(true);
 
         // Create new process group on Unix so we can kill all children
         #[cfg(unix)]
@@ -244,11 +252,24 @@ impl DaemonManager {
             match timeout.await {
                 Ok(Ok(status)) => info!("{} exited with status: {}", backend_name, status),
                 Ok(Err(e)) => warn!("Error waiting for process: {}", e),
+                #[cfg(unix)]
                 Err(_) => warn!(
                     "Timeout waiting for {} to honor SIGTERM after 30 s; \
                      proceeding with exit without force-killing.",
                     backend_name
                 ),
+                // On Windows the loop above sent no graceful signal
+                // (there is no SIGTERM analog reachable from here),
+                // so the timeout is really "we waited 30 s for nothing
+                // to happen." TerminateProcess via Child::kill() is
+                // the only termination path; without it the dashboard
+                // would orphan on app exit. State preservation on
+                // Windows is out of scope for this fix.
+                #[cfg(not(unix))]
+                Err(_) => {
+                    warn!("Timeout waiting for {} to exit; force-killing.", backend_name);
+                    let _ = child.kill().await;
+                }
             }
         }
 
@@ -275,6 +296,16 @@ impl DaemonManager {
     ///
     /// SIGTERM only — the dashboard is expected to honor it and clean
     /// up its own state. If it doesn't, that's a dashboard-side bug.
+    ///
+    /// Guards against PID-reuse via `getpgid()`: if the dashboard child
+    /// exited independently (crash / external kill) and tokio reaped
+    /// it before we got here, the kernel may have handed our recorded
+    /// PID to an unrelated process. We spawned the dashboard with
+    /// `process_group(0)`, so the child is its own pgleader (pgid ==
+    /// pid). An unrelated process inheriting the recycled PID is
+    /// almost certainly not its own pgleader, so a `getpgid(pid) !=
+    /// pid` result short-circuits the signal and we don't disturb the
+    /// stranger.
     pub fn terminate_blocking(&self) {
         let pid = self.dashboard_pid.swap(0, Ordering::SeqCst);
         if pid == 0 {
@@ -283,8 +314,21 @@ impl DaemonManager {
         #[cfg(unix)]
         {
             use nix::sys::signal::{killpg, Signal};
-            use nix::unistd::Pid;
-            let _ = killpg(Pid::from_raw(pid), Signal::SIGTERM);
+            use nix::unistd::{getpgid, Pid};
+            let pid_t = Pid::from_raw(pid);
+            match getpgid(Some(pid_t)) {
+                Ok(pgid) if pgid == pid_t => {
+                    let _ = killpg(pid_t, Signal::SIGTERM);
+                }
+                _ => {
+                    warn!(
+                        "Recorded dashboard pid {} is no longer its own \
+                         process group leader; skipping SIGTERM to avoid \
+                         signaling a recycled-PID stranger.",
+                        pid
+                    );
+                }
+            }
         }
     }
 

--- a/src-tauri/src/daemon/mod.rs
+++ b/src-tauri/src/daemon/mod.rs
@@ -6,7 +6,7 @@ use anyhow::{Context, Result};
 use std::fs::File;
 use std::path::PathBuf;
 use std::process::Stdio;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
 use std::sync::Arc;
 use tauri::AppHandle;
 use tokio::process::{Child, Command};
@@ -32,6 +32,12 @@ pub struct DaemonManager {
     port: u16,
     /// Whether the daemon is running
     running: Arc<AtomicBool>,
+    /// PID of the dashboard child, mirrored as an atomic so synchronous
+    /// exit paths (e.g. macOS Dock-Quit, which fires `RunEvent::Exit`
+    /// without going through `ExitRequested`) can SIGKILL the process
+    /// group without locking the tokio mutex. Zero when no child is
+    /// running.
+    dashboard_pid: Arc<AtomicI32>,
     /// Use `esphome-device-builder` instead of `esphome dashboard`
     use_device_builder: Arc<AtomicBool>,
 }
@@ -63,6 +69,7 @@ impl DaemonManager {
             logs_dir,
             port: settings.port,
             running: Arc::new(AtomicBool::new(false)),
+            dashboard_pid: Arc::new(AtomicI32::new(0)),
             use_device_builder: Arc::new(AtomicBool::new(settings.backend.is_builder())),
         })
     }
@@ -140,8 +147,13 @@ impl DaemonManager {
             .current_dir(&self.config_dir)
             // Redirect stdout/stderr to single log file
             .stdout(Stdio::from(log_file))
-            .stderr(Stdio::from(log_file_clone))
-            .kill_on_drop(true);
+            .stderr(Stdio::from(log_file_clone));
+        // NOTE: not setting `kill_on_drop(true)`. That would have tokio
+        // send SIGKILL to the Child when it gets dropped (either when
+        // stop()'s wait times out, or when AppState drops at process
+        // teardown), which force-kills the dashboard and corrupts its
+        // state. Our shutdown is SIGTERM only — see `stop()` and
+        // `terminate_blocking()`.
 
         // Create new process group on Unix so we can kill all children
         #[cfg(unix)]
@@ -164,6 +176,9 @@ impl DaemonManager {
         cmd.env("PYTHONIOENCODING", "utf-8");
 
         let child = cmd.spawn().context("Failed to spawn ESPHome process")?;
+        if let Some(pid) = child.id() {
+            self.dashboard_pid.store(pid as i32, Ordering::SeqCst);
+        }
 
         let mut process = self.process.lock().await;
         *process = Some(child);
@@ -215,30 +230,54 @@ impl DaemonManager {
                 }
             }
 
-            // Wait for process to exit (with timeout)
-            let timeout = tokio::time::timeout(tokio::time::Duration::from_secs(5), child.wait());
+            // Wait up to 30 s for the dashboard to honor SIGTERM and exit
+            // cleanly. The dashboard's shutdown can drain in-flight work
+            // (firmware queue, partial writes, lock release) and we have
+            // measured this taking up to 30 s in the wild. We do NOT
+            // escalate to SIGKILL on timeout — force-killing here
+            // corrupts dashboard state. If the dashboard doesn't honor
+            // SIGTERM within the window, that's a dashboard-side bug;
+            // we log a warning and let the child finish on its own
+            // (it may briefly outlive us as an orphan of launchd).
+            let timeout = tokio::time::timeout(tokio::time::Duration::from_secs(30), child.wait());
 
             match timeout.await {
                 Ok(Ok(status)) => info!("{} exited with status: {}", backend_name, status),
                 Ok(Err(e)) => warn!("Error waiting for process: {}", e),
-                Err(_) => {
-                    warn!("Timeout waiting for graceful shutdown, forcing kill");
-                    #[cfg(unix)]
-                    {
-                        use nix::sys::signal::{killpg, Signal};
-                        use nix::unistd::Pid;
-                        if let Some(pid) = child.id() {
-                            // Force kill the process group
-                            let _ = killpg(Pid::from_raw(pid as i32), Signal::SIGKILL);
-                        }
-                    }
-                    let _ = child.kill().await;
-                }
+                Err(_) => warn!(
+                    "Timeout waiting for {} to honor SIGTERM after 30 s; \
+                     proceeding with exit without force-killing.",
+                    backend_name
+                ),
             }
         }
 
+        self.dashboard_pid.store(0, Ordering::SeqCst);
         info!("{} stopped", backend_name);
         Ok(())
+    }
+
+    /// Synchronously send SIGTERM to the dashboard's process group.
+    /// Safe to call from any context (including a tauri `RunEvent::Exit`
+    /// callback where the tokio runtime is already winding down) — no
+    /// async involvement. No-op if the daemon is not running. Used as
+    /// a last-resort guard so we never leave the dashboard orphaned,
+    /// regardless of which exit path Tauri dispatches us on.
+    ///
+    /// SIGTERM only — the dashboard is expected to honor it and clean
+    /// up its own state. If it doesn't, that's a dashboard-side bug.
+    pub fn terminate_blocking(&self) {
+        let pid = self.dashboard_pid.swap(0, Ordering::SeqCst);
+        if pid == 0 {
+            return;
+        }
+        self.running.store(false, Ordering::SeqCst);
+        #[cfg(unix)]
+        {
+            use nix::sys::signal::{killpg, Signal};
+            use nix::unistd::Pid;
+            let _ = killpg(Pid::from_raw(pid), Signal::SIGTERM);
+        }
     }
 
     /// Restart the daemon

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -322,10 +322,11 @@ pub fn run(cli: Cli) {
                 }
             });
 
-            // Set up signal handlers for graceful shutdown on Ctrl+C
+            // Set up signal handlers for graceful shutdown on Ctrl+C.
+            // The daemon-stop is handled by the RunEvent::ExitRequested
+            // branch in run() below; we just trip the exit here.
             #[cfg(unix)]
             {
-                let signal_state = state.clone();
                 let signal_app = app.handle().clone();
                 async_runtime::spawn(async move {
                     let mut sigint = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt())
@@ -342,12 +343,6 @@ pub fn run(cli: Cli) {
                         }
                     }
 
-                    // Stop the daemon
-                    if let Err(e) = signal_state.daemon.stop().await {
-                        error!("Error stopping daemon on signal: {}", e);
-                    }
-
-                    // Exit the app
                     signal_app.exit(0);
                 });
             }
@@ -378,15 +373,43 @@ pub fn run(cli: Cli) {
         .build(tauri::generate_context!())
         .expect("error while building tauri application")
         .run(|app_handle, event| {
-            if let RunEvent::ExitRequested { .. } = event {
-                // Stop the daemon before exiting
+            // RunEvent::Exit is the only event guaranteed to fire on every
+            // macOS quit path. In particular, Dock right-click → Quit does
+            // NOT go through RunEvent::ExitRequested in this Tauri version
+            // — empirically only RunEvent::Exit fires, after the runtime
+            // is already winding down. Send a synchronous SIGTERM to the
+            // dashboard's process group here so the child can never
+            // outlive us regardless of which path dispatched. SIGTERM
+            // only; the dashboard cleans up its own state.
+            if matches!(event, RunEvent::Exit) {
                 if let Some(state) = app_handle.try_state::<Arc<AppState>>() {
-                    info!("Stopping ESPHome daemon before exit");
-                    async_runtime::block_on(async {
-                        if let Err(e) = state.daemon.stop().await {
-                            warn!("Error stopping daemon: {}", e);
-                        }
-                    });
+                    state.daemon.terminate_blocking();
+                }
+            }
+
+            if let RunEvent::ExitRequested { api, .. } = event {
+                // Running daemon.stop() via async_runtime::block_on from
+                // inside the run() callback orphans the dashboard child:
+                // the future does not actually run to completion before
+                // Tauri tears the process down, so SIGTERM is never sent.
+                // Prevent the immediate exit, drain the daemon on the
+                // tokio runtime via spawn (the same shape the SIGINT/
+                // SIGTERM handler uses), then call app.exit(0) which
+                // re-enters this branch with running=false and falls
+                // through to a clean exit.
+                if let Some(state) = app_handle.try_state::<Arc<AppState>>() {
+                    if state.daemon.is_running() {
+                        api.prevent_exit();
+                        let state_clone: Arc<AppState> = state.inner().clone();
+                        let app = app_handle.clone();
+                        async_runtime::spawn(async move {
+                            info!("Stopping ESPHome daemon before exit");
+                            if let Err(e) = state_clone.daemon.stop().await {
+                                warn!("Error stopping daemon: {}", e);
+                            }
+                            app.exit(0);
+                        });
+                    }
                 }
             }
         });

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -373,15 +373,24 @@ pub fn run(cli: Cli) {
         .build(tauri::generate_context!())
         .expect("error while building tauri application")
         .run(|app_handle, event| {
-            // RunEvent::Exit is the only event guaranteed to fire on every
-            // macOS quit path. In particular, Dock right-click → Quit does
-            // NOT go through RunEvent::ExitRequested in this Tauri version
-            // — empirically only RunEvent::Exit fires, after the runtime
-            // is already winding down. Send a synchronous SIGTERM to the
-            // dashboard's process group here so the child can never
-            // outlive us regardless of which path dispatched. SIGTERM
-            // only; the dashboard cleans up its own state.
-            if matches!(event, RunEvent::Exit) {
+            // Synchronously SIGTERM the dashboard's process group on any
+            // exit-related event so the signal is in the kernel before
+            // we attempt anything else. Covers two scenarios:
+            //
+            // * macOS Dock right-click → Quit, which on this Tauri
+            //   version only fires `RunEvent::Exit` (not ExitRequested)
+            //   after the runtime is already winding down.
+            // * A future Tauri version that DOES fire ExitRequested for
+            //   Dock-Quit but doesn't honor `prevent_exit()` long enough
+            //   for the spawned graceful-stop task below to actually
+            //   run.
+            //
+            // `terminate_blocking` is idempotent (atomic-swap on the
+            // stored PID), doesn't touch the `running` flag, and is
+            // a no-op once `stop()` has already cleared the PID — so
+            // calling it on both events is safe and double-firing the
+            // SIGTERM is harmless (the kernel coalesces).
+            if matches!(event, RunEvent::Exit | RunEvent::ExitRequested { .. }) {
                 if let Some(state) = app_handle.try_state::<Arc<AppState>>() {
                     state.daemon.terminate_blocking();
                 }

--- a/src-tauri/src/tray/mod.rs
+++ b/src-tauri/src/tray/mod.rs
@@ -813,15 +813,9 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>, _a
         }
         ids::QUIT => {
             info!("Quit requested");
-            let state = state.clone();
-            let app = app_handle.clone();
-            // Use block_on to ensure daemon stops before exit
-            async_runtime::block_on(async move {
-                if let Err(e) = state.daemon.stop().await {
-                    error!("Error stopping daemon: {}", e);
-                }
-            });
-            app.exit(0);
+            // Delegate cleanup to the RunEvent::ExitRequested handler in
+            // lib.rs so the shutdown sequence lives in exactly one place.
+            app_handle.exit(0);
         }
         _ => {}
     }


### PR DESCRIPTION
~~Needs testing on Linux. Only tested on MacOS~~ Jesse tested on linux

## Problem

Quitting the ESPHome Builder desktop left the Python dashboard child running, holding port 6052 until killed manually. When cleanup *did* run, it escalated to `SIGKILL` after 5 s — corrupting dashboard state mid-shutdown.

Three desktop-side exit paths existed, each with its own bug profile:

| Path | Trigger | Pre-fix behaviour |
|---|---|---|
| 1 | macOS Dock right-click → Quit | Dashboard fully orphaned — `daemon.stop()` never ran. |
| 2 | `SIGINT` / `SIGTERM` to the desktop | Worked, but 5 s timeout escalated to `SIGKILL`. |
| 3 | Tray menu → Quit ESPHome | Worked, same `SIGKILL` escalation. |

## Investigation

Ran the binary in a terminal with tracing visible and triggered each path. Findings:

1. **Paths 2 and 3 already worked** — `daemon.stop()` ran on `async_runtime::spawn`, `SIGTERM` was delivered, the wait completed (or timed out into SIGKILL). The shape that works: `async_runtime::spawn` (or `block_on` called outside the Tauri run-loop callback) followed by `app.exit(0)`.
2. **Path 1 silently failed** — diagnostic logging confirmed Tauri 2 on this version does **not** fire `RunEvent::ExitRequested` for macOS Dock-Quit on a tray-only app. Only `RunEvent::Exit` fires, and by then the runtime is winding down. The original `block_on(daemon.stop())` inside `ExitRequested` therefore never executed for this path; the dashboard was reparented to launchd.
3. **The 5 s timeout was too aggressive.** Real dashboard shutdown takes up to ~30 s. The escalation to `SIGKILL` after 5 s was the actual source of state corruption — the desktop was force-killing mid-flush.
4. **`kill_on_drop(true)` was a second SIGKILL source** — when the `Child` got dropped (after the wait timed out or when `AppState` was torn down), tokio quietly sent its own `SIGKILL`.

## Fix

### One shutdown sequence, three entry points

- **Tray Quit** (`tray/mod.rs`) — now just `app_handle.exit(0)`.
- **SIGINT / SIGTERM handler** (`lib.rs`) — now just `signal_app.exit(0)`. No daemon work in the handler.
- Both land in **`RunEvent::ExitRequested`** in `lib.rs`, the single place `daemon.stop()` runs. Uses `api.prevent_exit()` + `async_runtime::spawn` so the future actually runs to completion on the tokio runtime (the original `block_on` shape did not on this Tauri version), then calls `app.exit(0)` which re-enters with `is_running == false` and falls through to a clean exit.

### Catching macOS Dock-Quit + future-proofing

Because `ExitRequested` is unreachable on Path 1, the `run()` callback also hooks **`RunEvent::Exit`** — and now also fires the same sync-SIGTERM on `RunEvent::ExitRequested` itself — calling a new synchronous `DaemonManager::terminate_blocking()`. That method reads an atomically-stored dashboard PID, issues one `killpg(SIGTERM)`, and returns; no tokio runtime involvement, safe during runtime teardown.

Why both events: today, Dock-Quit only fires `Exit`. If a future Tauri version starts firing `ExitRequested` for Dock-Quit but doesn't honor `prevent_exit()` long enough for the spawned graceful-stop task to actually run, the in-line sync SIGTERM at `ExitRequested` time guarantees the signal is in the kernel regardless. `terminate_blocking()` is idempotent (atomic-swap on the stored PID), doesn't touch the `running` flag, and is a no-op once `stop()` has already cleared the PID — so calling it on both events is safe and double-firing the SIGTERM is harmless (the kernel coalesces).

### No more SIGKILL

- `daemon.stop()`'s timeout is now **30 s** (was 5 s); on expiry it logs a warning and proceeds, no force kill. If the dashboard is slow to honor SIGTERM, the desktop exits and the dashboard finishes its cleanup in the background, briefly orphaned but with state intact.
- `kill_on_drop(true)` on the spawned `Command` has been removed; `terminate_blocking()` is the replacement safety net.

### Net behaviour

| Path | What happens |
|---|---|
| Tray Quit / SIGINT / SIGTERM | `ExitRequested` → sync SIGTERM via `terminate_blocking()` → spawn `daemon.stop()` (which also sends SIGTERM via `killpg`, kernel coalesces) → wait ≤30 s for clean exit → `app.exit(0)` → `Exit` fires → `terminate_blocking()` no-op → done. |
| Dock right-click Quit (today's Tauri) | `Exit` only → `terminate_blocking()` sends sync SIGTERM → desktop exits → dashboard finishes its own cleanup in background. |
| Dock right-click Quit (hypothetical future Tauri firing `ExitRequested` but tearing down the runtime quickly) | `ExitRequested` → sync SIGTERM via `terminate_blocking()` (guaranteed delivery) → graceful spawn queued (may or may not run) → `Exit` fires → `terminate_blocking()` no-op → done. |
| Anywhere | No `SIGKILL` is ever sent from the desktop side. |

## Test plan

Verified on `/Applications/ESPHome Builder.app` v0.7.0 with the patched binary, macOS 15:

- [x] Path 1 (Dock-Quit): SIGTERM delivered synchronously inside `RunEvent::Exit`; dashboard exits cleanly after its own drain; no orphan once dashboard finishes.
- [x] Path 2 (SIGTERM): `kill -TERM` on desktop PID cleans both processes within the wait window.
- [x] Path 3 (Tray Quit): Logged the 30-s timeout warning on a run with a slow dashboard; exited without force-killing; dashboard released the port shortly after.

## Out of scope / follow-ups

- The dashboard's own SIGTERM handler is slow (20–60 s) and is now the dominant latency in quit. Tracked separately for `esphome/device-builder`.
- Parent watchdog (`esphome/device-builder#599`) is independently useful for the SIGKILL / crash case and doesn't replace this PR.
- Windows exit path uses a different model and wasn't exercised here. File separately if issues are observed.