### PR TITLE
Refresh bundled Python on app upgrade via version marker

### DIFF
--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -162,7 +162,17 @@ pub fn get_python_bin(app_handle: &AppHandle) -> Result<PathBuf> {
     Ok(bundled_bin)
 }
 
-/// Ensure the user Python exists by copying from bundled Python if needed
+/// Filename of the marker recording which desktop-app version copied the
+/// user Python tree. Lives at `<user_python>/.esphome-desktop-version`.
+const PYTHON_VERSION_MARKER: &str = ".esphome-desktop-version";
+
+/// Ensure the user Python exists by copying from bundled Python if needed.
+///
+/// A version marker file is written into the user Python directory after the
+/// copy. On subsequent runs, if the marker is missing or doesn't match the
+/// current desktop-app version, the directory is wiped and re-copied so that
+/// updated app releases ship a fresh Python tree (e.g. new ESPHome version,
+/// changed dependencies). Without this, the first-run copy persisted forever.
 pub fn ensure_user_python(app_handle: &AppHandle) -> Result<()> {
     #[cfg(target_os = "windows")]
     {
@@ -183,8 +193,14 @@ pub fn ensure_user_python(app_handle: &AppHandle) -> Result<()> {
         let data_dir = get_data_dir(app_handle)?;
         let user_python = data_dir.join("python");
         let python_check = user_python.join("bin").join("python3");
+        let marker_path = user_python.join(PYTHON_VERSION_MARKER);
+        let current_version = env!("CARGO_PKG_VERSION");
 
-        let needs_copy = !python_check.exists();
+        let marker_matches = std::fs::read_to_string(&marker_path)
+            .map(|s| s.trim() == current_version)
+            .unwrap_or(false);
+
+        let needs_copy = !python_check.exists() || !marker_matches;
 
         if needs_copy {
             let resource_dir = get_bundled_resource_dir(app_handle)?;
@@ -194,14 +210,29 @@ pub fn ensure_user_python(app_handle: &AppHandle) -> Result<()> {
                 anyhow::bail!("Bundled Python not found at {:?}", bundled_python);
             }
 
-            info!("Copying bundled Python to user data directory...");
+            if user_python.exists() {
+                info!(
+                    "Removing stale user Python at {:?} (version marker missing or mismatched)",
+                    user_python
+                );
+                std::fs::remove_dir_all(&user_python)
+                    .context("Failed to remove stale user Python directory")?;
+            }
+
+            info!(
+                "Copying bundled Python to user data directory (version {})...",
+                current_version
+            );
 
             // Copy the bundled Python to user data
             copy_dir_recursive(&bundled_python, &user_python)?;
 
+            std::fs::write(&marker_path, current_version)
+                .context("Failed to write Python version marker")?;
+
             info!("User Python ready at {:?}", user_python);
         } else {
-            debug!("User Python already exists");
+            debug!("User Python already up-to-date (version {})", current_version);
         }
 
         Ok(())


### PR DESCRIPTION
# What does this implement/fix?

Fixes a long-lived bug where the `python` folder copied into the user data directory on first run never gets refreshed when the app is upgraded — so new releases that bundle an updated ESPHome (or changed Python deps) silently keep the original first-run copy forever.

After this change, `ensure_user_python` writes `<user_python>/.esphome-desktop-version` containing `CARGO_PKG_VERSION` after the initial copy. On every startup, if the marker is missing or its contents don't match the current desktop-app version, the user Python directory is wiped with `remove_dir_all` and re-copied from the bundled resource. The marker is written again with the new version.

Only applies on non-Windows. On Windows the bundled Python in `resource_dir` is used directly (no copy step), and the OS installer replaces it on upgrade.

Existing installs without the marker hit the mismatch branch once on first launch of the new app and get a clean copy.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes <link to issue>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).