### PR TITLE
Disable cache-bin in rust-cache to fix macOS CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,6 +82,9 @@ jobs:
         with:
           workspaces: src-tauri
           key: ${{ matrix.target }}
+          # Workaround for Swatinem/rust-cache#341 — caching ~/.cargo/bin
+          # produces broken cargo/rustc symlinks on the new macOS runner image.
+          cache-bin: false
 
       - name: Install Tauri CLI
         run: |


### PR DESCRIPTION
# What does this implement/fix?

Workaround for [Swatinem/rust-cache#341](https://github.com/Swatinem/rust-cache/issues/341). After a recent GitHub macOS-15 runner image refresh, the `~/.cargo/bin` contents that `rust-cache` restores end up as broken symlinks pointing at `rustup-init` instead of the real `cargo`/`rustc`. The `Install Tauri CLI` step then fails with `error: unexpected argument 'install' found` because `cargo install …` runs `rustup-init` instead.

Setting `cache-bin: false` skips that part of the cache. `tauri-cli` will recompile on each macOS run until the upstream fix lands, but the workflow is unblocked. Applied uniformly so Linux and Windows stay consistent with macOS.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes upstream macOS CI breakage (see [Swatinem/rust-cache#341](https://github.com/Swatinem/rust-cache/issues/341))

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).