### PR TITLE
Add universal macOS dmg build and download references

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,12 +46,9 @@ jobs:
             bundles: deb,rpm
           - platform: macos
             os: macos-15
-            target: macos-arm64
-            bundles: dmg
-          - platform: macos
-            os: macos-15
-            target: macos-x64
-            rust_target: x86_64-apple-darwin
+            target: macos-universal
+            rust_targets: aarch64-apple-darwin,x86_64-apple-darwin
+            rust_build_target: universal-apple-darwin
             bundles: dmg
 
     runs-on: ${{ matrix.os }}
@@ -79,7 +76,7 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
         with:
-          targets: ${{ matrix.rust_target }}
+          targets: ${{ matrix.rust_targets }}
 
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -155,11 +152,11 @@ jobs:
       # Build step - macOS CI
       - name: Build (macOS CI)
         if: matrix.platform == 'macos' && github.event_name != 'workflow_run'
-        run: cargo tauri build ${{ matrix.rust_target && format('--target {0}', matrix.rust_target) || '' }}
+        run: cargo tauri build ${{ matrix.rust_build_target && format('--target {0}', matrix.rust_build_target) || '' }}
 
       - name: Build (macOS Release with signing)
         if: matrix.platform == 'macos' && github.event_name == 'workflow_run'
-        run: cargo tauri build ${{ matrix.rust_target && format('--target {0}', matrix.rust_target) || '' }}
+        run: cargo tauri build ${{ matrix.rust_build_target && format('--target {0}', matrix.rust_build_target) || '' }}
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -167,6 +164,23 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+
+      - name: Normalize macOS universal DMG filename
+        if: matrix.platform == 'macos'
+        run: |
+          set -euo pipefail
+          DMG_DIR="src-tauri/target/${{ matrix.rust_build_target && format('{0}/', matrix.rust_build_target) || '' }}release/bundle/dmg"
+          DMG_FILE=$(find "$DMG_DIR" -maxdepth 1 -name '*.dmg' -print -quit)
+          if [[ -z "$DMG_FILE" ]]; then
+            echo "::error::No DMG produced in $DMG_DIR"
+            exit 1
+          fi
+          VERSION=$(jq -r '.version' src-tauri/tauri.conf.json)
+          UNIVERSAL_DMG="$DMG_DIR/ESPHome.Builder_${VERSION}_universal.dmg"
+          if [[ "$DMG_FILE" != "$UNIVERSAL_DMG" ]]; then
+            mv "$DMG_FILE" "$UNIVERSAL_DMG"
+          fi
+          echo "Universal DMG: $UNIVERSAL_DMG"
 
       # The sharun-based AppImage format uses DwarFS and does not include Tauri
       # resources. The build leaves the AppDir intact, so we inject Python into
