### PR TITLE
Add Linux aarch64 builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,15 @@ jobs:
             os: ubuntu-22.04
             target: linux-x64
             bundles: deb,rpm
+          - platform: linux
+            os: ubuntu-22.04-arm
+            target: linux-arm64
+            bundles: appimage
+            tauri_branch: feat/truly-portable-appimage
+          - platform: linux
+            os: ubuntu-22.04-arm
+            target: linux-arm64
+            bundles: deb,rpm
           - platform: macos
             os: macos-15
             target: macos-arm64
@@ -193,9 +202,11 @@ jobs:
           OFFSET=$("$APPIMAGE" --appimage-offset)
           dd if="$APPIMAGE" of=runtime.bin bs="$OFFSET" count=1
 
-          # Download mkdwarfs (same version used by quick-sharun.sh)
+          # Download mkdwarfs (same version used by quick-sharun.sh). The
+          # release asset name uses uname -m verbatim (x86_64 / aarch64).
           DWARFS_VERSION="0.14.1"
-          DWARFS_URL="https://github.com/mhx/dwarfs/releases/download/v${DWARFS_VERSION}/dwarfs-universal-${DWARFS_VERSION}-Linux-x86_64"
+          DWARFS_ARCH=$(uname -m)
+          DWARFS_URL="https://github.com/mhx/dwarfs/releases/download/v${DWARFS_VERSION}/dwarfs-universal-${DWARFS_VERSION}-Linux-${DWARFS_ARCH}"
           curl -L -o mkdwarfs "$DWARFS_URL"
           chmod +x mkdwarfs
 

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -59,8 +59,11 @@ jobs:
 
           write_links() {
             local ext="$1"
+            # Sort by name so the ordering is stable across builds — with
+            # multiple architectures in the same category (e.g. amd64 + arm64
+            # .deb files) the API otherwise returns them in completion order.
             echo "$artifacts" | jq -r --arg ext "$ext" \
-              '.[] | select(.name | test("\\." + $ext + "$"; "i")) | "- [\(.name)](https://github.com/'"$repo"'/actions/runs/'"$run_id"'/artifacts/\(.id))"' >> comment.md
+              '[.[] | select(.name | test("\\." + $ext + "$"; "i"))] | sort_by(.name) | .[] | "- [\(.name)](https://github.com/'"$repo"'/actions/runs/'"$run_id"'/artifacts/\(.id))"' >> comment.md
           }
 
           cat > comment.md <<'EOF'

--- a/README.md
+++ b/README.md
@@ -16,12 +16,13 @@ A cross-platform desktop application that bundles ESPHome with Python and runs t
 
 Download the latest release for your platform from the [Releases](https://github.com/esphome/esphome-desktop/releases/latest) page.
 
-| Platform | Installer |
-|----------|-----------|
-| macOS (Apple Silicon) | `ESPHome.Builder_x.x.x_aarch64.dmg` |
-| macOS (Intel) | `ESPHome.Builder_x.x.x_x64.dmg` |
-| Windows | `ESPHome.Builder_x.x.x_x64-setup.exe` |
-| Linux | `ESPHome.Builder_x.x.x_amd64.AppImage` or `.deb` |
+| Platform              | Installer                                                |
+| --------------------- | -------------------------------------------------------- |
+| macOS (Apple Silicon) | `ESPHome.Builder_x.x.x_aarch64.dmg`                      |
+| macOS (Intel)         | `ESPHome.Builder_x.x.x_x64.dmg`                          |
+| Windows               | `ESPHome.Builder_x.x.x_x64-setup.exe`                    |
+| Linux (x86_64)        | `ESPHome.Builder_x.x.x_amd64.AppImage` or `.deb`         |
+| Linux (aarch64)       | `ESPHome.Builder_x.x.x_aarch64.AppImage` or `_arm64.deb` |
 
 ### First Run
 

--- a/build-scripts/prepare_bundle.sh
+++ b/build-scripts/prepare_bundle.sh
@@ -35,7 +35,11 @@ detect_platform() {
             fi
             ;;
         Linux)
-            echo "linux-x64"
+            if [[ "$arch" == "aarch64" || "$arch" == "arm64" ]]; then
+                echo "linux-arm64"
+            else
+                echo "linux-x64"
+            fi
             ;;
         MINGW*|MSYS*|CYGWIN*)
             echo "windows-x64"
@@ -49,7 +53,7 @@ detect_platform() {
 PLATFORM="${1:-$(detect_platform)}"
 
 if [[ "$PLATFORM" == "unknown" ]]; then
-    echo "Could not detect platform. Please specify: macos-x64, macos-arm64, windows-x64, linux-x64"
+    echo "Could not detect platform. Please specify: macos-x64, macos-arm64, windows-x64, linux-x64, linux-arm64"
     exit 1
 fi
 
@@ -69,6 +73,10 @@ case $PLATFORM in
         ;;
     linux-x64)
         FILENAME="cpython-${PYTHON_VERSION}+${PBS_VERSION}-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        PYTHON_BIN="bin/python3"
+        ;;
+    linux-arm64)
+        FILENAME="cpython-${PYTHON_VERSION}+${PBS_VERSION}-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
         PYTHON_BIN="bin/python3"
         ;;
 esac


### PR DESCRIPTION
# What does this implement/fix?

Adds Linux aarch64 build coverage alongside the existing x86_64 matrix. AppImage, deb, and RPM bundles are now produced on the public `ubuntu-22.04-arm` runners and uploaded to release assets and PR comments the same way as the x86_64 artifacts.

Changes:

- `.github/workflows/build.yml` — two new matrix entries (`linux-arm64` × appimage, `linux-arm64` × deb,rpm) on `ubuntu-22.04-arm`. The mkdwarfs download in the AppImage repack step now uses `uname -m` so it resolves to the aarch64 binary on ARM runners.
- `build-scripts/prepare_bundle.sh` — Linux platform detection now recognises `aarch64`/`arm64` and a new `linux-arm64` case pulls the `aarch64-unknown-linux-gnu` python-build-standalone tarball.
- `.github/workflows/pr-comment.yml` — artifacts within each section are sorted by name so the amd64/arm64 entries don't reshuffle based on upload completion order.
- `README.md` — installer table now lists Linux x86_64 and aarch64 separately.

The AUR PKGBUILD remains x86_64-only by design; aarch64 AUR coverage is a separate change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes <link to issue>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).