### PR TITLE
Bundle esphome-device-builder alongside esphome

### DIFF
--- a/build-scripts/prepare_bundle.sh
+++ b/build-scripts/prepare_bundle.sh
@@ -3,7 +3,8 @@
 #
 # This script:
 # 1. Downloads python-build-standalone
-# 2. Installs ESPHome directly into the standalone Python (no venv)
+# 2. Installs ESPHome and ESPHome Device Builder directly into the
+#    standalone Python (no venv)
 # 3. Prepares it for bundling with the app
 #
 # Note: No venv is used to avoid absolute path issues in bundled executables
@@ -116,6 +117,18 @@ echo "=== Installing ESPHome ==="
 echo ""
 echo "=== Verifying ESPHome ==="
 "$PYTHON_DIR/$PYTHON_BIN" -m esphome version
+
+# Install ESPHome Device Builder (the default backend). Pre-releases are
+# allowed so the bundle tracks the BuilderBeta channel that's wired up as
+# Backend::default() in src-tauri/src/settings/mod.rs.
+echo ""
+echo "=== Installing ESPHome Device Builder ==="
+"$PYTHON_DIR/$PYTHON_BIN" -m pip install --pre esphome-device-builder
+
+# Verify ESPHome Device Builder
+echo ""
+echo "=== Verifying ESPHome Device Builder ==="
+"$PYTHON_DIR/$PYTHON_BIN" -c "from importlib.metadata import version; print('esphome-device-builder', version('esphome-device-builder'))"
 
 # Copy Python directory to bundle location
 echo ""


### PR DESCRIPTION
# What does this implement/fix?

The default backend is now \`Backend::BuilderBeta\`, but the standalone Python bundle only shipped \`esphome\`. On first run with a fresh settings file the daemon spawned \`python -m esphome_device_builder\` and crashed with \`ModuleNotFoundError\`, because \`install_device_builder\` only runs on a CLI override, a tray-menu backend switch, or the explicit "Update Now" action. This installs \`esphome-device-builder\` (with \`--pre\` to match the beta channel) during \`prepare_bundle.sh\` so it's available from the very first launch, alongside the existing \`esphome\` install.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes <link to issue>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).