### PR TITLE
Refactor prepare_bundle.sh into reusable functions

### DIFF
--- a/build-scripts/prepare_bundle.sh
+++ b/build-scripts/prepare_bundle.sh
@@ -50,109 +50,50 @@ detect_platform() {
     esac
 }
 
-PLATFORM="${1:-$(detect_platform)}"
+# Download the python-build-standalone tarball for the given platform and
+# extract it to $BUILD_DIR/python-${platform}. Tarball downloads are cached
+# in /tmp so re-runs don't re-download.
+download_and_extract_python() {
+    local platform="$1"
+    local filename="$2"
+    local python_dir="$BUILD_DIR/python-${platform}"
+    local url="${BASE_URL}/${filename}"
+    local temp_file="/tmp/${filename}"
 
-if [[ "$PLATFORM" == "unknown" ]]; then
-    echo "Could not detect platform. Please specify: macos-x64, macos-arm64, windows-x64, linux-x64, linux-arm64"
-    exit 1
-fi
+    echo ""
+    echo "=== Downloading Python ${PYTHON_VERSION} for ${platform} ==="
+    if [[ ! -f "$temp_file" ]]; then
+        curl -L -o "$temp_file" "$url"
+    else
+        echo "Using cached download: $temp_file"
+    fi
 
-# Set platform-specific variables
-case $PLATFORM in
-    macos-x64)
-        FILENAME="cpython-${PYTHON_VERSION}+${PBS_VERSION}-x86_64-apple-darwin-install_only_stripped.tar.gz"
-        PYTHON_BIN="bin/python3"
-        ;;
-    macos-arm64)
-        FILENAME="cpython-${PYTHON_VERSION}+${PBS_VERSION}-aarch64-apple-darwin-install_only_stripped.tar.gz"
-        PYTHON_BIN="bin/python3"
-        ;;
-    windows-x64)
-        FILENAME="cpython-${PYTHON_VERSION}+${PBS_VERSION}-x86_64-pc-windows-msvc-install_only_stripped.tar.gz"
-        PYTHON_BIN="python.exe"
-        ;;
-    linux-x64)
-        FILENAME="cpython-${PYTHON_VERSION}+${PBS_VERSION}-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
-        PYTHON_BIN="bin/python3"
-        ;;
-    linux-arm64)
-        FILENAME="cpython-${PYTHON_VERSION}+${PBS_VERSION}-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
-        PYTHON_BIN="bin/python3"
-        ;;
-esac
-
-URL="${BASE_URL}/${FILENAME}"
-PYTHON_DIR="$BUILD_DIR/python-${PLATFORM}"
-
-echo "=== Preparing ESPHome bundle for ${PLATFORM} ==="
-
-# Clean up previous builds
-rm -rf "$PYTHON_DIR" "$BUNDLE_DIR"
-mkdir -p "$BUILD_DIR"
-
-# Download Python
-echo ""
-echo "=== Downloading Python ${PYTHON_VERSION} ==="
-TEMP_FILE="/tmp/${FILENAME}"
-if [[ ! -f "$TEMP_FILE" ]]; then
-    curl -L -o "$TEMP_FILE" "$URL"
-else
-    echo "Using cached download: $TEMP_FILE"
-fi
-
-# Extract Python
-echo ""
-echo "=== Extracting Python ==="
-mkdir -p "$PYTHON_DIR"
-tar -xzf "$TEMP_FILE" -C "$PYTHON_DIR" --strip-components=1
-
-# Verify Python works
-echo ""
-echo "=== Verifying Python ==="
-"$PYTHON_DIR/$PYTHON_BIN" --version
-
-# Upgrade pip
-echo ""
-echo "=== Upgrading pip ==="
-"$PYTHON_DIR/$PYTHON_BIN" -m pip install --upgrade pip
-
-# Install ESPHome directly into standalone Python (no venv)
-echo ""
-echo "=== Installing ESPHome ==="
-"$PYTHON_DIR/$PYTHON_BIN" -m pip install esphome
-
-# Verify ESPHome
-echo ""
-echo "=== Verifying ESPHome ==="
-"$PYTHON_DIR/$PYTHON_BIN" -m esphome version
-
-# Install ESPHome Device Builder (the default backend). Pre-releases are
-# allowed so the bundle tracks the BuilderBeta channel that's wired up as
-# Backend::default() in src-tauri/src/settings/mod.rs.
-echo ""
-echo "=== Installing ESPHome Device Builder ==="
-"$PYTHON_DIR/$PYTHON_BIN" -m pip install --pre esphome-device-builder
-
-# Verify ESPHome Device Builder
-echo ""
-echo "=== Verifying ESPHome Device Builder ==="
-"$PYTHON_DIR/$PYTHON_BIN" -c "from importlib.metadata import version; print('esphome-device-builder', version('esphome-device-builder'))"
+    echo ""
+    echo "=== Extracting Python for ${platform} ==="
+    rm -rf "$python_dir"
+    mkdir -p "$python_dir"
+    tar -xzf "$temp_file" -C "$python_dir" --strip-components=1
+}
 
 # Rewrite pip-generated script shebangs so the bundle is relocatable.
 # pip bakes the build-time python path into every console-script shebang
