### PR TITLE
Default backend to ESPHome Builder (beta)

### DIFF
--- a/src-tauri/src/settings/mod.rs
+++ b/src-tauri/src/settings/mod.rs
@@ -56,7 +56,7 @@ pub enum Backend {
 
 impl Default for Backend {
     fn default() -> Self {
-        Self::Classic
+        Self::BuilderBeta
     }
 }
 


### PR DESCRIPTION
# What does this implement/fix?

Switches the default `Backend` to `BuilderBeta` so new installs (and existing configs without a `backend` field set) start on the new ESPHome Device Builder. The previous default (`Classic` dashboard) is still selectable from the tray menu. There are no stable releases of the new builder yet, so the beta channel is the only working "new builder" option.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes <link to issue>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).