### PR TITLE
Shrink release artifacts by using stripped python-build-standalone tarballs

### DIFF
--- a/build-scripts/prepare_bundle.sh
+++ b/build-scripts/prepare_bundle.sh
@@ -56,19 +56,19 @@ fi
 # Set platform-specific variables
 case $PLATFORM in
     macos-x64)
-        FILENAME="cpython-${PYTHON_VERSION}+${PBS_VERSION}-x86_64-apple-darwin-install_only.tar.gz"
+        FILENAME="cpython-${PYTHON_VERSION}+${PBS_VERSION}-x86_64-apple-darwin-install_only_stripped.tar.gz"
         PYTHON_BIN="bin/python3"
         ;;
     macos-arm64)
-        FILENAME="cpython-${PYTHON_VERSION}+${PBS_VERSION}-aarch64-apple-darwin-install_only.tar.gz"
+        FILENAME="cpython-${PYTHON_VERSION}+${PBS_VERSION}-aarch64-apple-darwin-install_only_stripped.tar.gz"
         PYTHON_BIN="bin/python3"
         ;;
     windows-x64)
-        FILENAME="cpython-${PYTHON_VERSION}+${PBS_VERSION}-x86_64-pc-windows-msvc-install_only.tar.gz"
+        FILENAME="cpython-${PYTHON_VERSION}+${PBS_VERSION}-x86_64-pc-windows-msvc-install_only_stripped.tar.gz"
         PYTHON_BIN="python.exe"
         ;;
     linux-x64)
-        FILENAME="cpython-${PYTHON_VERSION}+${PBS_VERSION}-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        FILENAME="cpython-${PYTHON_VERSION}+${PBS_VERSION}-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
         PYTHON_BIN="bin/python3"
         ;;
 esac


### PR DESCRIPTION
# What does this implement/fix?

The python-build-standalone Linux `install_only` tarball ships **unstripped** binaries, which is the entire reason the Linux release artifacts are several times larger than macOS/Windows:

- `lib/libpython3.13.so.1.0` — 239 MB on disk, 29 MB after `strip --strip-unneeded` (210 MB of DWARF debug info)
- `bin/python3.13` — 109 MB unstripped

The `install_only_stripped` variant is a first-class build target maintained by Astral that just drops the debug symbols. Switching to it gives meaningful savings on Linux and Windows; macOS is already effectively stripped (~80 KB diff) but the line change is made anyway so the four arms of the case block are consistent.

| Platform | `install_only` | `install_only_stripped` |
|---|---|---|
| Linux x64 | 124 MB | 35 MB |
| Windows x64 | 47 MB | 22 MB |
| macOS x64 | 17.7 MB | 17.6 MB |
| macOS arm64 | 17.8 MB | 17.7 MB |

Predicted release artifact impact (very rough, since these are already compressed):

- Linux .deb/.rpm: 339 MB → ~250 MB
- Linux AppImage: 230 MB → ~150 MB
- Windows .exe: 64 MB → ~40 MB
- macOS .dmg: unchanged

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).