### PR TITLE
Fix PR artifact comment body using gh api file syntax

### DIFF
--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -111,8 +111,8 @@ jobs:
 
           if [ -n "$comment_id" ]; then
             gh api "repos/${repo}/issues/comments/${comment_id}" \
-              --method PATCH -f body=@comment.md
+              --method PATCH -F body=@comment.md
           else
             gh api "repos/${repo}/issues/${pr_number}/comments" \
-              --method POST -f body=@comment.md
+              --method POST -F body=@comment.md
           fi


### PR DESCRIPTION
# What does this implement/fix?

The \`pr-comment\` workflow built the artifact-list comment in \`comment.md\` and then tried to post it with \`gh api -f body=@comment.md\`. With lowercase \`-f\` (\`--raw-field\`), \`gh api\` does **not** interpret the \`@\` prefix — it passes the literal string \`@comment.md\` as the body. Only \`-F\` (\`--field\`, typed) treats \`@file\` as "read value from file". As a result the bot posted a comment whose entire body was the four characters \`@comment.md\` (see [#85 (comment)](https://github.com/esphome/esphome-desktop/pull/85#issuecomment-4454289705)). Switching both the PATCH (edit existing) and POST (create new) calls to \`-F body=@comment.md\` makes \`gh\` upload the file contents as the comment body.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes <link to issue>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).