### PR TITLE
Add download landing page deployed at desktop.esphome.io

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,71 @@
+name: Deploy Pages
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Determine latest release
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          if [ -n "${EVENT_TAG}" ]; then
+            tag="${EVENT_TAG}"
+          else
+            if ! tag=$(gh release view --repo "${{ github.repository }}" --json tagName --jq .tagName); then
+              echo "::error::Could not determine latest release tag."
+              exit 1
+            fi
+          fi
+          version="${tag#v}"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Building page for $tag (version $version)"
+
+      - name: Build site
+        env:
+          TAG: ${{ steps.release.outputs.tag }}
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          mkdir -p _site
+          # envsubst only substitutes the listed variables; any other $VAR
+          # references in the template (e.g. $USER in shell snippets) are
+          # left alone.
+          envsubst '$VERSION $TAG' < web/index.html > _site/index.html
+          cp src-tauri/icons/128x128.png _site/icon.png
+
+      - name: Configure Pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: _site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A cross-platform desktop application that bundles ESPHome with Python and runs t
 
 ### Pre-built Installers
 
-Download the latest release for your platform from the [Releases](https://github.com/esphome/esphome-desktop/releases/latest) page.
+Download the latest release for your platform from [desktop.esphome.io](https://desktop.esphome.io), or grab the files directly from the [GitHub releases](https://github.com/esphome/esphome-desktop/releases/latest) page.
 
 | Platform | Installer |
 |----------|-----------|

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,591 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Download ESPHome Builder</title>
+  <link rel="icon" type="image/png" href="icon.png">
+  <meta name="description" content="Download ESPHome Builder, the ESPHome Device Builder as a desktop app for macOS, Windows, and Linux.">
+  <meta name="esphome-version" content="$VERSION">
+  <meta name="esphome-tag" content="$TAG">
+  <meta name="theme-color" content="#038fc7">
+  <style>
+    :root {
+      /* Brand tokens from esphome/device-builder-frontend */
+      --brand: #009fee;
+      --brand-button: #009ac7;
+      --brand-button-hover: color-mix(in srgb, #009ac7, black 10%);
+      --brand-soft: #dff3fc;
+      --brand-fg: #ffffff;
+
+      /* Web Awesome default palette neutrals (the device-builder defaults) */
+      --bg: #f8f9fa;
+      --surface: #ffffff;
+      --surface-soft: #f1f2f3;
+      --fg: #1b1d26;
+      --fg-muted: #9194a2;
+      --fg-strong: #424554;
+      --border: #e4e5e9;
+      --border-strong: #c7c9d0;
+      --code-bg: #f1f2f3;
+      --shadow-sm: 0 1px 2px rgba(16, 18, 25, 0.06);
+      --shadow-md: 0 4px 16px rgba(16, 18, 25, 0.08);
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --brand-soft: rgba(0, 159, 238, 0.16);
+        --bg: #101219;
+        --surface: #1b1d26;
+        --surface-soft: #2f323f;
+        --fg: #f1f2f3;
+        --fg-muted: #9194a2;
+        --fg-strong: #e4e5e9;
+        --border: #2f323f;
+        --border-strong: #424554;
+        --code-bg: #2f323f;
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+        --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.5);
+      }
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+      background: var(--bg);
+      color: var(--fg);
+      font-size: 16.5px;
+      line-height: 1.65;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+    }
+    .container { max-width: 720px; margin: 0 auto; padding: 0 24px; }
+
+    .hero {
+      padding: 72px 0 24px;
+      text-align: center;
+    }
+    h1 {
+      margin: 0 0 12px;
+      display: flex;
+      justify-content: center;
+      font-weight: 400;
+      line-height: 1;
+    }
+    .esphome-wordmark {
+      width: auto;
+      height: 42px;
+      display: block;
+    }
+    .tagline {
+      font-size: 1.0625rem;
+      color: var(--fg-muted);
+      margin: 16px auto 0;
+      max-width: 480px;
+    }
+    .version-pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      margin-top: 20px;
+      padding: 5px 14px;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      font-size: 0.8125rem;
+      color: var(--fg-muted);
+      font-variant-numeric: tabular-nums;
+      text-decoration: none;
+      transition: border-color 0.15s ease, color 0.15s ease;
+    }
+    .version-pill:hover {
+      border-color: var(--brand);
+      color: var(--brand);
+    }
+    .version-pill strong {
+      color: var(--fg);
+      font-weight: 600;
+    }
+    .version-pill:hover strong { color: var(--brand); }
+    .version-pill .dot {
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: var(--brand);
+    }
+
+    main { padding-bottom: 96px; }
+
+    .tabs {
+      margin-top: 40px;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 20px;
+      box-shadow: var(--shadow-md);
+      overflow: hidden;
+    }
+    .tablist {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      background: var(--surface-soft);
+      padding: 6px;
+      gap: 4px;
+    }
+    .tab {
+      appearance: none;
+      background: none;
+      border: none;
+      padding: 12px 8px;
+      font: inherit;
+      color: var(--fg-muted);
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+      font-weight: 500;
+      font-size: 0.9375rem;
+      border-radius: 12px;
+      transition: color 0.15s ease, background-color 0.15s ease, box-shadow 0.15s ease;
+    }
+    .tab svg { width: 18px; height: 18px; }
+    .tab:hover { color: var(--fg); }
+    .tab[aria-selected="true"] {
+      background: var(--brand-button);
+      color: var(--brand-fg);
+      box-shadow: var(--shadow-sm);
+    }
+    .tab:focus-visible {
+      outline: 2px solid var(--brand);
+      outline-offset: 2px;
+    }
+
+    .tabpanel { padding: 36px 32px 32px; }
+    .tabpanel[hidden] { display: none; }
+    .panel-title {
+      margin: 0 0 4px;
+      font-size: 1.25rem;
+      font-weight: 600;
+      letter-spacing: -0.01em;
+    }
+    .panel-sub {
+      margin: 0 0 24px;
+      color: var(--fg-muted);
+      font-size: 0.9375rem;
+    }
+
+    .download-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      align-items: center;
+    }
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 10px;
+      padding: 14px 26px;
+      background: var(--brand-button);
+      color: var(--brand-fg);
+      text-decoration: none;
+      border-radius: 12px;
+      font-weight: 600;
+      font-size: 1rem;
+      border: none;
+      cursor: pointer;
+      box-shadow: var(--shadow-sm);
+      transition: background-color 0.15s ease, transform 0.05s ease;
+      font-family: inherit;
+    }
+    .btn:hover {
+      background: var(--brand-button-hover);
+    }
+    .btn:active { transform: translateY(1px); }
+    .btn svg { width: 18px; height: 18px; }
+
+    .segmented {
+      display: inline-flex;
+      padding: 4px;
+      background: var(--surface-soft);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      gap: 2px;
+    }
+    .segmented button {
+      appearance: none;
+      background: none;
+      border: none;
+      padding: 8px 14px;
+      font: inherit;
+      font-size: 0.875rem;
+      color: var(--fg-muted);
+      cursor: pointer;
+      border-radius: 8px;
+      transition: color 0.15s ease, background-color 0.15s ease;
+    }
+    .segmented button:hover { color: var(--fg); }
+    .segmented button[aria-pressed="true"] {
+      background: var(--surface);
+      color: var(--fg);
+      box-shadow: var(--shadow-sm);
+    }
+
+    .steps {
+      margin: 32px 0 0;
+      padding-top: 28px;
+      border-top: 1px solid var(--border);
+    }
+    .steps h3 {
+      margin: 0 0 12px;
+      font-size: 0.8125rem;
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      color: var(--brand);
+    }
+    .steps ol { margin: 0; padding-left: 1.4em; }
+    .steps li { margin-bottom: 6px; }
+    .steps p, .steps li { color: var(--fg); }
+    .note {
+      margin-top: 16px;
+      padding: 12px 16px;
+      background: var(--brand-soft);
+      border-radius: 8px;
+      font-size: 0.875rem;
+      color: var(--fg);
+      border-left: 3px solid var(--brand);
+    }
+
+    code, pre {
+      font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+      font-size: 0.875em;
+    }
+    code {
+      background: var(--code-bg);
+      padding: 2px 6px;
+      border-radius: 4px;
+      color: var(--fg);
+    }
+    pre {
+      background: var(--code-bg);
+      padding: 12px 14px;
+      border-radius: 8px;
+      overflow-x: auto;
+      margin: 8px 0 0;
+    }
+    pre code { background: none; padding: 0; }
+
+    .below {
+      margin-top: 56px;
+      text-align: center;
+      color: var(--fg-muted);
+      font-size: 0.9375rem;
+      max-width: 540px;
+      margin-left: auto;
+      margin-right: auto;
+    }
+    .below h2 {
+      font-size: 1.125rem;
+      font-weight: 600;
+      color: var(--fg);
+      margin: 0 0 8px;
+    }
+
+    footer {
+      padding: 40px 0 0;
+      text-align: center;
+      color: var(--fg-muted);
+      font-size: 0.875rem;
+      border-top: 1px solid var(--border);
+      margin-top: 64px;
+    }
+    footer a {
+      color: var(--fg-muted);
+      text-decoration: none;
+      margin: 0 12px;
+      transition: color 0.15s ease;
+    }
+    footer a:hover { color: var(--brand); }
+    .ohf {
+      margin-top: 32px;
+      padding: 24px 0;
+      border-top: 1px solid var(--border);
+    }
+    .ohf-link {
+      display: inline-flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 8px;
+      text-decoration: none;
+      color: var(--fg-muted);
+      font-size: 0.8125rem;
+      transition: color 0.15s ease;
+    }
+    .ohf-link:hover { color: var(--fg); }
+    .ohf-logo { height: 40px; width: auto; display: block; }
+
+    @media (max-width: 520px) {
+      .hero { padding: 48px 0 16px; }
+      .esphome-wordmark { height: 34px; }
+      .tabpanel { padding: 28px 20px 24px; }
+      .tab span { display: none; }
+      .tab svg { width: 22px; height: 22px; }
+      .download-row { flex-direction: column; align-items: stretch; }
+      .btn { width: 100%; }
+      .segmented { width: 100%; }
+      .segmented button { flex: 1; }
+    }
+  </style>
+</head>
+<body>
+  <header class="hero">
+    <div class="container">
+      <h1>
+        <picture>
+          <source srcset="https://media.esphome.io/logo/logo-text-on-dark.svg" media="(prefers-color-scheme: dark)">
+          <img src="https://media.esphome.io/logo/logo-text-on-light.svg" alt="ESPHome" class="esphome-wordmark">
+        </picture>
+      </h1>
+      <p class="tagline">The ESPHome Device Builder, as a desktop app for macOS, Windows, and Linux.</p>
+      <a class="version-pill" href="https://github.com/esphome/esphome-desktop/releases/tag/$TAG" target="_blank" rel="noopener">
+        <span class="dot" aria-hidden="true"></span>
+        Latest release <strong>$VERSION</strong>
+      </a>
+    </div>
+  </header>
+
+  <main class="container">
+    <div class="tabs">
+      <div class="tablist" role="tablist" aria-label="Operating system">
+        <button type="button" role="tab" id="tab-windows" class="tab"
+                aria-controls="panel-windows" aria-selected="false" data-os="windows">
+          <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M3 12V6.75l6-1.32v6.48zm17-9v8.75l-10 .15V5.21zM3 13l6 .09v6.81l-6-1.15zm17 .25V22l-10-1.91V13.1z"/></svg>
+          <span>Windows</span>
+        </button>
+        <button type="button" role="tab" id="tab-macos" class="tab"
+                aria-controls="panel-macos" aria-selected="false" data-os="macos">
+          <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12.152 6.896c-.948 0-2.415-1.078-3.96-1.04-2.04.027-3.91 1.183-4.961 3.014-2.117 3.675-.546 9.103 1.519 12.09 1.013 1.454 2.208 3.09 3.792 3.039 1.52-.065 2.09-.987 3.935-.987 1.831 0 2.35.987 3.96.948 1.637-.026 2.676-1.48 3.676-2.948 1.156-1.688 1.636-3.325 1.662-3.415-.039-.013-3.182-1.221-3.22-4.857-.026-3.04 2.48-4.494 2.597-4.559-1.429-2.09-3.623-2.324-4.39-2.376-2-.156-3.675 1.09-4.61 1.09zM15.53 3.83c.843-1.012 1.4-2.427 1.245-3.83-1.207.052-2.662.805-3.532 1.818-.78.896-1.454 2.338-1.273 3.714 1.338.104 2.715-.688 3.559-1.701"/></svg>
+          <span>macOS</span>
+        </button>
+        <button type="button" role="tab" id="tab-linux" class="tab"
+                aria-controls="panel-linux" aria-selected="false" data-os="linux">
+          <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12.504 0q-.232 0-.48.021c-4.226.333-3.105 4.807-3.17 6.298-.076 1.092-.3 1.953-1.05 3.02-.885 1.051-2.127 2.75-2.716 4.521-.278.832-.41 1.684-.287 2.489a.4.4 0 0 0-.11.135c-.26.268-.45.6-.663.839-.199.199-.485.267-.797.4-.313.136-.658.269-.864.68-.09.189-.136.394-.132.602 0 .199.027.4.055.536.058.399.116.728.04.97-.249.68-.28 1.145-.106 1.484.174.334.535.47.94.601.81.2 1.91.135 2.774.6.926.466 1.866.67 2.616.47.526-.116.97-.464 1.208-.946.587-.003 1.23-.269 2.26-.334.699-.058 1.574.267 2.577.2.025.134.063.198.114.333l.003.003c.391.778 1.113 1.132 1.884 1.071s1.592-.536 2.257-1.306c.631-.765 1.683-1.084 2.378-1.503.348-.199.629-.469.649-.853.023-.4-.2-.811-.714-1.376v-.097l-.003-.003c-.17-.2-.25-.535-.338-.926-.085-.401-.182-.786-.492-1.046h-.003c-.059-.054-.123-.067-.188-.135a.36.36 0 0 0-.19-.064c.431-1.278.264-2.55-.173-3.694-.533-1.41-1.465-2.638-2.175-3.483-.796-1.005-1.576-1.957-1.56-3.368.026-2.152.236-6.133-3.544-6.139m.529 3.405h.013c.213 0 .396.062.584.198.19.135.33.332.438.533.105.259.158.459.166.724 0-.02.006-.04.006-.06v.105l-.004-.021-.004-.024a1.8 1.8 0 0 1-.15.706.95.95 0 0 1-.213.335 1 1 0 0 0-.088-.042c-.104-.045-.198-.064-.284-.133a1.3 1.3 0 0 0-.22-.066c.05-.06.146-.133.183-.198q.08-.193.088-.402v-.02a1.2 1.2 0 0 0-.061-.4c-.045-.134-.101-.2-.183-.333-.084-.066-.167-.132-.267-.132h-.016c-.093 0-.176.03-.262.132a.8.8 0 0 0-.205.334 1.2 1.2 0 0 0-.09.4v.019q.002.134.02.267c-.193-.067-.438-.135-.607-.202a2 2 0 0 1-.018-.2v-.02a1.8 1.8 0 0 1 .15-.768 1.08 1.08 0 0 1 .43-.533 1 1 0 0 1 .594-.2zm-2.962.059h.036c.142 0 .27.048.399.135.146.129.264.288.344.465.09.199.14.4.153.667v.004c.007.134.006.2-.002.266v.08c-.03.007-.056.018-.083.024-.152.055-.274.135-.393.2q.018-.136.003-.267v-.015c-.012-.133-.04-.2-.082-.333a.6.6 0 0 0-.166-.267.25.25 0 0 0-.183-.064h-.021c-.071.006-.13.04-.186.132a.55.55 0 0 0-.12.27 1 1 0 0 0-.023.33v.015c.012.135.037.2.08.334.046.134.098.2.166.268q.014.014.034.024c-.07.057-.117.07-.176.136a.3.3 0 0 1-.131.068 2.6 2.6 0 0 1-.275-.402 1.8 1.8 0 0 1-.155-.667 1.8 1.8 0 0 1 .08-.668 1.4 1.4 0 0 1 .283-.535c.128-.133.26-.2.418-.2m1.37 1.706c.332 0 .733.065 1.216.399.293.2.523.269 1.052.468h.003c.255.136.405.266.478.399v-.131a.57.57 0 0 1 .016.47c-.123.31-.516.643-1.063.842v.002c-.268.135-.501.333-.775.465-.276.135-.588.292-1.012.267a1.1 1.1 0 0 1-.448-.067 4 4 0 0 1-.322-.198c-.195-.135-.363-.332-.612-.465v-.005h-.005c-.4-.246-.616-.512-.686-.71q-.104-.403.193-.6c.224-.135.38-.271.483-.336.104-.074.143-.102.176-.131h.002v-.003c.169-.202.436-.47.839-.601.139-.036.294-.065.466-.065zm2.8 2.142c.358 1.417 1.196 3.475 1.735 4.473.286.534.855 1.659 1.102 3.024.156-.005.33.018.513.064.646-1.671-.546-3.467-1.089-3.966-.22-.2-.232-.335-.123-.335.59.534 1.365 1.572 1.646 2.757.13.535.16 1.104.021 1.67.067.028.135.06.205.067 1.032.534 1.413.938 1.23 1.537v-.043c-.06-.003-.12 0-.18 0h-.016c.151-.467-.182-.825-1.065-1.224-.915-.4-1.646-.336-1.77.465-.008.043-.013.066-.018.135-.068.023-.139.053-.209.064-.43.268-.662.669-.793 1.187-.13.533-.17 1.156-.205 1.869v.003c-.02.334-.17.838-.319 1.35-1.5 1.072-3.58 1.538-5.348.334a2.7 2.7 0 0 0-.402-.533 1.5 1.5 0 0 0-.275-.333c.182 0 .338-.03.465-.067a.62.62 0 0 0 .314-.334c.108-.267 0-.697-.345-1.163s-.931-.995-1.788-1.521c-.63-.4-.986-.87-1.15-1.396-.165-.534-.143-1.085-.015-1.645.245-1.07.873-2.11 1.274-2.763.107-.065.037.135-.408.974-.396.751-1.14 2.497-.122 3.854a8.1 8.1 0 0 1 .647-2.876c.564-1.278 1.743-3.504 1.836-5.268.048.036.217.135.289.202.218.133.38.333.59.465.21.201.477.335.876.335q.058.005.11.006c.412 0 .73-.134.997-.268.29-.134.52-.334.74-.4h.005c.467-.135.835-.402 1.044-.7zm2.185 8.958c.037.6.343 1.245.882 1.377.588.134 1.434-.333 1.791-.765l.211-.01c.315-.007.577.01.847.268l.003.003c.208.199.305.53.391.876.085.4.154.78.409 1.066.486.527.645.906.636 1.14l.003-.007v.018l-.003-.012c-.015.262-.185.396-.498.595-.63.401-1.746.712-2.457 1.57-.618.737-1.37 1.14-2.036 1.191-.664.053-1.237-.2-1.574-.898l-.005-.003c-.21-.4-.12-1.025.056-1.69.176-.668.428-1.344.463-1.897.037-.714.076-1.335.195-1.814.12-.465.308-.797.641-.984l.045-.022zm-10.814.049h.01q.08 0 .157.014c.376.055.706.333 1.023.752l.91 1.664.003.003c.243.533.754 1.064 1.189 1.637.434.598.77 1.131.729 1.57v.006c-.057.744-.48 1.148-1.125 1.294-.645.135-1.52.002-2.395-.464-.968-.536-2.118-.469-2.857-.602q-.553-.1-.723-.4c-.11-.2-.113-.602.123-1.23v-.004l.002-.003c.117-.334.03-.752-.027-1.118-.055-.401-.083-.71.043-.94.16-.334.396-.4.69-.533.294-.135.64-.202.915-.47h.002v-.002c.256-.268.445-.601.668-.838.19-.201.38-.336.663-.336m7.159-9.074c-.435.201-.945.535-1.488.535-.542 0-.97-.267-1.28-.466-.154-.134-.28-.268-.373-.335-.164-.134-.144-.333-.074-.333.109.016.129.134.199.2.096.066.215.2.36.333.292.2.68.467 1.167.467.485 0 1.053-.267 1.398-.466.195-.135.445-.334.648-.467.156-.136.149-.267.279-.267.128.016.034.134-.147.332a8 8 0 0 1-.69.468zm-1.082-1.583V5.64c-.006-.02.013-.042.029-.05.074-.043.18-.027.26.004.063 0 .16.067.15.135-.006.049-.085.066-.135.066-.055 0-.092-.043-.141-.068-.052-.018-.146-.008-.163-.065m-.551 0c-.02.058-.113.049-.166.066-.047.025-.086.068-.14.068-.05 0-.13-.02-.136-.068-.01-.066.088-.133.15-.133.08-.031.184-.047.259-.005.019.009.036.03.03.05v.02h.003z"/></svg>
+          <span>Linux</span>
+        </button>
+      </div>
+
+      <section role="tabpanel" id="panel-windows" aria-labelledby="tab-windows" class="tabpanel" hidden>
+        <h2 class="panel-title">For Windows</h2>
+        <p class="panel-sub">Works on Windows 10 and Windows 11.</p>
+        <div class="download-row">
+          <a class="btn" id="windows-download" href="#">
+            <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M5 20h14v-2H5v2zM19 9h-4V3H9v6H5l7 7 7-7z"/></svg>
+            Download installer
+          </a>
+        </div>
+        <div class="steps">
+          <h3>Install</h3>
+          <ol>
+            <li>Open the downloaded <code>.exe</code> file.</li>
+            <li>If Windows asks <em>"Do you want to allow this app to make changes?"</em>, choose <strong>Yes</strong>.</li>
+            <li>Follow the installer prompts.</li>
+            <li>Launch <strong>ESPHome Builder</strong> from the Start menu.</li>
+          </ol>
+          <div class="note">If you see <em>"Windows protected your PC"</em>, click <strong>More info</strong> → <strong>Run anyway</strong>.</div>
+        </div>
+      </section>
+
+      <section role="tabpanel" id="panel-macos" aria-labelledby="tab-macos" class="tabpanel" hidden>
+        <h2 class="panel-title">For macOS</h2>
+        <p class="panel-sub">macOS 10.15 Catalina or newer.</p>
+        <div class="download-row">
+          <a class="btn" id="mac-download" href="#">
+            <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M5 20h14v-2H5v2zM19 9h-4V3H9v6H5l7 7 7-7z"/></svg>
+            Download disk image
+          </a>
+          <div class="segmented" role="group" aria-label="Mac architecture">
+            <button type="button" data-arch="arm64" aria-pressed="true">Apple Silicon</button>
+            <button type="button" data-arch="x64" aria-pressed="false">Intel</button>
+          </div>
+        </div>
+        <div class="steps">
+          <h3>Install</h3>
+          <ol>
+            <li>Open the downloaded <code>.dmg</code> file.</li>
+            <li>Drag <strong>ESPHome Builder</strong> into the <strong>Applications</strong> folder.</li>
+            <li>Open the Applications folder and double-click <strong>ESPHome Builder</strong>.</li>
+            <li>The first time you run it, macOS may ask you to confirm — click <strong>Open</strong>.</li>
+          </ol>
+          <div class="note">Not sure which Mac you have? Click the Apple menu → <strong>About This Mac</strong>. If you see <em>Apple M1/M2/M3/M4</em>, pick Apple Silicon. If you see <em>Intel</em>, pick Intel.</div>
+        </div>
+      </section>
+
+      <section role="tabpanel" id="panel-linux" aria-labelledby="tab-linux" class="tabpanel" hidden>
+        <h2 class="panel-title">For Linux</h2>
+        <p class="panel-sub">Choose the format that matches your distribution.</p>
+        <div class="download-row">
+          <a class="btn" id="linux-download" href="#">
+            <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M5 20h14v-2H5v2zM19 9h-4V3H9v6H5l7 7 7-7z"/></svg>
+            <span id="linux-download-label">Download .deb</span>
+          </a>
+          <div class="segmented" role="group" aria-label="Linux package format">
+            <button type="button" data-format="deb" aria-pressed="true">Debian / Ubuntu</button>
+            <button type="button" data-format="rpm" aria-pressed="false">Fedora / RHEL</button>
+            <button type="button" data-format="aur" aria-pressed="false">Arch (AUR)</button>
+            <button type="button" data-format="appimage" aria-pressed="false">AppImage</button>
+          </div>
+        </div>
+        <div class="steps">
+          <h3>Install</h3>
+          <div id="linux-install-deb">
+            <p>Double-click the file in your file manager, or run:</p>
+            <pre><code>sudo apt install ./ESPHome.Builder_*.deb</code></pre>
+          </div>
+          <div id="linux-install-rpm" hidden>
+            <p>Double-click the file in your file manager, or run:</p>
+            <pre><code>sudo dnf install ./ESPHome.Builder-*.rpm</code></pre>
+          </div>
+          <div id="linux-install-aur" hidden>
+            <p>Install the <code>esphome-desktop-bin</code> package with your favourite AUR helper:</p>
+            <pre><code>yay -S esphome-desktop-bin</code></pre>
+            <p>or:</p>
+            <pre><code>paru -S esphome-desktop-bin</code></pre>
+          </div>
+          <div id="linux-install-appimage" hidden>
+            <p>Make it executable and run it:</p>
+            <pre><code>chmod +x ESPHome.Builder_*.AppImage
+./ESPHome.Builder_*.AppImage</code></pre>
+          </div>
+          <div class="note">If serial devices don't show up, add your user to the <code>dialout</code> group and log out and back in: <code>sudo usermod -a -G dialout $USER</code>.</div>
+        </div>
+      </section>
+    </div>
+
+    <div class="below">
+      <h2>What happens on first launch?</h2>
+      <p>The app sets up ESPHome in the background and opens the Device Builder in your browser. A small icon appears in your system tray for quick access — open the Device Builder, check for updates, or quit from there.</p>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">
+      <div>
+        <a href="https://esphome.io">esphome.io</a>
+        <a href="https://github.com/esphome/esphome-desktop">Source</a>
+        <a href="https://github.com/esphome/esphome-desktop/releases">All releases</a>
+      </div>
+      <div class="ohf">
+        <a class="ohf-link" href="https://www.openhomefoundation.org/" target="_blank" rel="noopener noreferrer">
+          <span>ESPHome is a project from the</span>
+          <picture>
+            <source srcset="https://esphome.io/images/icons/ohf-logo-on-dark.svg" media="(prefers-color-scheme: dark)">
+            <img class="ohf-logo" src="https://esphome.io/images/icons/ohf-logo-on-light.svg" alt="Open Home Foundation" width="200" height="44">
+          </picture>
+        </a>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    (function () {
+      const TAG = document.querySelector('meta[name="esphome-tag"]').content;
+      const VERSION = document.querySelector('meta[name="esphome-version"]').content;
+      const BASE = 'https://github.com/esphome/esphome-desktop/releases/download/' + TAG + '/';
+
+      const ua = navigator.userAgent;
+      const platform = (navigator.userAgentData && navigator.userAgentData.platform) || navigator.platform || '';
+      let detected = 'windows';
+      if (/Mac/i.test(platform) || /Mac OS X/i.test(ua)) detected = 'macos';
+      else if (/Linux|X11|CrOS/i.test(platform + ' ' + ua) && !/Android/i.test(ua)) detected = 'linux';
+      else if (/Win/i.test(platform) || /Windows/i.test(ua)) detected = 'windows';
+
+      const tabs = document.querySelectorAll('[role="tab"]');
+      const panels = document.querySelectorAll('[role="tabpanel"]');
+      function selectTab(os) {
+        tabs.forEach(function (t) {
+          const on = t.dataset.os === os;
+          t.setAttribute('aria-selected', on ? 'true' : 'false');
+          t.tabIndex = on ? 0 : -1;
+        });
+        panels.forEach(function (p) {
+          p.hidden = p.id !== 'panel-' + os;
+        });
+      }
+      tabs.forEach(function (t) {
+        t.addEventListener('click', function () { selectTab(t.dataset.os); });
+        t.addEventListener('keydown', function (e) {
+          const order = ['windows', 'macos', 'linux'];
+          const i = order.indexOf(t.dataset.os);
+          if (e.key === 'ArrowRight') {
+            e.preventDefault();
+            const next = order[(i + 1) % order.length];
+            selectTab(next);
+            document.getElementById('tab-' + next).focus();
+          } else if (e.key === 'ArrowLeft') {
+            e.preventDefault();
+            const prev = order[(i - 1 + order.length) % order.length];
+            selectTab(prev);
+            document.getElementById('tab-' + prev).focus();
+          }
+        });
+      });
+      selectTab(detected);
+
+      document.getElementById('windows-download').href = BASE + 'ESPHome.Builder_' + VERSION + '_x64-setup.exe';
+
+      const macFiles = {
+        arm64: BASE + 'ESPHome.Builder_' + VERSION + '_aarch64.dmg',
+        x64: BASE + 'ESPHome.Builder_' + VERSION + '_x64.dmg',
+      };
+      const macBtn = document.getElementById('mac-download');
+      const macArchButtons = document.querySelectorAll('#panel-macos .segmented button');
+      function setMacArch(arch) {
+        macArchButtons.forEach(function (b) {
+          b.setAttribute('aria-pressed', b.dataset.arch === arch ? 'true' : 'false');
+        });
+        macBtn.href = macFiles[arch];
+      }
+      setMacArch('arm64');
+      macArchButtons.forEach(function (b) {
+        b.addEventListener('click', function () { setMacArch(b.dataset.arch); });
+      });
+
+      if (detected === 'macos' && navigator.userAgentData && navigator.userAgentData.getHighEntropyValues) {
+        navigator.userAgentData.getHighEntropyValues(['architecture']).then(function (info) {
+          setMacArch(info.architecture === 'x86' ? 'x64' : 'arm64');
+        }).catch(function () {});
+      }
+
+      const linuxFiles = {
+        deb: { url: BASE + 'ESPHome.Builder_' + VERSION + '_amd64.deb', label: 'Download .deb' },
+        rpm: { url: BASE + 'ESPHome.Builder-' + VERSION + '-1.x86_64.rpm', label: 'Download .rpm' },
+        aur: { url: 'https://aur.archlinux.org/packages/esphome-desktop-bin', label: 'View on AUR' },
+        appimage: { url: BASE + 'ESPHome.Builder_' + VERSION + '_amd64.AppImage', label: 'Download AppImage' },
+      };
+      const linuxBtn = document.getElementById('linux-download');
+      const linuxLabel = document.getElementById('linux-download-label');
+      const linuxFormatButtons = document.querySelectorAll('#panel-linux .segmented button');
+      const linuxInstallBlocks = {
+        deb: document.getElementById('linux-install-deb'),
+        rpm: document.getElementById('linux-install-rpm'),
+        aur: document.getElementById('linux-install-aur'),
+        appimage: document.getElementById('linux-install-appimage'),
+      };
+      function setLinuxFormat(format) {
+        linuxFormatButtons.forEach(function (b) {
+          b.setAttribute('aria-pressed', b.dataset.format === format ? 'true' : 'false');
+        });
+        linuxBtn.href = linuxFiles[format].url;
+        linuxLabel.textContent = linuxFiles[format].label;
+        Object.keys(linuxInstallBlocks).forEach(function (k) {
+          linuxInstallBlocks[k].hidden = k !== format;
+        });
+      }
+      setLinuxFormat('deb');
+      linuxFormatButtons.forEach(function (b) {
+        b.addEventListener('click', function () { setLinuxFormat(b.dataset.format); });
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/web/index.html
+++ b/web/index.html
@@ -378,7 +378,7 @@
         <h2 class="panel-title">For Windows</h2>
         <p class="panel-sub">Works on Windows 10 and Windows 11.</p>
         <div class="download-row">
-          <a class="btn" id="windows-download" href="#">
+          <a class="btn" id="windows-download" href="https://github.com/esphome/esphome-desktop/releases/download/$TAG/ESPHome.Builder_${VERSION}_x64-setup.exe">
             <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M5 20h14v-2H5v2zM19 9h-4V3H9v6H5l7 7 7-7z"/></svg>
             Download installer
           </a>
@@ -399,7 +399,7 @@
         <h2 class="panel-title">For macOS</h2>
         <p class="panel-sub">macOS 10.15 Catalina or newer.</p>
         <div class="download-row">
-          <a class="btn" id="mac-download" href="#">
+          <a class="btn" id="mac-download" href="https://github.com/esphome/esphome-desktop/releases/download/$TAG/ESPHome.Builder_${VERSION}_aarch64.dmg">
             <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M5 20h14v-2H5v2zM19 9h-4V3H9v6H5l7 7 7-7z"/></svg>
             Download disk image
           </a>
@@ -424,7 +424,7 @@
         <h2 class="panel-title">For Linux</h2>
         <p class="panel-sub">Choose the format that matches your distribution.</p>
         <div class="download-row">
-          <a class="btn" id="linux-download" href="#">
+          <a class="btn" id="linux-download" href="https://github.com/esphome/esphome-desktop/releases/download/$TAG/ESPHome.Builder_${VERSION}_amd64.deb">
             <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M5 20h14v-2H5v2zM19 9h-4V3H9v6H5l7 7 7-7z"/></svg>
             <span id="linux-download-label">Download .deb</span>
           </a>


### PR DESCRIPTION
# What does this implement/fix?

Adds a single-file static download landing page that gets deployed to GitHub Pages at `desktop.esphome.io` on every published release.

The page detects the visitor's OS and shows tabbed install instructions for Windows, macOS (Apple Silicon / Intel toggle), and Linux (Debian/Ubuntu, Fedora/RHEL, Arch AUR, AppImage). Download links point at the versioned release artifacts on GitHub releases — the deploy workflow (`.github/workflows/deploy-pages.yml`) re-renders the page on every `release: published` event, substituting `$VERSION` and `$TAG` into the template with `envsubst`, so the links always resolve to the latest release without any duplicated assets in the release itself.

Styling matches the [device-builder-frontend](https://github.com/esphome/device-builder-frontend) palette (primary `#009fee`, button `#009ac7`, Web Awesome neutral grays) with a `<picture>` swap for dark mode. Logos are referenced from `media.esphome.io` and `esphome.io` so the repo doesn't ship copies of them.

<img width="2302" height="2008" alt="2026-05-20_13-58-01" src="https://github.com/user-attachments/assets/9ab08675-ac3a-4ee5-a92c-97ad3a9378a9" />

<img width="1784" height="1878" alt="2026-05-20_14-02-12" src="https://github.com/user-attachments/assets/5d444630-fc69-4326-a6ff-4a476489766d" />


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).