### PR TITLE
Harden workflow permissions and fix PR artifact comments for forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,8 @@ on:
     types: [completed]
   workflow_dispatch:
 
+permissions: {}
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -23,6 +25,8 @@ jobs:
     if: >-
       github.event_name != 'workflow_run' ||
       github.event.workflow_run.conclusion == 'success'
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -239,81 +243,26 @@ jobs:
           path: src-tauri/target/${{ matrix.rust_target && format('{0}/', matrix.rust_target) || '' }}release/bundle/dmg/*.dmg
           archive: false
 
-  # Comment on PR with artifact links
-  comment:
-    needs: build
+  # Persist PR metadata so the companion "PR Comment" workflow (which runs
+  # in the base-repo context via workflow_run, granting write access to fork
+  # PRs too) knows which PR to comment on. JSON so we can add more fields
+  # later without changing the file format.
+  pr-info:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
-    permissions:
-      pull-requests: write
-
+    permissions: {}
     steps:
-      - name: Find Comment
-        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
-        id: fc
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: '<!-- build-artifacts-comment -->'
-
-      - name: Build artifact comment
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Write PR info
         run: |
-          set -euo pipefail
-
-          run_id="${{ github.run_id }}"
-          repo="${{ github.repository }}"
-
-          artifacts_json=$(gh api "repos/${repo}/actions/runs/${run_id}/artifacts" --paginate)
-          artifacts=$(echo "$artifacts_json" | jq -s '[.[].artifacts[]]')
-
-          write_links() {
-            local ext="$1"
-            echo "$artifacts" | jq -r --arg ext "$ext" \
-              '.[] | select(.name | test("\\." + $ext + "$"; "i")) | "- [\(.name)](https://github.com/'"$repo"'/actions/runs/'"$run_id"'/artifacts/\(.id))"' >> comment.md
+          cat > pr-info.json <<EOF
+          {
+            "pr_number": ${{ github.event.pull_request.number }}
           }
-
-          cat > comment.md <<'EOF'
-          <!-- build-artifacts-comment -->
-          ## 📦 Build Artifacts
-
-          The following artifacts are available from this build:
-
-          ### Windows
           EOF
-
-          write_links "exe"
-
-          cat >> comment.md <<'EOF'
-
-          ### Linux
-          EOF
-
-          write_links "AppImage"
-          write_links "deb"
-          write_links "rpm"
-
-          cat >> comment.md <<'EOF'
-
-          ### macOS
-          EOF
-
-          write_links "dmg"
-
-          cat >> comment.md <<EOF
-
-          ---
-          *Last updated: ${{ github.event.pull_request.head.sha }} - Run #${{ github.run_number }}*
-          EOF
-
-      - name: Create or update comment
-        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          comment-id: ${{ steps.fc.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          edit-mode: replace
-          body-path: comment.md
+          path: pr-info.json
+          archive: false
 
   release:
     needs: build

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -1,0 +1,118 @@
+name: PR Comment
+
+# Runs in the base-repo context after the "Build" workflow completes, which
+# gives us write access to PR comments even for PRs from forks (the Build
+# workflow's pull_request trigger only has read tokens for forks).
+
+on:
+  workflow_run:
+    workflows: ["Build"]
+    types: [completed]
+
+permissions: {}
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    permissions: {}
+
+    steps:
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ vars.ESPHOME_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}
+
+      - name: Download PR info
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: pr-info.json
+          github-token: ${{ steps.generate-token.outputs.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Read PR info
+        id: pr
+        run: |
+          set -euo pipefail
+          number=$(jq -r '.pr_number' pr-info.json)
+          if ! [[ "$number" =~ ^[0-9]+$ ]]; then
+            echo "::error::Invalid PR number: $number"
+            exit 1
+          fi
+          echo "number=${number}" >> "$GITHUB_OUTPUT"
+
+      - name: Build artifact comment
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          set -euo pipefail
+
+          run_id="${{ github.event.workflow_run.id }}"
+          repo="${{ github.repository }}"
+
+          artifacts_json=$(gh api "repos/${repo}/actions/runs/${run_id}/artifacts" --paginate)
+          artifacts=$(echo "$artifacts_json" | jq -s '[.[].artifacts[]]')
+
+          write_links() {
+            local ext="$1"
+            echo "$artifacts" | jq -r --arg ext "$ext" \
+              '.[] | select(.name | test("\\." + $ext + "$"; "i")) | "- [\(.name)](https://github.com/'"$repo"'/actions/runs/'"$run_id"'/artifacts/\(.id))"' >> comment.md
+          }
+
+          cat > comment.md <<'EOF'
+          <!-- build-artifacts-comment -->
+          ## 📦 Build Artifacts
+
+          The following artifacts are available from this build:
+
+          ### Windows
+          EOF
+
+          write_links "exe"
+
+          cat >> comment.md <<'EOF'
+
+          ### Linux
+          EOF
+
+          write_links "AppImage"
+          write_links "deb"
+          write_links "rpm"
+
+          cat >> comment.md <<'EOF'
+
+          ### macOS
+          EOF
+
+          write_links "dmg"
+
+          cat >> comment.md <<EOF
+
+          ---
+          *Last updated: ${{ github.event.workflow_run.head_sha }} - Run #${{ github.event.workflow_run.run_number }} - $(date -u +'%Y-%m-%d %H:%M:%S UTC')*
+          EOF
+
+      - name: Post or update comment
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          set -euo pipefail
+
+          repo="${{ github.repository }}"
+          pr_number="${{ steps.pr.outputs.number }}"
+
+          comment_id=$(gh api "repos/${repo}/issues/${pr_number}/comments" --paginate \
+            --jq '.[] | select(.body | contains("<!-- build-artifacts-comment -->")) | .id' \
+            | head -n1)
+
+          if [ -n "$comment_id" ]; then
+            gh api "repos/${repo}/issues/comments/${comment_id}" \
+              --method PATCH -f body=@comment.md
+          else
+            gh api "repos/${repo}/issues/${pr_number}/comments" \
+              --method POST -f body=@comment.md
+          fi

--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -8,10 +8,14 @@ on:
   release:
     types: [published]
 
+permissions: {}
+
 jobs:
   generate:
     name: Generate PKGBUILD
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,9 +6,7 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: read
+permissions: {}
 
 jobs:
   release-drafter:


### PR DESCRIPTION
# What does this implement/fix?

Two related workflow improvements:

**1. Minimal permissions on every workflow.** Each workflow now sets `permissions: {}` at the top level and grants narrowly-scoped permissions per job. Release Drafter drops to `{}` entirely since all GitHub operations use the app-minted token. The build job moves to `contents: read`; the PR-comment job and AUR generate jobs follow suit.

**2. Split the PR artifact-link comment into a `workflow_run`-triggered companion workflow.** The previous `comment` job inside `build.yml` ran in the `pull_request` context, which only grants read tokens for PRs from forks — the comment writes silently failed for any external contributor. The new `pr-comment.yml` triggers on `workflow_run` after Build completes, runs in the base-repo context, mints a GitHub App token (same bot identity as Release Drafter), and posts the comment with full write access. The build workflow uploads a tiny `pr-info.json` artifact so the companion knows which PR to comment on. The peter-evans actions were also dropped in favour of direct `gh api` calls, removing two third-party dependencies.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes <link to issue>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).