### PR TITLE
Preserve tag_name when patching draft release body

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -392,6 +392,7 @@ jobs:
           if [ "$new_body" != "$body" ]; then
             gh api "repos/${{ github.repository }}/releases/${release_id}" \
               --method PATCH \
+              --field "tag_name=${{ steps.find-release.outputs.tag_name }}" \
               --field "body=${new_body}" \
               --field "draft=true" \
               --silent


### PR DESCRIPTION
# What does this implement/fix?

The release job's `Remove assets-pending warning from release body` step PATCHes the draft release without sending `tag_name`. After the v0.8.0 release was published with `tag_name: untagged-8d7a5adba3ad51f08860` (no real git tag created), include `tag_name` explicitly in the PATCH so the field cannot be lost — regardless of whether the API would otherwise have preserved it. Defensive belt-and-braces around the only automated step that touches the release between draft creation and manual publish.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes <link to issue>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).