### PR TITLE
Make the bundled Python relocatable

### DIFF
--- a/build-scripts/prepare_bundle.sh
+++ b/build-scripts/prepare_bundle.sh
@@ -130,9 +130,63 @@ echo ""
 echo "=== Verifying ESPHome Device Builder ==="
 "$PYTHON_DIR/$PYTHON_BIN" -c "from importlib.metadata import version; print('esphome-device-builder', version('esphome-device-builder'))"
 
-# Copy Python directory to bundle location
+# Rewrite pip-generated script shebangs so the bundle is relocatable.
+# pip bakes the build-time python path into every console-script shebang
+# (`#!$PYTHON_DIR/bin/python3`), so when the bundle ships to a user's
+# machine the kernel can't find the interpreter and every `esphome`,
+# `platformio`, `pip`, … invocation fails silently (see issue #34).
+# Replace each shebang with the same sh/Python polyglot that
+# python-build-standalone uses for its own scripts (idle3, pydoc3.13, …),
+# so the whole bin/ directory is consistent and relocatable.
+# Windows uses .exe launchers (not text scripts) so it's skipped here.
+if [[ "$PLATFORM" != "windows-x64" ]]; then
+    echo ""
+    echo "=== Making scripts relocatable ==="
+    PY_MAJOR_MINOR="${PYTHON_VERSION%.*}"
+    REWRITTEN=0
+    for script in "$PYTHON_DIR/bin"/*; do
+        [[ -f "$script" ]] || continue
+        # Skip symlinks (their targets are processed as regular files in this
+        # same loop, and the symlinks pick up the rewritten content).
+        [[ -L "$script" ]] && continue
+        # Skip the python3 executable itself and any other Mach-O / ELF binary.
+        if file -b "$script" | grep -qE 'Mach-O|ELF'; then
+            continue
+        fi
+        # Only rewrite scripts whose shebang points into the build python.
+        first_line=$(head -n1 "$script" 2>/dev/null) || continue
+        case "$first_line" in
+            "#!$PYTHON_DIR/"*) ;;
+            *) continue ;;
+        esac
+        {
+            printf '%s\n' '#!/bin/sh'
+            printf '%s\n' "'''exec' \"\$(dirname -- \"\$(realpath -- \"\$0\")\")/python${PY_MAJOR_MINOR}\" \"\$0\" \"\$@\""
+            printf '%s\n' "' '''"
+            tail -n +2 "$script"
+        } > "$script.relocatable"
+        chmod +x "$script.relocatable"
+        mv "$script.relocatable" "$script"
+        REWRITTEN=$((REWRITTEN + 1))
+    done
+    echo "Rewrote shebangs in $REWRITTEN scripts"
+fi
+
+# Strip __pycache__ directories. Python regenerates .pyc files at runtime
+# from the .py source, and the build-time .pyc files bake in absolute paths
+# to the build directory (visible in tracebacks), so shipping them just
+# bloats the bundle and leaks build paths to users.
+echo ""
+echo "=== Stripping __pycache__ ==="
+PYCACHE_COUNT=$(find "$PYTHON_DIR" -type d -name __pycache__ | wc -l)
+find "$PYTHON_DIR" -type d -name __pycache__ -exec rm -rf {} +
+echo "Removed $PYCACHE_COUNT __pycache__ directories"
+
+# Copy Python directory to bundle location. Wipe any prior bundle first so
+# `cp -R` can't fall back to merge behavior on top of a partial previous run.
 echo ""
 echo "=== Preparing bundle ==="
+rm -rf "$BUNDLE_DIR"
 cp -R "$PYTHON_DIR" "$BUNDLE_DIR"
 
 # Get size


### PR DESCRIPTION
# What does this implement/fix?

pip writes the build-time interpreter path (`#!$BUILD_DIR/.../python3`) into the shebang of every console-script it installs, so after the .dmg / .deb / AppImage ships to a user's machine the kernel can't find `python3` and any invocation of `esphome`, `platformio`, `pip`, etc. fails. The desktop daemon itself works because it calls `python3 -m esphome_device_builder` directly, but as soon as ESPHome shells out to `platformio` (or anything else in `bin/`) the build dies silently — which is what users see as "the progress screen is blank and stays blank" on releases shipped from CI.

`build-scripts/prepare_bundle.sh` now post-processes pip's scripts to use the same `sh`/Python polyglot shebang that python-build-standalone uses for its own bundled scripts (`idle3`, `pydoc3.13`, etc.), so the polyglot pattern is consistent across the whole `bin/` directory and python3 is resolved relative to the script at runtime. Symlinks and the python3 binary itself are skipped. The byte sequence is verified identical to `head -3 bin/idle3` from the standalone bundle.

While there, `__pycache__` directories are stripped before bundling (~48 MB saved per platform; the `.pyc` files bake in build-time absolute paths that show up in user tracebacks otherwise), and `$BUNDLE_DIR` is wiped right before `cp -R` so a partial prior run can't merge stale content into the next bundle.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes #34

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).