-# (`#!$PYTHON_DIR/bin/python3`), so when the bundle ships to a user's
+# (`#!$python_dir/bin/python3`), so when the bundle ships to a user's
 # machine the kernel can't find the interpreter and every `esphome`,
 # `platformio`, `pip`, … invocation fails silently (see issue #34).
 # Replace each shebang with the same sh/Python polyglot that
 # python-build-standalone uses for its own scripts (idle3, pydoc3.13, …),
 # so the whole bin/ directory is consistent and relocatable.
-# Windows uses .exe launchers (not text scripts) so it's skipped here.
-if [[ "$PLATFORM" != "windows-x64" ]]; then
+# Windows uses .exe launchers (not text scripts) so it's not called there.
+make_scripts_relocatable() {
+    local platform="$1"
+    local python_dir="$2"
+
     echo ""
-    echo "=== Making scripts relocatable ==="
-    PY_MAJOR_MINOR="${PYTHON_VERSION%.*}"
-    REWRITTEN=0
-    for script in "$PYTHON_DIR/bin"/*; do
+    echo "=== Making scripts relocatable (${platform}) ==="
+    local py_major_minor="${PYTHON_VERSION%.*}"
+    local rewritten=0
+    local script first_line
+    for script in "$python_dir/bin"/*; do
         [[ -f "$script" ]] || continue
         # Skip symlinks (their targets are processed as regular files in this
         # same loop, and the symlinks pick up the rewritten content).
@@ -164,31 +105,120 @@ if [[ "$PLATFORM" != "windows-x64" ]]; then
         # Only rewrite scripts whose shebang points into the build python.
         first_line=$(head -n1 "$script" 2>/dev/null) || continue
         case "$first_line" in
-            "#!$PYTHON_DIR/"*) ;;
+            "#!$python_dir/"*) ;;
             *) continue ;;
         esac
         {
             printf '%s\n' '#!/bin/sh'
-            printf '%s\n' "'''exec' \"\$(dirname -- \"\$(realpath -- \"\$0\")\")/python${PY_MAJOR_MINOR}\" \"\$0\" \"\$@\""
+            printf '%s\n' "'''exec' \"\$(dirname -- \"\$(realpath -- \"\$0\")\")/python${py_major_minor}\" \"\$0\" \"\$@\""
             printf '%s\n' "' '''"
             tail -n +2 "$script"
         } > "$script.relocatable"
         chmod +x "$script.relocatable"
         mv "$script.relocatable" "$script"
-        REWRITTEN=$((REWRITTEN + 1))
+        rewritten=$((rewritten + 1))
     done
-    echo "Rewrote shebangs in $REWRITTEN scripts"
-fi
+    echo "Rewrote shebangs in $rewritten scripts"
+}
 
 # Strip __pycache__ directories. Python regenerates .pyc files at runtime
 # from the .py source, and the build-time .pyc files bake in absolute paths
 # to the build directory (visible in tracebacks), so shipping them just
 # bloats the bundle and leaks build paths to users.
-echo ""
-echo "=== Stripping __pycache__ ==="
-PYCACHE_COUNT=$(find "$PYTHON_DIR" -type d -name __pycache__ | wc -l)
-find "$PYTHON_DIR" -type d -name __pycache__ -exec rm -rf {} +
-echo "Removed $PYCACHE_COUNT __pycache__ directories"
+strip_pycache() {
+    local platform="$1"
+    local python_dir="$2"
+
+    echo ""
+    echo "=== Stripping __pycache__ (${platform}) ==="
+    local count
+    count=$(find "$python_dir" -type d -name __pycache__ | wc -l)
+    find "$python_dir" -type d -name __pycache__ -exec rm -rf {} +
+    echo "Removed $count __pycache__ directories"
+}
+
+# Install ESPHome + ESPHome Device Builder into the standalone Python and
+# post-process the install (rewrite shebangs, strip __pycache__) so the
+# tree is relocatable and bundle-ready.
+install_python_packages() {
+    local platform="$1"
+    local python_dir="$2"
+    local python_bin="$3"
+
+    echo ""
+    echo "=== Verifying Python (${platform}) ==="
+    "$python_dir/$python_bin" --version
+
+    echo ""
+    echo "=== Upgrading pip (${platform}) ==="
+    "$python_dir/$python_bin" -m pip install --upgrade pip
+
+    echo ""
+    echo "=== Installing ESPHome (${platform}) ==="
+    "$python_dir/$python_bin" -m pip install esphome
+
+    echo ""
+    echo "=== Verifying ESPHome (${platform}) ==="
+    "$python_dir/$python_bin" -m esphome version
+
+    # Install ESPHome Device Builder (the default backend). Pre-releases are
+    # allowed so the bundle tracks the BuilderBeta channel that's wired up as
+    # Backend::default() in src-tauri/src/settings/mod.rs.
+    echo ""
+    echo "=== Installing ESPHome Device Builder (${platform}) ==="
+    "$python_dir/$python_bin" -m pip install --pre esphome-device-builder
+
+    echo ""
+    echo "=== Verifying ESPHome Device Builder (${platform}) ==="
+    "$python_dir/$python_bin" -c "from importlib.metadata import version; print('esphome-device-builder', version('esphome-device-builder'))"
+
+    if [[ "$platform" != "windows-x64" ]]; then
+        make_scripts_relocatable "$platform" "$python_dir"
+    fi
+
+    strip_pycache "$platform" "$python_dir"
+}
+
+# Look up the PBS tarball + python binary for a platform, then download
+# and install. Centralizes the platform table so adding a new platform is
+# one entry here.
+prepare_python_for_platform() {
+    local platform="$1"
+    local arch_os python_bin
+
+    case "$platform" in
+        macos-x64)    arch_os="x86_64-apple-darwin";       python_bin="bin/python3" ;;
+        macos-arm64)  arch_os="aarch64-apple-darwin";      python_bin="bin/python3" ;;
+        windows-x64)  arch_os="x86_64-pc-windows-msvc";    python_bin="python.exe"  ;;
+        linux-x64)    arch_os="x86_64-unknown-linux-gnu";  python_bin="bin/python3" ;;
+        linux-arm64)  arch_os="aarch64-unknown-linux-gnu"; python_bin="bin/python3" ;;
+        *)
+            echo "Unsupported platform: $platform"
+            exit 1
+            ;;
+    esac
+
+    local filename="cpython-${PYTHON_VERSION}+${PBS_VERSION}-${arch_os}-install_only_stripped.tar.gz"
+    download_and_extract_python "$platform" "$filename"
+    install_python_packages "$platform" "$BUILD_DIR/python-${platform}" "$python_bin"
+}
+
+PLATFORM="${1:-$(detect_platform)}"
+
+if [[ "$PLATFORM" == "unknown" ]]; then
+    echo "Could not detect platform. Please specify: macos-x64, macos-arm64, windows-x64, linux-x64, linux-arm64"
+    exit 1
+fi
+
+echo "=== Preparing ESPHome bundle for ${PLATFORM} ==="
+
+# Clean up previous builds
+rm -rf "$BUNDLE_DIR"
+mkdir -p "$BUILD_DIR"
+
+prepare_python_for_platform "$PLATFORM"
+
+PYTHON_DIR="$BUILD_DIR/python-${PLATFORM}"
 
 # Copy Python directory to bundle location. Wipe any prior bundle first so
 # `cp -R` can't fall back to merge behavior on top of a partial previous run.


### PR DESCRIPTION
# What does this implement/fix?

Pure refactor of `build-scripts/prepare_bundle.sh`: lift the linear download → install → relocate → strip pipeline into named functions (`download_and_extract_python`, `install_python_packages`, `make_scripts_relocatable`, `strip_pycache`) plus a `prepare_python_for_platform` that owns the platform → PBS-tarball table. The top-level dispatch shrinks to one helper call.

No behavior change: same ordering, same wipe semantics, same shebang rewrite, same `__pycache__` strip, same `set -e`. Loop and helper variables are now `local` so they don't leak into the global namespace.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- Prep work for #97

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).