@@ -243,7 +257,7 @@ jobs:
         if: contains(matrix.bundles, 'dmg')
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          path: src-tauri/target/${{ matrix.rust_target && format('{0}/', matrix.rust_target) || '' }}release/bundle/dmg/*.dmg
+          path: src-tauri/target/${{ matrix.rust_build_target && format('{0}/', matrix.rust_build_target) || '' }}release/bundle/dmg/ESPHome.Builder_*_universal.dmg
           archive: false
 
   # Persist PR metadata so the companion "PR Comment" workflow (which runs

--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ Download the latest release for your platform from [desktop.esphome.io](https://
 
 | Platform | Installer |
 |----------|-----------|
-| macOS (Apple Silicon) | `ESPHome.Builder_x.x.x_aarch64.dmg` |
-| macOS (Intel) | `ESPHome.Builder_x.x.x_x64.dmg` |
+| macOS (Apple Silicon + Intel) | `ESPHome.Builder_x.x.x_universal.dmg` |
 | Windows | `ESPHome.Builder_x.x.x_x64-setup.exe` |
 | Linux | `ESPHome.Builder_x.x.x_amd64.AppImage` or `.deb` |
 
@@ -100,11 +99,13 @@ On Windows, the application itself is installed to `%LOCALAPPDATA%\ESPHome Build
    ```bash
    ./build-scripts/prepare_bundle.sh
    ```
+   On macOS, use `./build-scripts/prepare_bundle.sh macos-universal` if you want a universal package that supports both Apple Silicon and Intel.
 
 4. Build:
    ```bash
    cargo tauri build
    ```
+   On macOS, use `cargo tauri build --target universal-apple-darwin` to produce the universal DMG.
 
 The installer will be in `src-tauri/target/release/bundle/`.
 

--- a/build-scripts/prepare_bundle.sh
+++ b/build-scripts/prepare_bundle.sh
@@ -58,6 +58,52 @@ is_macho() {
     file -b "$path" | grep -q "Mach-O"
 }
 
+# Files needed only at compile time (building C extensions, embedding Python).
+# These are never identical between archs (arch-specific defines, paths,
+# static libs) and aren't used at runtime, so strip them before the universal
+# merge instead of trying to reconcile them.
+strip_build_only_files() {
+    local python_dir="$1"
+    local py_major_minor="${PYTHON_VERSION%.*}"
+    rm -rf "$python_dir/include"
+    rm -rf "$python_dir/lib/python${py_major_minor}/config-${py_major_minor}-darwin"
+    find "$python_dir/lib" -maxdepth 2 -type f \
+        \( -name '*.a' \
+        -o -name 'itclConfig.sh' \
+        -o -name 'tclConfig.sh' \
+        -o -name 'tkConfig.sh' \
+        -o -name 'tdbcConfig.sh' \) -delete 2>/dev/null || true
+}
+
+# Combine two Mach-O files into a fat output. Handles the case where pip
+# selected a universal2 wheel on one or both sides (e.g. orjson), so the
+# file already covers both archs and lipo -create would fail on overlap.
+merge_macho() {
+    local a="$1" b="$2" out="$3"
+    local a_archs b_archs
+    a_archs=$(lipo -archs "$a" 2>/dev/null || true)
+    b_archs=$(lipo -archs "$b" 2>/dev/null || true)
+    if [[ "$a_archs" == *arm64* && "$a_archs" == *x86_64* ]]; then
+        cp "$a" "$out"
+    elif [[ "$b_archs" == *arm64* && "$b_archs" == *x86_64* ]]; then
+        cp "$b" "$out"
+    else
+        lipo -create "$a" "$b" -output "$out"
+    fi
+}
+
+# Metadata files whose arch-specific contents (Tag, RECORD hashes, sysconfig
+# defines) don't affect runtime imports — Python imports the .so file by path,
+# not via RECORD. Pick the arm64 copy arbitrarily.
+prefer_arm_path() {
+    case "$1" in
+        *.dist-info/WHEEL|*.dist-info/RECORD|*.dist-info/REQUESTED) return 0;;
+        *.dist-info/top_level.txt|*.dist-info/sboms/*) return 0;;
+        */_sysconfigdata__darwin_darwin.py) return 0;;
+    esac
+    return 1
+}
+
 download_and_extract_python() {
     local platform="$1"
     local filename="$2"
@@ -177,60 +223,86 @@ merge_universal_python() {
         exit 1
     fi
 
+    strip_build_only_files "$arm_dir"
+    strip_build_only_files "$x64_dir"
+
     rm -rf "$universal_dir"
     cp -a "$arm_dir" "$universal_dir"
+
+    local dropped_archspec=0
 
     while IFS= read -r -d '' arm_path; do
         local rel_path="${arm_path#$arm_dir/}"
         local x64_path="$x64_dir/$rel_path"
         local universal_path="$universal_dir/$rel_path"
 
-        if [[ ! -e "$x64_path" ]]; then
-            echo "Error: x64 bundle is missing file present in arm64 bundle: $rel_path"
-            exit 1
-        fi
+        # Directories are created by cp -a; nothing to merge.
+        [[ -d "$arm_path" && ! -L "$arm_path" ]] && continue
 
-        if [[ -L "$arm_path" || -L "$x64_path" ]]; then
-            if [[ ! -L "$arm_path" || ! -L "$x64_path" ]]; then
-                echo "Error: type mismatch for $rel_path (symlink vs non-symlink)"
-                exit 1
-            fi
-            if [[ "$(readlink "$arm_path")" != "$(readlink "$x64_path")" ]]; then
-                echo "Error: symlink target mismatch for $rel_path"
-                exit 1
+        # Symlinks: cp -a preserved arm64's; if x64 has the same link, no work;
+        # if only arm64 has it, the arm copy is the right answer.
+        [[ -L "$arm_path" ]] && continue
+
+        # Only present on arm64. Drop arch-specific .so/.dylib so x86_64 doesn't
+        # try to dlopen a wrong-arch binary at import time (pure-Python fallback
+        # in the package will kick in on both archs). Keep everything else.
+        if [[ ! -e "$x64_path" ]]; then
+            if [[ "$arm_path" == *.so || "$arm_path" == *.dylib ]] && is_macho "$arm_path"; then
+                local archs
+                archs=$(lipo -archs "$arm_path" 2>/dev/null || true)
+                if [[ "$archs" != *x86_64* ]]; then
+                    rm -f "$universal_path"
+                    dropped_archspec=$((dropped_archspec + 1))
+                fi
             fi
             continue
         fi
 
-        if [[ -f "$arm_path" && -f "$x64_path" ]]; then
-            if is_macho "$arm_path"; then
-                if ! is_macho "$x64_path"; then
-                    echo "Error: expected Mach-O counterpart for $rel_path in x64 bundle"
-                    exit 1
-                fi
-                lipo -create "$arm_path" "$x64_path" -output "$universal_path"
-                if [[ -x "$arm_path" ]]; then
-                    chmod +x "$universal_path"
-                fi
-            elif ! cmp -s "$arm_path" "$x64_path"; then
-                echo "Error: non-Mach-O file differs between arm64 and x64 bundles: $rel_path"
-                exit 1
-            fi
-        elif [[ -d "$arm_path" && -d "$x64_path" ]]; then
-            :
-        elif [[ -e "$arm_path" ]]; then
-            echo "Error: file type mismatch between arm64 and x64 bundles: $rel_path"
-            exit 1
+        # Identical: cp -a already placed the arm copy.
+        cmp -s "$arm_path" "$x64_path" && continue
+
+        if is_macho "$arm_path" && is_macho "$x64_path"; then
+            merge_macho "$arm_path" "$x64_path" "$universal_path"
+            [[ -x "$arm_path" ]] && chmod +x "$universal_path"
+            continue
         fi
+
+        if prefer_arm_path "$rel_path"; then
+            continue
+        fi
+
+        echo "Error: non-Mach-O file differs between arm64 and x64 bundles: $rel_path"
+        exit 1
     done < <(find "$arm_dir" -mindepth 1 -print0)
 
+    # Bring across files only present on x64 (transitive deps that resolved
+    # differently between runs). Drop arch-specific .so/.dylib for the same
+    # reason as above.
     while IFS= read -r -d '' x64_path; do
         local rel_path="${x64_path#$x64_dir/}"
-        if [[ ! -e "$arm_dir/$rel_path" ]]; then
-            echo "Error: arm64 bundle is missing file present in x64 bundle: $rel_path"
-            exit 1
+        [[ -e "$arm_dir/$rel_path" ]] && continue
+        if [[ "$x64_path" == *.so || "$x64_path" == *.dylib ]] && is_macho "$x64_path"; then
+            local archs
+            archs=$(lipo -archs "$x64_path" 2>/dev/null || true)
+            if [[ "$archs" != *arm64* ]]; then
+                dropped_archspec=$((dropped_archspec + 1))
+                continue
+            fi
         fi
+        mkdir -p "$(dirname "$universal_dir/$rel_path")"
+        cp -a "$x64_path" "$universal_dir/$rel_path"
     done < <(find "$x64_dir" -mindepth 1 -print0)
+
+    if (( dropped_archspec > 0 )); then
+        echo "Dropped $dropped_archspec arch-specific binaries (packages will use pure-Python fallback)"
+    fi
+
+    local merged_archs
+    merged_archs=$(lipo -archs "$universal_dir/bin/python3.13" 2>/dev/null || true)
+    if [[ "$merged_archs" != *arm64* || "$merged_archs" != *x86_64* ]]; then
+        echo "Error: merged python3.13 is not universal (archs: $merged_archs)"
+        exit 1
+    fi
 }
 
 echo "=== Preparing ESPHome bundle for ${PLATFORM} ==="

--- a/build-scripts/prepare_bundle.sh
+++ b/build-scripts/prepare_bundle.sh
@@ -11,7 +11,7 @@
 #
 # Usage: ./prepare_bundle.sh [platform]
 
-set -e
+set -euo pipefail
 
 PYTHON_VERSION="3.13.12"
 PBS_VERSION="20260203"
@@ -49,138 +49,223 @@ detect_platform() {
 PLATFORM="${1:-$(detect_platform)}"
 
 if [[ "$PLATFORM" == "unknown" ]]; then
-    echo "Could not detect platform. Please specify: macos-x64, macos-arm64, windows-x64, linux-x64"
+    echo "Could not detect platform. Please specify: macos-x64, macos-arm64, macos-universal, windows-x64, linux-x64"
     exit 1
 fi
 
-# Set platform-specific variables
-case $PLATFORM in
-    macos-x64)
-        FILENAME="cpython-${PYTHON_VERSION}+${PBS_VERSION}-x86_64-apple-darwin-install_only_stripped.tar.gz"
-        PYTHON_BIN="bin/python3"
-        ;;
-    macos-arm64)
-        FILENAME="cpython-${PYTHON_VERSION}+${PBS_VERSION}-aarch64-apple-darwin-install_only_stripped.tar.gz"
-        PYTHON_BIN="bin/python3"
-        ;;
-    windows-x64)
-        FILENAME="cpython-${PYTHON_VERSION}+${PBS_VERSION}-x86_64-pc-windows-msvc-install_only_stripped.tar.gz"
-        PYTHON_BIN="python.exe"
-        ;;
-    linux-x64)
-        FILENAME="cpython-${PYTHON_VERSION}+${PBS_VERSION}-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
-        PYTHON_BIN="bin/python3"
-        ;;
-esac
+is_macho() {
+    local path="$1"
+    file -b "$path" | grep -q "Mach-O"
+}
 
-URL="${BASE_URL}/${FILENAME}"
-PYTHON_DIR="$BUILD_DIR/python-${PLATFORM}"
+download_and_extract_python() {
+    local platform="$1"
+    local filename="$2"
+    local python_dir="$BUILD_DIR/python-${platform}"
+    local url="${BASE_URL}/${filename}"
+    local temp_file="/tmp/${filename}"
+
+    rm -rf "$python_dir"
+    mkdir -p "$python_dir"
+
+    echo ""
+    echo "=== Downloading Python ${PYTHON_VERSION} for ${platform} ==="
+    if [[ ! -f "$temp_file" ]]; then
+        curl -L -o "$temp_file" "$url"
+    else
+        echo "Using cached download: $temp_file"
+    fi
+
+    echo ""
+    echo "=== Extracting Python for ${platform} ==="
+    tar -xzf "$temp_file" -C "$python_dir" --strip-components=1
+}
+
+install_python_packages() {
+    local platform="$1"
+    local python_dir="$2"
+    local python_bin="$3"
+
+    echo ""
+    echo "=== Verifying Python (${platform}) ==="
+    "$python_dir/$python_bin" --version
+
+    echo ""
+    echo "=== Upgrading pip (${platform}) ==="
+    "$python_dir/$python_bin" -m pip install --upgrade pip
+
+    echo ""
+    echo "=== Installing ESPHome (${platform}) ==="
+    "$python_dir/$python_bin" -m pip install esphome
+
+    echo ""
+    echo "=== Verifying ESPHome (${platform}) ==="
+    "$python_dir/$python_bin" -m esphome version
+
+    echo ""
+    echo "=== Installing ESPHome Device Builder (${platform}) ==="
+    "$python_dir/$python_bin" -m pip install --pre esphome-device-builder
+
+    echo ""
+    echo "=== Verifying ESPHome Device Builder (${platform}) ==="
+    "$python_dir/$python_bin" -c "from importlib.metadata import version; print('esphome-device-builder', version('esphome-device-builder'))"
+
+    if [[ "$platform" != "windows-x64" ]]; then
+        echo ""
+        echo "=== Making scripts relocatable (${platform}) ==="
+        local py_major_minor="${PYTHON_VERSION%.*}"
+        local rewritten=0
+        for script in "$python_dir/bin"/*; do
+            [[ -f "$script" ]] || continue
+            [[ -L "$script" ]] && continue
+            if file -b "$script" | grep -qE 'Mach-O|ELF'; then
+                continue
+            fi
+            first_line=$(head -n1 "$script" 2>/dev/null) || continue
+            case "$first_line" in
+                "#!$python_dir/"*) ;;
+                *) continue ;;
+            esac
+            {
+                printf '%s\n' '#!/bin/sh'
+                printf '%s\n' "'''exec' \"\$(dirname -- \"\$(realpath -- \"\$0\")\")/python${py_major_minor}\" \"\$0\" \"\$@\""
+                printf '%s\n' "' '''"
+                tail -n +2 "$script"
+            } > "$script.relocatable"
+            chmod +x "$script.relocatable"
+            mv "$script.relocatable" "$script"
+            rewritten=$((rewritten + 1))
+        done
+        echo "Rewrote shebangs in $rewritten scripts"
+    fi
+
+    echo ""
+    echo "=== Stripping __pycache__ (${platform}) ==="
+    local pycache_count
+    pycache_count=$(find "$python_dir" -type d -name __pycache__ | wc -l)
+    find "$python_dir" -type d -name __pycache__ -exec rm -rf {} +
+    echo "Removed $pycache_count __pycache__ directories"
+}
+
+merge_universal_python() {
+    local arm_dir="$1"
+    local x64_dir="$2"
+    local universal_dir="$3"
+
+    if ! command -v lipo >/dev/null 2>&1; then
+        echo "Error: lipo is required to build macos-universal bundles"
+        exit 1
+    fi
+
+    rm -rf "$universal_dir"
+    cp -a "$arm_dir" "$universal_dir"
+
+    while IFS= read -r -d '' arm_path; do
+        local rel_path="${arm_path#$arm_dir/}"
+        local x64_path="$x64_dir/$rel_path"
+        local universal_path="$universal_dir/$rel_path"
+
+        if [[ ! -e "$x64_path" ]]; then
+            echo "Error: x64 bundle is missing file present in arm64 bundle: $rel_path"
+            exit 1
+        fi
+
+        if [[ -L "$arm_path" || -L "$x64_path" ]]; then
+            if [[ ! -L "$arm_path" || ! -L "$x64_path" ]]; then
+                echo "Error: type mismatch for $rel_path (symlink vs non-symlink)"
+                exit 1
+            fi
+            if [[ "$(readlink "$arm_path")" != "$(readlink "$x64_path")" ]]; then
+                echo "Error: symlink target mismatch for $rel_path"
+                exit 1
+            fi
+            continue
+        fi
+
+        if [[ -f "$arm_path" && -f "$x64_path" ]]; then
+            if is_macho "$arm_path"; then
+                if ! is_macho "$x64_path"; then
+                    echo "Error: expected Mach-O counterpart for $rel_path in x64 bundle"
+                    exit 1
+                fi
+                lipo -create "$arm_path" "$x64_path" -output "$universal_path"
+                if [[ -x "$arm_path" ]]; then
+                    chmod +x "$universal_path"
+                fi
+            elif ! cmp -s "$arm_path" "$x64_path"; then
+                echo "Error: non-Mach-O file differs between arm64 and x64 bundles: $rel_path"
+                exit 1
+            fi
+        elif [[ -d "$arm_path" && -d "$x64_path" ]]; then
+            :
+        elif [[ -e "$arm_path" ]]; then
+            echo "Error: file type mismatch between arm64 and x64 bundles: $rel_path"
+            exit 1
+        fi
+    done < <(find "$arm_dir" -mindepth 1 -print0)
+
+    while IFS= read -r -d '' x64_path; do
+        local rel_path="${x64_path#$x64_dir/}"
+        if [[ ! -e "$arm_dir/$rel_path" ]]; then
+            echo "Error: arm64 bundle is missing file present in x64 bundle: $rel_path"
+            exit 1
+        fi
+    done < <(find "$x64_dir" -mindepth 1 -print0)
+}
 
 echo "=== Preparing ESPHome bundle for ${PLATFORM} ==="
 
 # Clean up previous builds
-rm -rf "$PYTHON_DIR" "$BUNDLE_DIR"
+rm -rf "$BUNDLE_DIR"
 mkdir -p "$BUILD_DIR"
 
-# Download Python
-echo ""
-echo "=== Downloading Python ${PYTHON_VERSION} ==="
-TEMP_FILE="/tmp/${FILENAME}"
-if [[ ! -f "$TEMP_FILE" ]]; then
-    curl -L -o "$TEMP_FILE" "$URL"
-else
-    echo "Using cached download: $TEMP_FILE"
-fi
+case "$PLATFORM" in
+    macos-x64)
+        FILENAME="cpython-${PYTHON_VERSION}+${PBS_VERSION}-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        PYTHON_DIR="$BUILD_DIR/python-${PLATFORM}"
+        download_and_extract_python "$PLATFORM" "$FILENAME"
+        install_python_packages "$PLATFORM" "$PYTHON_DIR" "bin/python3"
+        ;;
+    macos-arm64)
+        FILENAME="cpython-${PYTHON_VERSION}+${PBS_VERSION}-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        PYTHON_DIR="$BUILD_DIR/python-${PLATFORM}"
+        download_and_extract_python "$PLATFORM" "$FILENAME"
+        install_python_packages "$PLATFORM" "$PYTHON_DIR" "bin/python3"
+        ;;
+    windows-x64)
+        FILENAME="cpython-${PYTHON_VERSION}+${PBS_VERSION}-x86_64-pc-windows-msvc-install_only_stripped.tar.gz"
+        PYTHON_DIR="$BUILD_DIR/python-${PLATFORM}"
+        download_and_extract_python "$PLATFORM" "$FILENAME"
+        install_python_packages "$PLATFORM" "$PYTHON_DIR" "python.exe"
+        ;;
+    linux-x64)
+        FILENAME="cpython-${PYTHON_VERSION}+${PBS_VERSION}-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+        PYTHON_DIR="$BUILD_DIR/python-${PLATFORM}"
+        download_and_extract_python "$PLATFORM" "$FILENAME"
+        install_python_packages "$PLATFORM" "$PYTHON_DIR" "bin/python3"
+        ;;
+    macos-universal)
+        ARM_FILENAME="cpython-${PYTHON_VERSION}+${PBS_VERSION}-aarch64-apple-darwin-install_only_stripped.tar.gz"
+        X64_FILENAME="cpython-${PYTHON_VERSION}+${PBS_VERSION}-x86_64-apple-darwin-install_only_stripped.tar.gz"
+        ARM_DIR="$BUILD_DIR/python-macos-arm64"
+        X64_DIR="$BUILD_DIR/python-macos-x64"
+        PYTHON_DIR="$BUILD_DIR/python-${PLATFORM}"
 
-# Extract Python
-echo ""
-echo "=== Extracting Python ==="
-mkdir -p "$PYTHON_DIR"
-tar -xzf "$TEMP_FILE" -C "$PYTHON_DIR" --strip-components=1
+        download_and_extract_python "macos-arm64" "$ARM_FILENAME"
+        install_python_packages "macos-arm64" "$ARM_DIR" "bin/python3"
 
-# Verify Python works
-echo ""
-echo "=== Verifying Python ==="
-"$PYTHON_DIR/$PYTHON_BIN" --version
+        download_and_extract_python "macos-x64" "$X64_FILENAME"
+        install_python_packages "macos-x64" "$X64_DIR" "bin/python3"
 
-# Upgrade pip
-echo ""
-echo "=== Upgrading pip ==="
-"$PYTHON_DIR/$PYTHON_BIN" -m pip install --upgrade pip
-
-# Install ESPHome directly into standalone Python (no venv)
-echo ""
-echo "=== Installing ESPHome ==="
-"$PYTHON_DIR/$PYTHON_BIN" -m pip install esphome
-
-# Verify ESPHome
-echo ""
-echo "=== Verifying ESPHome ==="
-"$PYTHON_DIR/$PYTHON_BIN" -m esphome version
-
-# Install ESPHome Device Builder (the default backend). Pre-releases are
-# allowed so the bundle tracks the BuilderBeta channel that's wired up as
-# Backend::default() in src-tauri/src/settings/mod.rs.
-echo ""
-echo "=== Installing ESPHome Device Builder ==="
-"$PYTHON_DIR/$PYTHON_BIN" -m pip install --pre esphome-device-builder
-
-# Verify ESPHome Device Builder
-echo ""
-echo "=== Verifying ESPHome Device Builder ==="
-"$PYTHON_DIR/$PYTHON_BIN" -c "from importlib.metadata import version; print('esphome-device-builder', version('esphome-device-builder'))"
-
-# Rewrite pip-generated script shebangs so the bundle is relocatable.
-# pip bakes the build-time python path into every console-script shebang
-# (`#!$PYTHON_DIR/bin/python3`), so when the bundle ships to a user's
-# machine the kernel can't find the interpreter and every `esphome`,
-# `platformio`, `pip`, … invocation fails silently (see issue #34).
-# Replace each shebang with the same sh/Python polyglot that
-# python-build-standalone uses for its own scripts (idle3, pydoc3.13, …),
-# so the whole bin/ directory is consistent and relocatable.
-# Windows uses .exe launchers (not text scripts) so it's skipped here.
-if [[ "$PLATFORM" != "windows-x64" ]]; then
-    echo ""
-    echo "=== Making scripts relocatable ==="
-    PY_MAJOR_MINOR="${PYTHON_VERSION%.*}"
-    REWRITTEN=0
-    for script in "$PYTHON_DIR/bin"/*; do
-        [[ -f "$script" ]] || continue
-        # Skip symlinks (their targets are processed as regular files in this
-        # same loop, and the symlinks pick up the rewritten content).
-        [[ -L "$script" ]] && continue
-        # Skip the python3 executable itself and any other Mach-O / ELF binary.
-        if file -b "$script" | grep -qE 'Mach-O|ELF'; then
-            continue
-        fi
-        # Only rewrite scripts whose shebang points into the build python.
-        first_line=$(head -n1 "$script" 2>/dev/null) || continue
-        case "$first_line" in
-            "#!$PYTHON_DIR/"*) ;;
-            *) continue ;;
-        esac
-        {
-            printf '%s\n' '#!/bin/sh'
-            printf '%s\n' "'''exec' \"\$(dirname -- \"\$(realpath -- \"\$0\")\")/python${PY_MAJOR_MINOR}\" \"\$0\" \"\$@\""
-            printf '%s\n' "' '''"
-            tail -n +2 "$script"
-        } > "$script.relocatable"
-        chmod +x "$script.relocatable"
-        mv "$script.relocatable" "$script"
-        REWRITTEN=$((REWRITTEN + 1))
-    done
-    echo "Rewrote shebangs in $REWRITTEN scripts"
-fi
-
-# Strip __pycache__ directories. Python regenerates .pyc files at runtime
-# from the .py source, and the build-time .pyc files bake in absolute paths
-# to the build directory (visible in tracebacks), so shipping them just
-# bloats the bundle and leaks build paths to users.
-echo ""
-echo "=== Stripping __pycache__ ==="
-PYCACHE_COUNT=$(find "$PYTHON_DIR" -type d -name __pycache__ | wc -l)
-find "$PYTHON_DIR" -type d -name __pycache__ -exec rm -rf {} +
-echo "Removed $PYCACHE_COUNT __pycache__ directories"
+        echo ""
+        echo "=== Merging macOS universal Python bundle ==="
+        merge_universal_python "$ARM_DIR" "$X64_DIR" "$PYTHON_DIR"
+        ;;
+    *)
+        echo "Unsupported platform: $PLATFORM"
+        exit 1
+        ;;
+esac
 
 # Copy Python directory to bundle location. Wipe any prior bundle first so
 # `cp -R` can't fall back to merge behavior on top of a partial previous run.

--- a/build-scripts/prepare_bundle.sh
+++ b/build-scripts/prepare_bundle.sh
@@ -102,6 +102,9 @@ install_python_packages() {
     echo "=== Verifying ESPHome (${platform}) ==="
     "$python_dir/$python_bin" -m esphome version
 
+    # Install ESPHome Device Builder (the default backend). Pre-releases are
+    # allowed so the bundle tracks the BuilderBeta channel that's wired up as
+    # Backend::default() in src-tauri/src/settings/mod.rs.
     echo ""
     echo "=== Installing ESPHome Device Builder (${platform}) ==="
     "$python_dir/$python_bin" -m pip install --pre esphome-device-builder
@@ -110,6 +113,15 @@ install_python_packages() {
     echo "=== Verifying ESPHome Device Builder (${platform}) ==="
     "$python_dir/$python_bin" -c "from importlib.metadata import version; print('esphome-device-builder', version('esphome-device-builder'))"
 
+    # Rewrite pip-generated script shebangs so the bundle is relocatable.
+    # pip bakes the build-time python path into every console-script shebang
+    # (`#!$python_dir/bin/python3`), so when the bundle ships to a user's
+    # machine the kernel can't find the interpreter and every `esphome`,
+    # `platformio`, `pip`, … invocation fails silently (see issue #34).
+    # Replace each shebang with the same sh/Python polyglot that
+    # python-build-standalone uses for its own scripts (idle3, pydoc3.13, …),
+    # so the whole bin/ directory is consistent and relocatable.
+    # Windows uses .exe launchers (not text scripts) so it's skipped here.
     if [[ "$platform" != "windows-x64" ]]; then
         echo ""
         echo "=== Making scripts relocatable (${platform}) ==="
@@ -117,10 +129,14 @@ install_python_packages() {
         local rewritten=0
         for script in "$python_dir/bin"/*; do
             [[ -f "$script" ]] || continue
+            # Skip symlinks (their targets are processed as regular files in this
+            # same loop, and the symlinks pick up the rewritten content).
             [[ -L "$script" ]] && continue
+            # Skip the python3 executable itself and any other Mach-O / ELF binary.
             if file -b "$script" | grep -qE 'Mach-O|ELF'; then
                 continue
             fi
+            # Only rewrite scripts whose shebang points into the build python.
             first_line=$(head -n1 "$script" 2>/dev/null) || continue
             case "$first_line" in
                 "#!$python_dir/"*) ;;
@@ -139,6 +155,10 @@ install_python_packages() {
         echo "Rewrote shebangs in $rewritten scripts"
     fi
 
+    # Strip __pycache__ directories. Python regenerates .pyc files at runtime
+    # from the .py source, and the build-time .pyc files bake in absolute paths
+    # to the build directory (visible in tracebacks), so shipping them just
+    # bloats the bundle and leaks build paths to users.
     echo ""
     echo "=== Stripping __pycache__ (${platform}) ==="
     local pycache_count

--- a/web/index.html
+++ b/web/index.html
@@ -399,14 +399,10 @@
         <h2 class="panel-title">For macOS</h2>
         <p class="panel-sub">macOS 10.15 Catalina or newer.</p>
         <div class="download-row">
-          <a class="btn" id="mac-download" href="https://github.com/esphome/esphome-desktop/releases/download/$TAG/ESPHome.Builder_${VERSION}_aarch64.dmg">
+          <a class="btn" id="mac-download" href="https://github.com/esphome/esphome-desktop/releases/download/$TAG/ESPHome.Builder_${VERSION}_universal.dmg">
             <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M5 20h14v-2H5v2zM19 9h-4V3H9v6H5l7 7 7-7z"/></svg>
             Download disk image
           </a>
-          <div class="segmented" role="group" aria-label="Mac architecture">
-            <button type="button" data-arch="arm64" aria-pressed="true">Apple Silicon</button>
-            <button type="button" data-arch="x64" aria-pressed="false">Intel</button>
-          </div>
         </div>
         <div class="steps">
           <h3>Install</h3>
@@ -416,7 +412,7 @@
             <li>Open the Applications folder and double-click <strong>ESPHome Builder</strong>.</li>
             <li>The first time you run it, macOS may ask you to confirm — click <strong>Open</strong>.</li>
           </ol>
-          <div class="note">Not sure which Mac you have? Click the Apple menu → <strong>About This Mac</strong>. If you see <em>Apple M1/M2/M3/M4</em>, pick Apple Silicon. If you see <em>Intel</em>, pick Intel.</div>
+          <div class="note">One download supports both Apple Silicon and Intel Macs.</div>
         </div>
       </section>
 
@@ -533,28 +529,8 @@
 
       document.getElementById('windows-download').href = BASE + 'ESPHome.Builder_' + VERSION + '_x64-setup.exe';
 
-      const macFiles = {
-        arm64: BASE + 'ESPHome.Builder_' + VERSION + '_aarch64.dmg',
-        x64: BASE + 'ESPHome.Builder_' + VERSION + '_x64.dmg',
-      };
       const macBtn = document.getElementById('mac-download');
-      const macArchButtons = document.querySelectorAll('#panel-macos .segmented button');
-      function setMacArch(arch) {
-        macArchButtons.forEach(function (b) {
-          b.setAttribute('aria-pressed', b.dataset.arch === arch ? 'true' : 'false');
-        });
-        macBtn.href = macFiles[arch];
-      }
-      setMacArch('arm64');
-      macArchButtons.forEach(function (b) {
-        b.addEventListener('click', function () { setMacArch(b.dataset.arch); });
-      });
-
-      if (detected === 'macos' && navigator.userAgentData && navigator.userAgentData.getHighEntropyValues) {
-        navigator.userAgentData.getHighEntropyValues(['architecture']).then(function (info) {
-          setMacArch(info.architecture === 'x86' ? 'x64' : 'arm64');
-        }).catch(function () {});
-      }
+      macBtn.href = BASE + 'ESPHome.Builder_' + VERSION + '_universal.dmg';
 
       const linuxFiles = {
         deb: { url: BASE + 'ESPHome.Builder_' + VERSION + '_amd64.deb', label: 'Download .deb' },


### PR DESCRIPTION
Agent-Logs-Url: https://github.com/TimoPtr/esphome-desktop/sessions/d7b0d3e2-dbfa-41a4-b8db-142e426c3249

# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Make a universal macOS package instead of 2 to improve the UX.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes <link to issue>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).
