### PR TITLE
Add Tauri self-updater for the desktop app

### DIFF
--- a/.github/latest.schema.json
+++ b/.github/latest.schema.json
@@ -31,7 +31,7 @@
       "type": "string",
       "format": "uri",
       "description": "Canonical link to the release page on GitHub.",
-      "pattern": "^https://github\\.com/esphome/esphome-desktop/releases/tag/v[0-9]+\\.[0-9]+\\.[0-9]+$"
+      "pattern": "^https://github\\.com/esphome/esphome-desktop/releases/tag/v[0-9]+\\.[0-9]+\\.[0-9]+(?:[+-][0-9A-Za-z.-]+)?$"
     },
     "platforms": {
       "type": "object",
@@ -49,7 +49,7 @@
             "type": "string",
             "format": "uri",
             "description": "Download URL for the platform's updater bundle. Must point at a GitHub release asset on this repo and end in a supported updater bundle extension.",
-            "pattern": "^https://github\\.com/esphome/esphome-desktop/releases/download/v[0-9]+\\.[0-9]+\\.[0-9]+/.+\\.(exe|AppImage|app\\.tar\\.gz)$"
+            "pattern": "^https://github\\.com/esphome/esphome-desktop/releases/download/v[0-9]+\\.[0-9]+\\.[0-9]+(?:[+-][0-9A-Za-z.-]+)?/.+\\.(exe|AppImage|app\\.tar\\.gz)$"
           },
           "signature": {
             "type": "string",
@@ -82,7 +82,7 @@
               "type": "string",
               "format": "uri",
               "description": "GitHub release asset download URL for the installer.",
-              "pattern": "^https://github\\.com/esphome/esphome-desktop/releases/download/v[0-9]+\\.[0-9]+\\.[0-9]+/.+$"
+              "pattern": "^https://github\\.com/esphome/esphome-desktop/releases/download/v[0-9]+\\.[0-9]+\\.[0-9]+(?:[+-][0-9A-Za-z.-]+)?/.+$"
             },
             "size": {
               "type": "integer",

--- a/.github/latest.schema.json
+++ b/.github/latest.schema.json
@@ -1,12 +1,18 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/esphome/esphome-desktop/blob/main/.github/latest.schema.json",
-  "title": "Tauri Updater Manifest (latest.json)",
-  "description": "Shape of the latest.json manifest consumed by tauri-plugin-updater. The release workflow generates this from the per-platform .sig files and uploads it as a release asset.",
+  "$id": "https://desktop.esphome.io/latest.schema.json",
+  "title": "ESPHome Builder release manifest (latest.json)",
+  "description": "Shape of the latest.json manifest published to https://desktop.esphome.io/latest.json (and attached to each GitHub release as `latest.json`). `platforms` is consumed by tauri-plugin-updater for in-app self-updates; `downloads` and `release_url` are extra fields for download pages and other consumers that just want to know what the latest version is and where to fetch each installer.",
   "type": "object",
   "required": ["version", "pub_date", "platforms"],
   "additionalProperties": false,
   "properties": {
+    "$schema": {
+      "type": "string",
+      "format": "uri",
+      "description": "Optional pointer to the JSON Schema that validates this manifest. Convention for instance documents; ignored by tauri-plugin-updater.",
+      "pattern": "^https://desktop\\.esphome\\.io/latest\\.schema\\.json$"
+    },
     "version": {
       "type": "string",
       "description": "Application version (semver, no leading 'v').",
@@ -21,9 +27,15 @@
       "description": "ISO 8601 timestamp of when the release was published.",
       "format": "date-time"
     },
+    "release_url": {
+      "type": "string",
+      "format": "uri",
+      "description": "Canonical link to the release page on GitHub.",
+      "pattern": "^https://github\\.com/esphome/esphome-desktop/releases/tag/v[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
     "platforms": {
       "type": "object",
-      "description": "Per-platform updater bundles. At least one platform must be present.",
+      "description": "Per-platform updater bundles (Tauri updater format). At least one platform must be present.",
       "minProperties": 1,
       "propertyNames": {
         "pattern": "^(linux|windows|darwin)-(x86_64|aarch64|armv7|i686|universal)$"
@@ -43,6 +55,40 @@
             "type": "string",
             "description": "Tauri-generated signature (full .sig file contents).",
             "minLength": 1
+          }
+        }
+      }
+    },
+    "downloads": {
+      "type": "object",
+      "description": "All distributable installer URLs grouped by Tauri platform target. Includes formats not covered by the in-app updater (.deb, .rpm, .dmg) so download pages can offer the right installer per OS/arch.",
+      "propertyNames": {
+        "pattern": "^(linux|windows|darwin)-(x86_64|aarch64|armv7|i686|universal)$"
+      },
+      "additionalProperties": {
+        "type": "array",
+        "minItems": 1,
+        "items": {
+          "type": "object",
+          "required": ["kind", "url", "size"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": {
+              "type": "string",
+              "description": "Canonical short name for the installer format.",
+              "enum": ["nsis", "dmg", "appimage", "deb", "rpm"]
+            },
+            "url": {
+              "type": "string",
+              "format": "uri",
+              "description": "GitHub release asset download URL for the installer.",
+              "pattern": "^https://github\\.com/esphome/esphome-desktop/releases/download/v[0-9]+\\.[0-9]+\\.[0-9]+/.+$"
+            },
+            "size": {
+              "type": "integer",
+              "description": "Installer file size in bytes.",
+              "minimum": 0
+            }
           }
         }
       }

--- a/.github/latest.schema.json
+++ b/.github/latest.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/esphome/esphome-desktop/blob/main/.github/latest.schema.json",
+  "title": "Tauri Updater Manifest (latest.json)",
+  "description": "Shape of the latest.json manifest consumed by tauri-plugin-updater. The release workflow generates this from the per-platform .sig files and uploads it as a release asset.",
+  "type": "object",
+  "required": ["version", "pub_date", "platforms"],
+  "additionalProperties": false,
+  "properties": {
+    "version": {
+      "type": "string",
+      "description": "Application version (semver, no leading 'v').",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(?:[+-][0-9A-Za-z.-]+)?$"
+    },
+    "notes": {
+      "type": "string",
+      "description": "Release notes shown to the user before installing."
+    },
+    "pub_date": {
+      "type": "string",
+      "description": "ISO 8601 timestamp of when the release was published.",
+      "format": "date-time"
+    },
+    "platforms": {
+      "type": "object",
+      "description": "Per-platform updater bundles. At least one platform must be present.",
+      "minProperties": 1,
+      "propertyNames": {
+        "pattern": "^(linux|windows|darwin)-(x86_64|aarch64|armv7|i686|universal)$"
+      },
+      "additionalProperties": {
+        "type": "object",
+        "required": ["url", "signature"],
+        "additionalProperties": false,
+        "properties": {
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description": "Download URL for the platform's updater bundle. Must point at a GitHub release asset on this repo and end in a supported updater bundle extension.",
+            "pattern": "^https://github\\.com/esphome/esphome-desktop/releases/download/v[0-9]+\\.[0-9]+\\.[0-9]+/.+\\.(exe|AppImage|app\\.tar\\.gz)$"
+          },
+          "signature": {
+            "type": "string",
+            "description": "Tauri-generated signature (full .sig file contents).",
+            "minLength": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/.github/scripts/generate_latest_json.py
+++ b/.github/scripts/generate_latest_json.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Generate the latest.json release manifest.
+
+Invoked from the release job in .github/workflows/build.yml after build
+artifacts have been attached to the draft release. Produces a JSON manifest
+with:
+
+  * `platforms` — Tauri updater bundles + signatures (consumed by
+    tauri-plugin-updater for in-app self-updates).
+  * `downloads` — every distributable installer URL grouped by platform,
+    including formats the updater doesn't ship (.deb, .rpm, .dmg). For
+    download pages and other consumers.
+  * `release_url`, `pub_date`, `notes` — release metadata.
+
+The manifest is uploaded as a release asset and mirrored to
+https://desktop.esphome.io/latest.json by the deploy-pages workflow.
+
+Usage in CI (TAG / REPO / GH_TOKEN from env):
+
+    python3 .github/scripts/generate_latest_json.py
+
+Usage for local testing — run against the in-repo fixtures, no network
+and no `gh` auth required:
+
+    python3 .github/scripts/generate_latest_json.py \
+        --tag v0.10.0 \
+        --repo esphome/esphome-desktop \
+        --release-fixture tests/fixtures/release.json \
+        --artifacts-dir tests/fixtures/artifacts \
+        --output /tmp/latest.json
+
+To exercise a real release's data shape, replace the fixture with
+`gh release view <tag> --json body,publishedAt,assets > my-release.json`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+# (Tauri updater target, regex matching the .sig asset name)
+PLATFORM_SIG_MATCHERS: list[tuple[str, re.Pattern[str]]] = [
+    ("windows-x86_64", re.compile(r".+-setup\.exe\.sig$")),
+    ("linux-x86_64",   re.compile(r".+_amd64\.AppImage\.sig$")),
+    ("linux-aarch64",  re.compile(r".+_aarch64\.AppImage\.sig$")),
+    ("darwin-aarch64", re.compile(r".+_aarch64\.app\.tar\.gz\.sig$")),
+    ("darwin-x86_64",  re.compile(r".+_x64\.app\.tar\.gz\.sig$")),
+]
+
+# (Tauri updater target, canonical installer kind, regex matching asset name)
+# The .app.tar.gz updater bundles are intentionally absent — they're only
+# useful to the Tauri updater (already covered by `platforms`); a human
+# downloading first-install on macOS wants the .dmg.
+DOWNLOAD_MATCHERS: list[tuple[str, str, re.Pattern[str]]] = [
+    ("windows-x86_64", "nsis",     re.compile(r"-setup\.exe$")),
+    ("linux-x86_64",   "appimage", re.compile(r"_amd64\.AppImage$")),
+    ("linux-aarch64",  "appimage", re.compile(r"_aarch64\.AppImage$")),
+    ("linux-x86_64",   "deb",      re.compile(r"_amd64\.deb$")),
+    ("linux-aarch64",  "deb",      re.compile(r"_arm64\.deb$")),
+    ("linux-x86_64",   "rpm",      re.compile(r"\.x86_64\.rpm$")),
+    ("linux-aarch64",  "rpm",      re.compile(r"\.aarch64\.rpm$")),
+    ("darwin-aarch64", "dmg",      re.compile(r"_aarch64\.dmg$")),
+    ("darwin-x86_64",  "dmg",      re.compile(r"_x64\.dmg$")),
+]
+
+SCHEMA_URL = "https://desktop.esphome.io/latest.schema.json"
+
+
+def _warn(msg: str) -> None:
+    """Emit a GitHub-Actions-style warning to stderr (also readable locally)."""
+    print(f"::warning::{msg}", file=sys.stderr)
+
+
+def build_platforms(
+    assets_by_name: dict[str, dict[str, Any]],
+    artifacts_dir: Path,
+) -> dict[str, dict[str, str]]:
+    """Build the Tauri updater `platforms` block from release assets + local .sig files."""
+    platforms: dict[str, dict[str, str]] = {}
+    for plat, regex in PLATFORM_SIG_MATCHERS:
+        candidates = [a for a in assets_by_name.values() if regex.match(a["name"])]
+        if not candidates:
+            _warn(f"No signature asset found for {plat}")
+            continue
+        sig_asset = candidates[0]
+        bin_name = sig_asset["name"][: -len(".sig")]
+        bin_asset = assets_by_name.get(bin_name)
+        if not bin_asset:
+            _warn(f"No matching binary asset for {sig_asset['name']}")
+            continue
+        sig_files = list(artifacts_dir.rglob(sig_asset["name"]))
+        if not sig_files:
+            _warn(f"Signature file not found locally: {sig_asset['name']}")
+            continue
+        platforms[plat] = {
+            "signature": sig_files[0].read_text().strip(),
+            "url": bin_asset["url"],
+        }
+    return platforms
+
+
+def build_downloads(
+    release_assets: list[dict[str, Any]],
+) -> dict[str, list[dict[str, Any]]]:
+    """Group every distributable installer URL by platform."""
+    downloads: dict[str, list[dict[str, Any]]] = {}
+    for asset in release_assets:
+        name = asset["name"]
+        for plat, kind, regex in DOWNLOAD_MATCHERS:
+            if regex.search(name):
+                downloads.setdefault(plat, []).append({
+                    "kind": kind,
+                    "url": asset["url"],
+                    "size": asset["size"],
+                })
+                break
+    # Stable ordering inside each platform so the manifest doesn't churn
+    # between runs purely from asset-listing order.
+    for entries in downloads.values():
+        entries.sort(key=lambda e: e["kind"])
+    return downloads
+
+
+def build_manifest(
+    release: dict[str, Any],
+    repo: str,
+    tag: str,
+    artifacts_dir: Path,
+) -> dict[str, Any]:
+    """Pure transform: release info + local artifacts → manifest dict.
+
+    Args:
+        release: Output of `gh release view --json body,publishedAt,assets`
+            (each asset must have at least `name`, `url`, `size`).
+        repo: `<owner>/<name>` slug, used to build `release_url`.
+        tag: Release tag (e.g. `v0.10.0`), used to build `release_url`
+            and to derive the unprefixed `version` field.
+        artifacts_dir: Directory containing the per-platform `.sig` files
+            uploaded by the build matrix (typically `actions/download-artifact`
+            output).
+    """
+    version = tag.lstrip("v")
+    assets = release.get("assets") or []
+    assets_by_name = {a["name"]: a for a in assets}
+
+    platforms = build_platforms(assets_by_name, artifacts_dir)
+    downloads = build_downloads(assets)
+
+    pub_date = release.get("publishedAt") or datetime.now(timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+
+    return {
+        "$schema": SCHEMA_URL,
+        "version": version,
+        "notes": release.get("body") or "",
+        "pub_date": pub_date,
+        "release_url": f"https://github.com/{repo}/releases/tag/{tag}",
+        "platforms": platforms,
+        "downloads": downloads,
+    }
+
+
+def fetch_release(tag: str, repo: str) -> dict[str, Any]:
+    """Call `gh` to fetch release info. Requires `gh` to be on PATH and authed."""
+    return json.loads(
+        subprocess.check_output(
+            ["gh", "release", "view", tag, "--repo", repo, "--json", "body,publishedAt,assets"],
+            text=True,
+        )
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--tag",
+        default=os.environ.get("TAG"),
+        help="Release tag, e.g. v0.10.0. Defaults to $TAG.",
+    )
+    parser.add_argument(
+        "--repo",
+        default=os.environ.get("REPO"),
+        help="Repository slug, e.g. esphome/esphome-desktop. Defaults to $REPO.",
+    )
+    parser.add_argument(
+        "--artifacts-dir",
+        default="artifacts",
+        type=Path,
+        help="Directory containing the local .sig files (default: artifacts/).",
+    )
+    parser.add_argument(
+        "--output",
+        default="latest.json",
+        type=Path,
+        help="Output path for the manifest (default: latest.json).",
+    )
+    parser.add_argument(
+        "--release-fixture",
+        type=Path,
+        help="Load release JSON from a file instead of calling `gh`. "
+             "Useful for local testing without network or gh auth.",
+    )
+    args = parser.parse_args()
+
+    if not args.tag:
+        parser.error("--tag (or $TAG) is required")
+    if not args.repo:
+        parser.error("--repo (or $REPO) is required")
+
+    if args.release_fixture:
+        release = json.loads(args.release_fixture.read_text())
+    else:
+        release = fetch_release(args.tag, args.repo)
+
+    manifest = build_manifest(release, args.repo, args.tag, args.artifacts_dir)
+
+    rendered = json.dumps(manifest, indent=2)
+    args.output.write_text(rendered)
+    print(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,7 +153,7 @@ jobs:
         shell: bash
         run: |
           extra_args=""
-          if [[ -n "${{ matrix.updater_target }}" ]]; then
+          if [[ -n "${{ matrix.updater_target || '' }}" ]]; then
             extra_args="--config src-tauri/tauri.release.conf.json"
           fi
           cargo tauri build --verbose --bundles ${{ matrix.bundles }} $extra_args

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -366,9 +366,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          # Only need the JSON Schema for latest.json validation; skip LFS / submodules.
+          # Need the latest.json generator script + the JSON Schema it produces;
+          # nothing else from the source tree is required by the release job.
           sparse-checkout: |
             .github/latest.schema.json
+            .github/scripts
           sparse-checkout-cone-mode: false
 
       - name: Find draft release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,11 +35,13 @@ jobs:
             os: windows-latest
             target: windows-x64
             bundles: nsis
+            updater_target: windows-x86_64
           - platform: linux
             os: ubuntu-22.04
             target: linux-x64
             bundles: appimage
             tauri_branch: feat/truly-portable-appimage
+            updater_target: linux-x86_64
           - platform: linux
             os: ubuntu-22.04
             target: linux-x64
@@ -49,6 +51,7 @@ jobs:
             target: linux-arm64
             bundles: appimage
             tauri_branch: feat/truly-portable-appimage
+            updater_target: linux-aarch64
           - platform: linux
             os: ubuntu-22.04-arm
             target: linux-arm64
@@ -57,11 +60,13 @@ jobs:
             os: macos-15
             target: macos-arm64
             bundles: dmg
+            updater_target: darwin-aarch64
           - platform: macos
             os: macos-15
             target: macos-x64
             rust_target: x86_64-apple-darwin
             bundles: dmg
+            updater_target: darwin-x86_64
 
     runs-on: ${{ matrix.os }}
     name: Build ${{ matrix.target }}
@@ -145,9 +150,17 @@ jobs:
 
       - name: Build (Linux Release)
         if: matrix.platform == 'linux' && github.event_name == 'workflow_run'
-        run: cargo tauri build --verbose --bundles ${{ matrix.bundles }}
+        shell: bash
+        run: |
+          extra_args=""
+          if [[ -n "${{ matrix.updater_target }}" ]]; then
+            extra_args="--config src-tauri/tauri.release.conf.json"
+          fi
+          cargo tauri build --verbose --bundles ${{ matrix.bundles }} $extra_args
         env:
           TAURI_BUNDLER_NEW_APPIMAGE_FORMAT: true
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
 
       # Build step - Windows CI
       - name: Build (Windows CI)
@@ -156,7 +169,7 @@ jobs:
 
       - name: Build (Windows Release with signing)
         if: matrix.platform == 'windows' && github.event_name == 'workflow_run'
-        run: cargo tauri build
+        run: cargo tauri build --config src-tauri/tauri.release.conf.json
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
@@ -168,7 +181,7 @@ jobs:
 
       - name: Build (macOS Release with signing)
         if: matrix.platform == 'macos' && github.event_name == 'workflow_run'
-        run: cargo tauri build ${{ matrix.rust_target && format('--target {0}', matrix.rust_target) || '' }}
+        run: cargo tauri build ${{ matrix.rust_target && format('--target {0}', matrix.rust_target) || '' }} --config src-tauri/tauri.release.conf.json
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -176,6 +189,8 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
 
       # The sharun-based AppImage format uses DwarFS and does not include Tauri
       # resources. The build leaves the AppDir intact, so we inject Python into
@@ -221,6 +236,45 @@ jobs:
           # Clean up
           rm -f runtime.bin new.dwarfs mkdwarfs
 
+      # The .AppImage.sig produced by `cargo tauri build` was signed before the
+      # Python bundle was injected and the file repacked, so it's stale. Re-sign
+      # the final AppImage so the Tauri updater can verify it.
+      - name: Re-sign AppImage for updater
+        if: contains(matrix.bundles, 'appimage') && github.event_name == 'workflow_run'
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          APPIMAGE=$(find src-tauri/target/release/bundle/appimage -name "*.AppImage" | head -1)
+          cargo tauri signer sign \
+            --private-key "$TAURI_SIGNING_PRIVATE_KEY" \
+            --password "$TAURI_SIGNING_PRIVATE_KEY_PASSWORD" \
+            "$APPIMAGE"
+          echo "Signed: $APPIMAGE"
+          ls -la "${APPIMAGE}.sig"
+
+      # The macOS updater format is .app.tar.gz, which Tauri names after the
+      # product (no version or arch). Rename per-arch so the two macOS jobs'
+      # uploads don't collide on the release.
+      - name: Stage macOS updater artifact
+        if: matrix.platform == 'macos' && github.event_name == 'workflow_run'
+        shell: bash
+        run: |
+          set -euo pipefail
+          bundle_dir="src-tauri/target/${{ matrix.rust_target && format('{0}/', matrix.rust_target) || '' }}release/bundle/macos"
+          arch="${{ matrix.target == 'macos-arm64' && 'aarch64' || 'x64' }}"
+          shopt -s nullglob
+          for f in "$bundle_dir"/*.app.tar.gz; do
+            base="$(basename "$f" .app.tar.gz)"
+            new="$bundle_dir/${base}_${arch}.app.tar.gz"
+            mv "$f" "$new"
+            if [[ -f "${f}.sig" ]]; then
+              mv "${f}.sig" "${new}.sig"
+            fi
+            echo "Staged: $new"
+          done
+
       # Upload artifacts
       - name: Upload NSIS
         if: contains(matrix.bundles, 'nsis')
@@ -229,11 +283,25 @@ jobs:
           path: src-tauri/target/release/bundle/nsis/*.exe
           archive: false
 
+      - name: Upload NSIS updater signature
+        if: contains(matrix.bundles, 'nsis') && github.event_name == 'workflow_run'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          path: src-tauri/target/release/bundle/nsis/*.exe.sig
+          archive: false
+
       - name: Upload AppImage
         if: contains(matrix.bundles, 'appimage')
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           path: src-tauri/target/release/bundle/appimage/*.AppImage
+          archive: false
+
+      - name: Upload AppImage updater signature
+        if: contains(matrix.bundles, 'appimage') && github.event_name == 'workflow_run'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          path: src-tauri/target/release/bundle/appimage/*.AppImage.sig
           archive: false
 
       - name: Upload deb
@@ -255,6 +323,15 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           path: src-tauri/target/${{ matrix.rust_target && format('{0}/', matrix.rust_target) || '' }}release/bundle/dmg/*.dmg
+          archive: false
+
+      - name: Upload macOS updater bundle
+        if: matrix.platform == 'macos' && github.event_name == 'workflow_run'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          path: |
+            src-tauri/target/${{ matrix.rust_target && format('{0}/', matrix.rust_target) || '' }}release/bundle/macos/*.app.tar.gz
+            src-tauri/target/${{ matrix.rust_target && format('{0}/', matrix.rust_target) || '' }}release/bundle/macos/*.app.tar.gz.sig
           archive: false
 
   # Persist PR metadata so the companion "PR Comment" workflow (which runs
@@ -286,6 +363,14 @@ jobs:
       contents: write
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Only need the JSON Schema for latest.json validation; skip LFS / submodules.
+          sparse-checkout: |
+            .github/latest.schema.json
+          sparse-checkout-cone-mode: false
+
       - name: Find draft release
         id: find-release
         env:
@@ -336,6 +421,94 @@ jobs:
             echo "Uploading: $file"
             gh release upload "$tag" "$file" --repo "${{ github.repository }}" --clobber
           done
+
+      # Build the Tauri updater manifest from the per-platform .sig files now
+      # attached to the draft release, then upload it as latest.json. The app's
+      # updater plugin fetches this from
+      # https://github.com/<repo>/releases/latest/download/latest.json once the
+      # release is published.
+      - name: Generate latest.json for updater
+        shell: python
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.find-release.outputs.tag_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          import json
+          import os
+          import re
+          import subprocess
+          import sys
+          from datetime import datetime, timezone
+          from pathlib import Path
+
+          tag = os.environ['TAG']
+          repo = os.environ['REPO']
+          version = tag.lstrip('v')
+
+          release = json.loads(subprocess.check_output([
+              'gh', 'release', 'view', tag, '--repo', repo,
+              '--json', 'body,publishedAt,assets',
+          ], text=True))
+
+          assets_by_name = {a['name']: a for a in release.get('assets', [])}
+
+          # Each entry: (Tauri updater target, regex matching the .sig asset name)
+          platform_matchers = [
+              ('windows-x86_64', re.compile(r'.+-setup\.exe\.sig$')),
+              ('linux-x86_64',   re.compile(r'.+_amd64\.AppImage\.sig$')),
+              ('linux-aarch64',  re.compile(r'.+_aarch64\.AppImage\.sig$')),
+              ('darwin-aarch64', re.compile(r'.+_aarch64\.app\.tar\.gz\.sig$')),
+              ('darwin-x86_64',  re.compile(r'.+_x64\.app\.tar\.gz\.sig$')),
+          ]
+
+          platforms = {}
+          for plat, regex in platform_matchers:
+              candidates = [a for a in assets_by_name.values() if regex.match(a['name'])]
+              if not candidates:
+                  print(f'::warning::No signature asset found for {plat}', file=sys.stderr)
+                  continue
+              sig_asset = candidates[0]
+              bin_name = sig_asset['name'][:-len('.sig')]
+              bin_asset = assets_by_name.get(bin_name)
+              if not bin_asset:
+                  print(f'::warning::No matching binary asset for {sig_asset["name"]}', file=sys.stderr)
+                  continue
+              sig_files = list(Path('artifacts').rglob(sig_asset['name']))
+              if not sig_files:
+                  print(f'::warning::Signature file not found locally: {sig_asset["name"]}', file=sys.stderr)
+                  continue
+              signature = sig_files[0].read_text().strip()
+              platforms[plat] = {
+                  'signature': signature,
+                  'url': bin_asset['url'],
+              }
+
+          pub_date = release.get('publishedAt') or datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+
+          manifest = {
+              'version': version,
+              'notes': release.get('body') or '',
+              'pub_date': pub_date,
+              'platforms': platforms,
+          }
+
+          Path('latest.json').write_text(json.dumps(manifest, indent=2))
+          print(json.dumps(manifest, indent=2))
+
+      - name: Validate latest.json against schema
+        run: |
+          set -euo pipefail
+          pip install --quiet check-jsonschema
+          check-jsonschema --schemafile .github/latest.schema.json latest.json
+
+      - name: Upload latest.json to draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          tag="${{ steps.find-release.outputs.tag_name }}"
+          gh release upload "$tag" latest.json --repo "${{ github.repository }}" --clobber
 
       - name: Remove assets-pending warning from release body
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -422,79 +422,17 @@ jobs:
             gh release upload "$tag" "$file" --repo "${{ github.repository }}" --clobber
           done
 
-      # Build the Tauri updater manifest from the per-platform .sig files now
-      # attached to the draft release, then upload it as latest.json. The app's
-      # updater plugin fetches this from
-      # https://github.com/<repo>/releases/latest/download/latest.json once the
-      # release is published.
+      # Build latest.json from the per-platform .sig files now attached to
+      # the draft release. See .github/scripts/generate_latest_json.py for
+      # the full manifest shape and the rationale around the `downloads`
+      # section (formats the Tauri updater doesn't ship — .deb, .rpm, .dmg)
+      # and the desktop.esphome.io schema reference.
       - name: Generate latest.json for updater
-        shell: python
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.find-release.outputs.tag_name }}
           REPO: ${{ github.repository }}
-        run: |
-          import json
-          import os
-          import re
-          import subprocess
-          import sys
-          from datetime import datetime, timezone
-          from pathlib import Path
-
-          tag = os.environ['TAG']
-          repo = os.environ['REPO']
-          version = tag.lstrip('v')
-
-          release = json.loads(subprocess.check_output([
-              'gh', 'release', 'view', tag, '--repo', repo,
-              '--json', 'body,publishedAt,assets',
-          ], text=True))
-
-          assets_by_name = {a['name']: a for a in release.get('assets', [])}
-
-          # Each entry: (Tauri updater target, regex matching the .sig asset name)
-          platform_matchers = [
-              ('windows-x86_64', re.compile(r'.+-setup\.exe\.sig$')),
-              ('linux-x86_64',   re.compile(r'.+_amd64\.AppImage\.sig$')),
-              ('linux-aarch64',  re.compile(r'.+_aarch64\.AppImage\.sig$')),
-              ('darwin-aarch64', re.compile(r'.+_aarch64\.app\.tar\.gz\.sig$')),
-              ('darwin-x86_64',  re.compile(r'.+_x64\.app\.tar\.gz\.sig$')),
-          ]
-
-          platforms = {}
-          for plat, regex in platform_matchers:
-              candidates = [a for a in assets_by_name.values() if regex.match(a['name'])]
-              if not candidates:
-                  print(f'::warning::No signature asset found for {plat}', file=sys.stderr)
-                  continue
-              sig_asset = candidates[0]
-              bin_name = sig_asset['name'][:-len('.sig')]
-              bin_asset = assets_by_name.get(bin_name)
-              if not bin_asset:
-                  print(f'::warning::No matching binary asset for {sig_asset["name"]}', file=sys.stderr)
-                  continue
-              sig_files = list(Path('artifacts').rglob(sig_asset['name']))
-              if not sig_files:
-                  print(f'::warning::Signature file not found locally: {sig_asset["name"]}', file=sys.stderr)
-                  continue
-              signature = sig_files[0].read_text().strip()
-              platforms[plat] = {
-                  'signature': signature,
-                  'url': bin_asset['url'],
-              }
-
-          pub_date = release.get('publishedAt') or datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
-
-          manifest = {
-              'version': version,
-              'notes': release.get('body') or '',
-              'pub_date': pub_date,
-              'platforms': platforms,
-          }
-
-          Path('latest.json').write_text(json.dumps(manifest, indent=2))
-          print(json.dumps(manifest, indent=2))
+        run: python3 .github/scripts/generate_latest_json.py
 
       - name: Validate latest.json against schema
         run: |

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -58,6 +58,20 @@ jobs:
           envsubst '$VERSION $TAG' < web/index.html > _site/index.html
           cp src-tauri/icons/128x128.png _site/icon.png
 
+      # Mirror the release manifest to the Pages site so consumers (download
+      # pages, integrations, etc.) can fetch a stable
+      # https://desktop.esphome.io/latest.json without hitting the GitHub
+      # releases API. The schema is published alongside it so the manifest's
+      # `$schema` reference resolves on the same domain.
+      - name: Mirror latest.json + schema to site
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          gh release download "$TAG" --repo "${{ github.repository }}" --pattern latest.json --dir _site --clobber
+          cp .github/latest.schema.json _site/latest.schema.json
+
       - name: Configure Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ A cross-platform desktop application that bundles ESPHome with Python and runs t
 
 - **System Tray Integration**: Runs in the background with a system tray icon
 - **Single-Instance**: Only one instance runs at a time; launching again opens the browser
-- **Auto-Updates**: Checks for ESPHome updates and notifies you
+- **Auto-Updates**: Checks for ESPHome (Python) updates and notifies you
+- **Self-Updating App**: macOS DMG, Windows NSIS, and Linux AppImage installs can update themselves in-place from GitHub Releases
 - **Cross-Platform**: Native installers for macOS (DMG), Windows (NSIS), and Linux (AppImage/deb)
 - **Bundled Python**: Includes a full Python 3.13 runtime - no system Python required
 
@@ -49,7 +50,8 @@ Right-click (or left-click on some platforms) the tray icon to access:
 - **Open Dashboard** - Open the dashboard in your browser
 - **Status** - Shows if the daemon is running
 - **Port** - Shows the configured port
-- **Check for Updates** - Check for new ESPHome versions
+- **Check for Updates** - Check for new ESPHome (Python) versions
+- **Check for App Updates** - Check for a new ESPHome Builder desktop release and install it in-place
 - **View Logs** - Open the logs folder
 - **Open Config Folder** - Open where your ESPHome configs are stored
 - **Restart Dashboard** - Restart the ESPHome process
@@ -116,6 +118,19 @@ For development with hot-reload:
 ```bash
 cargo tauri dev
 ```
+
+### Releasing & Self-Update Signing
+
+The desktop app uses `tauri-plugin-updater` to check
+`https://github.com/esphome/esphome-desktop/releases/latest/download/latest.json`
+for new versions and install them in-place. When a release builds via
+`.github/workflows/build.yml`, every supported installer is signed with the
+Tauri Ed25519 key and a `latest.json` manifest is uploaded to the draft
+release. Once the release is published, existing installs pick it up on their
+next update check.
+
+Linux `.deb` / `.rpm` and AUR installs do **not** self-update — those users
+update through their system package manager.
 
 ## Configuration
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -98,6 +98,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -837,6 +846,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1118,6 +1138,7 @@ dependencies = [
  "tauri-plugin-process",
  "tauri-plugin-shell",
  "tauri-plugin-single-instance",
+ "tauri-plugin-updater",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -1169,6 +1190,16 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -2321,6 +2352,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2619,6 +2656,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2700,6 +2749,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2723,6 +2778,20 @@ checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3469,15 +3538,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3570,6 +3644,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3578,6 +3664,33 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -3609,6 +3722,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3667,6 +3789,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -4235,6 +4380,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4475,6 +4631,39 @@ dependencies = [
  "tracing",
  "windows-sys 0.60.2",
  "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest 0.13.1",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
 ]
 
 [[package]]
@@ -5399,6 +5588,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6040,6 +6238,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6201,6 +6409,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.13.0",
+ "memchr",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,6 +23,7 @@ tauri-plugin-single-instance = "2"
 tauri-plugin-notification = "2"
 tauri-plugin-process = "2"
 tauri-plugin-dialog = "2"
+tauri-plugin-updater = "2"
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }

--- a/src-tauri/src/app_update/mod.rs
+++ b/src-tauri/src/app_update/mod.rs
@@ -1,0 +1,252 @@
+//! Desktop application self-updater.
+//!
+//! Wraps `tauri-plugin-updater` to check GitHub Releases for a new version
+//! of the ESPHome Builder desktop app itself (not the bundled ESPHome
+//! Python package — that lives in [`crate::update`]).
+//!
+//! The app self-update ships with a fresh Python bundle (ESPHome and
+//! `esphome-device-builder` pre-installed at build time). Installing it
+//! overwrites the user's `python/` directory, wiping any pip-installed
+//! version bumps. The check helpers here return [`NextStep`] so callers
+//! that orchestrate the full app → ESPHome → device-builder sequence can
+//! skip the Python-package checks when the app itself is about to roll.
+
+use std::time::Duration;
+
+use tauri::AppHandle;
+use tauri_plugin_dialog::{DialogExt, MessageDialogKind};
+use tauri_plugin_notification::NotificationExt;
+use tauri_plugin_updater::UpdaterExt;
+use tracing::{debug, error, info, warn};
+
+/// Whether the orchestrator should proceed to check the Python packages
+/// (`esphome` / `esphome-device-builder`) after the desktop self-update
+/// check completes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NextStep {
+    /// Carry on with ESPHome / device-builder checks.
+    Continue,
+    /// Stop — an app update is pending or actively installing, and pip-installing
+    /// a Python-package update right now would just get overwritten by the new
+    /// bundled Python on the next launch.
+    Skip,
+}
+
+/// User-initiated app-update check. Always shows the "update available" dialog;
+/// the "you're up to date" dialog is only shown when `show_no_update_dialog`
+/// is true, so chained callers ("Check for Updates") can stay quiet and fall
+/// through to the ESPHome check instead. Errors are always surfaced.
+pub async fn check_for_user(app_handle: &AppHandle, show_no_update_dialog: bool) -> NextStep {
+    let updater = match app_handle.updater() {
+        Ok(u) => u,
+        Err(e) => {
+            warn!("Updater not available: {}", e);
+            show_error(app_handle, format!("Updater not available: {}", e)).await;
+            return NextStep::Continue;
+        }
+    };
+
+    match updater.check().await {
+        Ok(Some(update)) => {
+            info!(
+                "Desktop update available: {} (current: {})",
+                update.version, update.current_version
+            );
+
+            let new_version = update.version.clone();
+            let current_version = update.current_version.clone();
+            let notes = update.body.clone().unwrap_or_default();
+
+            let dialog_app = app_handle.clone();
+            let msg = format_update_prompt(&current_version, &new_version, &notes);
+            let confirmed = tokio::task::spawn_blocking(move || {
+                dialog_app
+                    .dialog()
+                    .message(msg)
+                    .title("Desktop Update Available")
+                    .buttons(tauri_plugin_dialog::MessageDialogButtons::OkCancelCustom(
+                        "Update Now".to_string(),
+                        "Later".to_string(),
+                    ))
+                    .blocking_show()
+            })
+            .await
+            .unwrap_or(false);
+
+            if !confirmed {
+                // User saw the dialog and declined — fall through to ESPHome check.
+                return NextStep::Continue;
+            }
+
+            apply_update(app_handle, update).await;
+            // The install completed (or failed and surfaced an error). Either
+            // way, do NOT proceed to ESPHome — on success the new bundled Python
+            // will replace ours; on failure the user is in a state we shouldn't
+            // compound with more pip activity.
+            NextStep::Skip
+        }
+        Ok(None) => {
+            let current = app_handle.package_info().version.to_string();
+            info!("Desktop app is up to date ({})", current);
+            if show_no_update_dialog {
+                let dialog_app = app_handle.clone();
+                let msg = format!("ESPHome Builder {} is the latest version.", current);
+                let _ = tokio::task::spawn_blocking(move || {
+                    dialog_app
+                        .dialog()
+                        .message(msg)
+                        .kind(MessageDialogKind::Info)
+                        .title("No Updates Available")
+                        .blocking_show();
+                })
+                .await;
+            }
+            NextStep::Continue
+        }
+        Err(e) => {
+            warn!("Desktop update check failed: {}", e);
+            show_error(app_handle, format!("Failed to check for updates: {}", e)).await;
+            NextStep::Continue
+        }
+    }
+}
+
+/// Background check. Only surfaces a notification when a new version is
+/// available; stays silent for "no update" and for errors. Returns
+/// [`NextStep::Skip`] when an update is available so the background loop
+/// can skip the Python-package checks until the user installs.
+pub async fn check_and_notify(app_handle: &AppHandle) -> NextStep {
+    let updater = match app_handle.updater() {
+        Ok(u) => u,
+        Err(e) => {
+            debug!("Updater not available for background check: {}", e);
+            return NextStep::Continue;
+        }
+    };
+
+    match updater.check().await {
+        Ok(Some(update)) => {
+            info!(
+                "Desktop update available in background: {} (current: {})",
+                update.version, update.current_version
+            );
+            if let Err(e) = app_handle
+                .notification()
+                .builder()
+                .title("ESPHome Builder Update Available")
+                .body(format!(
+                    "Version {} is available (you have {}). Open the tray menu and choose \"Check for App Updates…\" to install.",
+                    update.version, update.current_version
+                ))
+                .show()
+            {
+                error!("Failed to show desktop-update notification: {}", e);
+            }
+            NextStep::Skip
+        }
+        Ok(None) => {
+            debug!("Desktop app is up to date (background check)");
+            NextStep::Continue
+        }
+        Err(e) => {
+            debug!("Background desktop update check failed: {}", e);
+            NextStep::Continue
+        }
+    }
+}
+
+/// Download and install the given update, then prompt the user to restart.
+async fn apply_update(app_handle: &AppHandle, update: tauri_plugin_updater::Update) {
+    let new_version = update.version.clone();
+
+    let mut downloaded: u64 = 0;
+    let mut last_logged = std::time::Instant::now();
+    let result = update
+        .download_and_install(
+            move |chunk, total| {
+                downloaded = downloaded.saturating_add(chunk as u64);
+                // Throttle progress logs to once per second.
+                if last_logged.elapsed() >= Duration::from_secs(1) {
+                    if let Some(total) = total {
+                        info!(
+                            "Downloading desktop update: {}/{} bytes",
+                            downloaded, total
+                        );
+                    } else {
+                        info!("Downloading desktop update: {} bytes", downloaded);
+                    }
+                    last_logged = std::time::Instant::now();
+                }
+            },
+            || info!("Desktop update download complete; installing…"),
+        )
+        .await;
+
+    match result {
+        Ok(()) => {
+            info!("Desktop update {} installed", new_version);
+            let dialog_app = app_handle.clone();
+            let msg = format!(
+                "ESPHome Builder {} has been installed.\n\nRestart now to use the new version?",
+                new_version
+            );
+            let restart = tokio::task::spawn_blocking(move || {
+                dialog_app
+                    .dialog()
+                    .message(msg)
+                    .title("Update Installed")
+                    .buttons(tauri_plugin_dialog::MessageDialogButtons::OkCancelCustom(
+                        "Restart Now".to_string(),
+                        "Later".to_string(),
+                    ))
+                    .blocking_show()
+            })
+            .await
+            .unwrap_or(false);
+
+            if restart {
+                info!("Restarting to apply desktop update");
+                app_handle.restart();
+            }
+        }
+        Err(e) => {
+            error!("Desktop update install failed: {}", e);
+            show_error(app_handle, format!("Failed to install update: {}", e)).await;
+        }
+    }
+}
+
+async fn show_error(app_handle: &AppHandle, msg: String) {
+    let dialog_app = app_handle.clone();
+    let _ = tokio::task::spawn_blocking(move || {
+        dialog_app
+            .dialog()
+            .message(msg)
+            .kind(MessageDialogKind::Error)
+            .title("Update Check Failed")
+            .blocking_show();
+    })
+    .await;
+}
+
+fn format_update_prompt(current: &str, new: &str, notes: &str) -> String {
+    let trimmed_notes = notes.trim();
+    if trimmed_notes.is_empty() {
+        format!(
+            "ESPHome Builder {} is available.\n\nYou currently have version {}.\n\nWould you like to download and install it now?",
+            new, current
+        )
+    } else {
+        // Keep release notes short in the dialog so it doesn't grow off-screen.
+        let preview: String = trimmed_notes.chars().take(800).collect();
+        let elided = if trimmed_notes.chars().count() > 800 {
+            "\n…"
+        } else {
+            ""
+        };
+        format!(
+            "ESPHome Builder {} is available.\n\nYou currently have version {}.\n\nRelease notes:\n{}{}\n\nWould you like to download and install it now?",
+            new, current, preview, elided
+        )
+    }
+}

--- a/src-tauri/src/app_update/mod.rs
+++ b/src-tauri/src/app_update/mod.rs
@@ -135,7 +135,7 @@ pub async fn check_and_notify(app_handle: &AppHandle) -> NextStep {
                 .builder()
                 .title("ESPHome Builder Update Available")
                 .body(format!(
-                    "Version {} is available (you have {}). Open the tray menu and choose \"Check for App Updates…\" to install.",
+                    "Version {} is available (you have {}). Open the tray menu and choose \"Check for App Updates...\" to install.",
                     update.version, update.current_version
                 ))
                 .show()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@
 //! A cross-platform desktop application that manages ESPHome as a background daemon
 //! with system tray integration.
 
+mod app_update;
 mod daemon;
 mod platform;
 mod settings;
@@ -152,6 +153,7 @@ pub fn run(cli: Cli) {
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_single_instance::init(|app, args, cwd| {
             // Another instance tried to start - open the dashboard instead
             info!(
@@ -295,8 +297,13 @@ pub fn run(cli: Cli) {
             });
 
             // Start update checker (check after 30s, then every 24 hours)
-            // The dev channel skips automatic update checks entirely.
-            // When the active backend is a builder variant, the
+            // Order matters: check the desktop app first. A self-update ships
+            // a fresh Python bundle that overwrites the user's `python/`
+            // directory, so any pip-installed ESPHome / device-builder bump
+            // we'd do now would be wiped by the next launch. Skip the Python
+            // checks while an app update is pending.
+            // The dev channel skips automatic update checks entirely. When
+            // the active backend is a builder variant, the
             // `esphome-device-builder` package is checked on the same schedule.
             let update_state = state.clone();
             let update_app = app.handle().clone();
@@ -305,6 +312,11 @@ pub fn run(cli: Cli) {
                 let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(86400));
                 loop {
                     interval.tick().await;
+                    if app_update::check_and_notify(&update_app).await == app_update::NextStep::Skip
+                    {
+                        // App update pending — leave the Python packages alone.
+                        continue;
+                    }
                     let (channel, backend) = {
                         let settings = update_state.settings.read().await;
                         (settings.release_channel, settings.backend)

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -310,10 +310,11 @@ fn restore_preserved_versions(python_bin: &Path, preserved: &PreservedVersions) 
 /// Returns `None` if the package isn't installed or the call fails.
 #[cfg(not(target_os = "windows"))]
 fn read_package_version(python_bin: &Path, package: &str) -> Option<String> {
+    // Written as a single-line literal with explicit `\n` so each Python
+    // statement starts at column zero — avoids any ambiguity about whether
+    // a Rust line-continuation strips the source-line indentation.
     let script = format!(
-        "from importlib.metadata import version, PackageNotFoundError\n\
-         try: print(version('{}'))\n\
-         except PackageNotFoundError: pass",
+        "from importlib.metadata import version, PackageNotFoundError\ntry: print(version('{}'))\nexcept PackageNotFoundError: pass",
         package
     );
     let mut cmd = std::process::Command::new(python_bin);
@@ -331,20 +332,58 @@ fn read_package_version(python_bin: &Path, package: &str) -> Option<String> {
     }
 }
 
-/// Synchronously run `pip install <package>==<version>`. Pinning the exact
-/// version lets pip resolve pre-releases without needing `--pre`.
+/// Hard upper bound on a single `pip install` invocation during the
+/// version-restore path. Five minutes is well over the time needed to
+/// upgrade `esphome` on a working connection; bounding it prevents a
+/// stalled network from hanging app startup indefinitely.
+#[cfg(not(target_os = "windows"))]
+const PIP_INSTALL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
+
+/// Synchronously run `pip install <package>==<version>` with a wall-clock
+/// timeout. Pinning the exact version lets pip resolve pre-releases without
+/// needing `--pre`. On timeout the child is killed and an error is returned;
+/// the caller logs a warning and falls back to the bundled version, so a
+/// stalled pip can't block app launch.
 #[cfg(not(target_os = "windows"))]
 fn pip_install_blocking(python_bin: &Path, package: &str, version: &str) -> Result<()> {
+    use std::io::Read;
+    use std::time::{Duration, Instant};
+
     let spec = format!("{}=={}", package, version);
     let mut cmd = std::process::Command::new(python_bin);
     cmd.args(["-m", "pip", "install", &spec]);
+    cmd.stderr(std::process::Stdio::piped());
     configure_no_window_command(&mut cmd);
-    let output = cmd.output().context("Failed to run pip install")?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("pip install {} failed: {}", spec, stderr.trim());
+
+    let mut child = cmd.spawn().context("Failed to spawn pip install")?;
+    let deadline = Instant::now() + PIP_INSTALL_TIMEOUT;
+
+    loop {
+        match child.try_wait().context("Failed to poll pip install")? {
+            Some(status) => {
+                if status.success() {
+                    return Ok(());
+                }
+                let mut stderr = String::new();
+                if let Some(mut err) = child.stderr.take() {
+                    let _ = err.read_to_string(&mut stderr);
+                }
+                anyhow::bail!("pip install {} failed: {}", spec, stderr.trim());
+            }
+            None => {
+                if Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    anyhow::bail!(
+                        "pip install {} timed out after {:?}",
+                        spec,
+                        PIP_INSTALL_TIMEOUT
+                    );
+                }
+                std::thread::sleep(Duration::from_millis(500));
+            }
+        }
     }
-    Ok(())
 }
 
 /// Recursively copy a directory

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -358,15 +358,28 @@ fn pip_install_blocking(python_bin: &Path, package: &str, version: &str) -> Resu
     let mut child = cmd.spawn().context("Failed to spawn pip install")?;
     let deadline = Instant::now() + PIP_INSTALL_TIMEOUT;
 
+    // Drain stderr in a background thread. pip's progress bars and resolver
+    // diagnostics can easily exceed the OS pipe buffer (~64 KiB on Linux);
+    // if nothing reads the parent's end, pip blocks on `write()` mid-install,
+    // which would defeat the deadline and hang startup. The reader exits
+    // naturally once the child closes its stderr fd (normal exit or kill).
+    let mut stderr_thread = child.stderr.take().map(|mut handle| {
+        std::thread::spawn(move || {
+            let mut buf = String::new();
+            let _ = handle.read_to_string(&mut buf);
+            buf
+        })
+    });
+
     loop {
         match child.try_wait().context("Failed to poll pip install")? {
             Some(status) => {
+                let stderr = stderr_thread
+                    .take()
+                    .and_then(|t| t.join().ok())
+                    .unwrap_or_default();
                 if status.success() {
                     return Ok(());
-                }
-                let mut stderr = String::new();
-                if let Some(mut err) = child.stderr.take() {
-                    let _ = err.read_to_string(&mut stderr);
                 }
                 anyhow::bail!("pip install {} failed: {}", spec, stderr.trim());
             }
@@ -374,10 +387,15 @@ fn pip_install_blocking(python_bin: &Path, package: &str, version: &str) -> Resu
                 if Instant::now() >= deadline {
                     let _ = child.kill();
                     let _ = child.wait();
+                    let stderr = stderr_thread
+                        .take()
+                        .and_then(|t| t.join().ok())
+                        .unwrap_or_default();
                     anyhow::bail!(
-                        "pip install {} timed out after {:?}",
+                        "pip install {} timed out after {:?}; partial stderr: {}",
                         spec,
-                        PIP_INSTALL_TIMEOUT
+                        PIP_INSTALL_TIMEOUT,
+                        stderr.trim()
                     );
                 }
                 std::thread::sleep(Duration::from_millis(500));

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -339,6 +339,33 @@ fn read_package_version(python_bin: &Path, package: &str) -> Option<String> {
 #[cfg(not(target_os = "windows"))]
 const PIP_INSTALL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
 
+/// Maximum length of pip stderr included in a failure error message. pip's
+/// resolver and progress output can run to many kilobytes; the actionable
+/// failure reason is almost always at the tail, so we truncate to the last
+/// N bytes to keep log lines (and downstream UI surfaces) bounded.
+#[cfg(not(target_os = "windows"))]
+const PIP_STDERR_TAIL_BYTES: usize = 4096;
+
+/// Return `s` trimmed and truncated to the last [`PIP_STDERR_TAIL_BYTES`]
+/// bytes, with a marker line if anything was dropped. Backs up to a UTF-8
+/// char boundary so the result is always valid `str`.
+#[cfg(not(target_os = "windows"))]
+fn tail_for_log(s: &str) -> String {
+    let trimmed = s.trim();
+    if trimmed.len() <= PIP_STDERR_TAIL_BYTES {
+        return trimmed.to_string();
+    }
+    let mut start = trimmed.len() - PIP_STDERR_TAIL_BYTES;
+    while start < trimmed.len() && !trimmed.is_char_boundary(start) {
+        start += 1;
+    }
+    format!(
+        "...(stderr truncated to last {} bytes)\n{}",
+        PIP_STDERR_TAIL_BYTES,
+        &trimmed[start..]
+    )
+}
+
 /// Synchronously run `pip install <package>==<version>` with a wall-clock
 /// timeout. Pinning the exact version lets pip resolve pre-releases without
 /// needing `--pre`. On timeout the child is killed and an error is returned;
@@ -381,7 +408,7 @@ fn pip_install_blocking(python_bin: &Path, package: &str, version: &str) -> Resu
                 if status.success() {
                     return Ok(());
                 }
-                anyhow::bail!("pip install {} failed: {}", spec, stderr.trim());
+                anyhow::bail!("pip install {} failed: {}", spec, tail_for_log(&stderr));
             }
             None => {
                 if Instant::now() >= deadline {
@@ -395,7 +422,7 @@ fn pip_install_blocking(python_bin: &Path, package: &str, version: &str) -> Resu
                         "pip install {} timed out after {:?}; partial stderr: {}",
                         spec,
                         PIP_INSTALL_TIMEOUT,
-                        stderr.trim()
+                        tail_for_log(&stderr)
                     );
                 }
                 std::thread::sleep(Duration::from_millis(500));

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -5,7 +5,7 @@
 #![allow(dead_code)]
 
 use anyhow::{Context, Result};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tauri::{AppHandle, Manager};
 use tracing::debug;
 
@@ -210,6 +210,23 @@ pub fn ensure_user_python(app_handle: &AppHandle) -> Result<()> {
                 anyhow::bail!("Bundled Python not found at {:?}", bundled_python);
             }
 
+            // Snapshot the user's pre-existing package versions BEFORE the
+            // wipe so we can restore them after the bundled tree is in place.
+            // Without this, a user who pip-bumped ESPHome past the bundled
+            // version would silently get downgraded by every app self-update.
+            let preserved = if python_check.exists() {
+                let old_python_bin = python_check.clone();
+                PreservedVersions {
+                    esphome: read_package_version(&old_python_bin, "esphome"),
+                    esphome_device_builder: read_package_version(
+                        &old_python_bin,
+                        "esphome-device-builder",
+                    ),
+                }
+            } else {
+                PreservedVersions::default()
+            };
+
             if user_python.exists() {
                 info!(
                     "Removing stale user Python at {:?} (version marker missing or mismatched)",
@@ -230,6 +247,8 @@ pub fn ensure_user_python(app_handle: &AppHandle) -> Result<()> {
             std::fs::write(&marker_path, current_version)
                 .context("Failed to write Python version marker")?;
 
+            restore_preserved_versions(&python_check, &preserved);
+
             info!("User Python ready at {:?}", user_python);
         } else {
             debug!("User Python already up-to-date (version {})", current_version);
@@ -237,6 +256,95 @@ pub fn ensure_user_python(app_handle: &AppHandle) -> Result<()> {
 
         Ok(())
     }
+}
+
+/// User-preferred package versions captured before the bundled Python tree
+/// is wiped during an app-version refresh. See [`ensure_user_python`].
+#[derive(Debug, Default)]
+struct PreservedVersions {
+    esphome: Option<String>,
+    esphome_device_builder: Option<String>,
+}
+
+/// Reinstall any preserved package whose pinned version is newer than the
+/// version that just shipped in the new bundled Python tree. Bundled wins
+/// for ties and for when bundled is newer (so users always benefit from the
+/// app's fresher bundle when they haven't explicitly bumped past it). Each
+/// reinstall is best-effort — a network failure here logs a warning and
+/// falls through to the bundled version rather than blocking app start.
+#[cfg(not(target_os = "windows"))]
+fn restore_preserved_versions(python_bin: &Path, preserved: &PreservedVersions) {
+    use tracing::{info, warn};
+
+    for (package, saved) in [
+        ("esphome", preserved.esphome.as_deref()),
+        ("esphome-device-builder", preserved.esphome_device_builder.as_deref()),
+    ] {
+        let Some(saved) = saved else { continue };
+        let Some(bundled) = read_package_version(python_bin, package) else {
+            // Package isn't in the bundled tree (shouldn't happen for these
+            // two, but don't fight it). Skip the restore.
+            continue;
+        };
+        if !crate::update::is_newer_version(saved, &bundled) {
+            debug!(
+                "Bundled {} {} satisfies user preference {}; not reinstalling",
+                package, bundled, saved
+            );
+            continue;
+        }
+        info!(
+            "Restoring user-preferred {} {} over bundled {}",
+            package, saved, bundled
+        );
+        if let Err(e) = pip_install_blocking(python_bin, package, saved) {
+            warn!(
+                "Failed to restore {} {}: {}. Continuing with bundled {}.",
+                package, saved, e, bundled
+            );
+        }
+    }
+}
+
+/// Read the installed version of a Python package via `importlib.metadata`.
+/// Returns `None` if the package isn't installed or the call fails.
+#[cfg(not(target_os = "windows"))]
+fn read_package_version(python_bin: &Path, package: &str) -> Option<String> {
+    let script = format!(
+        "from importlib.metadata import version, PackageNotFoundError\n\
+         try: print(version('{}'))\n\
+         except PackageNotFoundError: pass",
+        package
+    );
+    let mut cmd = std::process::Command::new(python_bin);
+    cmd.args(["-c", &script]);
+    configure_no_window_command(&mut cmd);
+    let output = cmd.output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let v = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if v.is_empty() {
+        None
+    } else {
+        Some(v)
+    }
+}
+
+/// Synchronously run `pip install <package>==<version>`. Pinning the exact
+/// version lets pip resolve pre-releases without needing `--pre`.
+#[cfg(not(target_os = "windows"))]
+fn pip_install_blocking(python_bin: &Path, package: &str, version: &str) -> Result<()> {
+    let spec = format!("{}=={}", package, version);
+    let mut cmd = std::process::Command::new(python_bin);
+    cmd.args(["-m", "pip", "install", &spec]);
+    configure_no_window_command(&mut cmd);
+    let output = cmd.output().context("Failed to run pip install")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("pip install {} failed: {}", spec, stderr.trim());
+    }
+    Ok(())
 }
 
 /// Recursively copy a directory

--- a/src-tauri/src/tray/mod.rs
+++ b/src-tauri/src/tray/mod.rs
@@ -23,6 +23,7 @@ mod ids {
     pub const VERSION: &str = "version";
     pub const PORT: &str = "port";
     pub const CHECK_UPDATES: &str = "check_updates";
+    pub const CHECK_APP_UPDATES: &str = "check_app_updates";
     pub const VIEW_LOGS: &str = "view_logs";
     pub const OPEN_CONFIG: &str = "open_config";
     pub const RESTART: &str = "restart";
@@ -138,6 +139,10 @@ pub fn build_tray_menu(app_handle: &AppHandle, state: &Arc<AppState>) -> Result<
         .item(&channel_submenu)
         .item(
             &MenuItemBuilder::with_id(ids::CHECK_UPDATES, "Check for Updates...")
+                .build(app_handle)?,
+        )
+        .item(
+            &MenuItemBuilder::with_id(ids::CHECK_APP_UPDATES, "Check for App Updates...")
                 .build(app_handle)?,
         )
         .separator()
@@ -269,6 +274,17 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>, _a
             let state = state.clone();
             let app = app_handle.clone();
             async_runtime::spawn(async move {
+                // Always check the desktop app first. Installing a self-update
+                // replaces the bundled `python/` directory, which would wipe
+                // any pip bump we do here. If the user accepts the app update
+                // (or it errors mid-install), skip the Python checks; if they
+                // decline or there's no app update, fall through.
+                if crate::app_update::check_for_user(&app, false).await
+                    == crate::app_update::NextStep::Skip
+                {
+                    return;
+                }
+
                 let (channel, backend) = {
                     let settings = state.settings.read().await;
                     (settings.release_channel, settings.backend)
@@ -469,6 +485,14 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>, _a
                         }
                     }
                 }
+            });
+        }
+        ids::CHECK_APP_UPDATES => {
+            let app = app_handle.clone();
+            async_runtime::spawn(async move {
+                // Verbose mode: this menu item is app-only, so surface "no
+                // updates available" feedback too.
+                crate::app_update::check_for_user(&app, true).await;
             });
         }
         ids::CHANNEL_STABLE | ids::CHANNEL_BETA | ids::CHANNEL_DEV => {

--- a/src-tauri/src/update/mod.rs
+++ b/src-tauri/src/update/mod.rs
@@ -766,7 +766,7 @@ fn parse_version(s: &str) -> Vec<(u32, u8, u32)> {
 }
 
 /// Compare two version strings and return true if `latest` is newer than `installed`
-pub fn is_newer_version(latest: &str, installed: &str) -> bool {
+pub(crate) fn is_newer_version(latest: &str, installed: &str) -> bool {
     let latest_parts = parse_version(latest);
     let installed_parts = parse_version(installed);
 

--- a/src-tauri/src/update/mod.rs
+++ b/src-tauri/src/update/mod.rs
@@ -766,7 +766,7 @@ fn parse_version(s: &str) -> Vec<(u32, u8, u32)> {
 }
 
 /// Compare two version strings and return true if `latest` is newer than `installed`
-fn is_newer_version(latest: &str, installed: &str) -> bool {
+pub fn is_newer_version(latest: &str, installed: &str) -> bool {
     let latest_parts = parse_version(latest);
     let installed_parts = parse_version(installed);
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -49,6 +49,15 @@
   "plugins": {
     "shell": {
       "open": true
+    },
+    "updater": {
+      "endpoints": [
+        "https://github.com/esphome/esphome-desktop/releases/latest/download/latest.json"
+      ],
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEI3MDI1M0QwQTJFNTc2QkEKUldTNmR1V2kwRk1DdHcwMnBvb1E1eEFOQUVHK1k0MXRLMUFzUzZQZWUwZVpVWHYxVXRJM2xTTEgK",
+      "windows": {
+        "installMode": "passive"
+      }
     }
   }
 }

--- a/src-tauri/tauri.release.conf.json
+++ b/src-tauri/tauri.release.conf.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "bundle": {
+    "createUpdaterArtifacts": true
+  }
+}

--- a/tests/fixtures/artifacts/ESPHome Builder_0.10.0_aarch64.AppImage.sig
+++ b/tests/fixtures/artifacts/ESPHome Builder_0.10.0_aarch64.AppImage.sig
@@ -1,0 +1,2 @@
+untrusted comment: placeholder fixture signature for ESPHome Builder_0.10.0_aarch64.AppImage.sig
+FIXTUREONLYxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx==

--- a/tests/fixtures/artifacts/ESPHome Builder_0.10.0_amd64.AppImage.sig
+++ b/tests/fixtures/artifacts/ESPHome Builder_0.10.0_amd64.AppImage.sig
@@ -1,0 +1,2 @@
+untrusted comment: placeholder fixture signature for ESPHome Builder_0.10.0_amd64.AppImage.sig
+FIXTUREONLYxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx==

--- a/tests/fixtures/artifacts/ESPHome Builder_0.10.0_x64-setup.exe.sig
+++ b/tests/fixtures/artifacts/ESPHome Builder_0.10.0_x64-setup.exe.sig
@@ -1,0 +1,2 @@
+untrusted comment: placeholder fixture signature for ESPHome Builder_0.10.0_x64-setup.exe.sig
+FIXTUREONLYxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx==

--- a/tests/fixtures/artifacts/ESPHome Builder_aarch64.app.tar.gz.sig
+++ b/tests/fixtures/artifacts/ESPHome Builder_aarch64.app.tar.gz.sig
@@ -1,0 +1,2 @@
+untrusted comment: placeholder fixture signature for ESPHome Builder_aarch64.app.tar.gz.sig
+FIXTUREONLYxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx==

--- a/tests/fixtures/artifacts/ESPHome Builder_x64.app.tar.gz.sig
+++ b/tests/fixtures/artifacts/ESPHome Builder_x64.app.tar.gz.sig
@@ -1,0 +1,2 @@
+untrusted comment: placeholder fixture signature for ESPHome Builder_x64.app.tar.gz.sig
+FIXTUREONLYxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx==

--- a/tests/fixtures/release.json
+++ b/tests/fixtures/release.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Mock output of `gh release view <tag> --json body,publishedAt,assets`. Used by tests/run_generate_latest_json.sh and as a manual fixture for .github/scripts/generate_latest_json.py. Asset URLs are dot-substituted GitHub release download URLs; sizes are illustrative.",
+  "_comment": "Mock output of `gh release view <tag> --json body,publishedAt,assets`. Used as a manual fixture for `.github/scripts/generate_latest_json.py`. Asset URLs are dot-substituted GitHub release download URLs; sizes are illustrative.",
   "body": "## What's Changed\n\n* Fixture release used to exercise the latest.json generator.\n\n**Full Changelog**: https://github.com/esphome/esphome-desktop/compare/v0.9.0...v0.10.0",
   "publishedAt": "2026-05-22T14:31:08Z",
   "assets": [

--- a/tests/fixtures/release.json
+++ b/tests/fixtures/release.json
@@ -1,0 +1,23 @@
+{
+  "_comment": "Mock output of `gh release view <tag> --json body,publishedAt,assets`. Used by tests/run_generate_latest_json.sh and as a manual fixture for .github/scripts/generate_latest_json.py. Asset URLs are dot-substituted GitHub release download URLs; sizes are illustrative.",
+  "body": "## What's Changed\n\n* Fixture release used to exercise the latest.json generator.\n\n**Full Changelog**: https://github.com/esphome/esphome-desktop/compare/v0.9.0...v0.10.0",
+  "publishedAt": "2026-05-22T14:31:08Z",
+  "assets": [
+    {"name": "ESPHome Builder_0.10.0_x64-setup.exe",         "url": "https://github.com/esphome/esphome-desktop/releases/download/v0.10.0/ESPHome.Builder_0.10.0_x64-setup.exe",         "size": 175342211},
+    {"name": "ESPHome Builder_0.10.0_x64-setup.exe.sig",     "url": "https://github.com/esphome/esphome-desktop/releases/download/v0.10.0/ESPHome.Builder_0.10.0_x64-setup.exe.sig",     "size": 200},
+    {"name": "ESPHome Builder_0.10.0_amd64.AppImage",        "url": "https://github.com/esphome/esphome-desktop/releases/download/v0.10.0/ESPHome.Builder_0.10.0_amd64.AppImage",        "size": 184232123},
+    {"name": "ESPHome Builder_0.10.0_amd64.AppImage.sig",    "url": "https://github.com/esphome/esphome-desktop/releases/download/v0.10.0/ESPHome.Builder_0.10.0_amd64.AppImage.sig",    "size": 200},
+    {"name": "ESPHome Builder_0.10.0_aarch64.AppImage",      "url": "https://github.com/esphome/esphome-desktop/releases/download/v0.10.0/ESPHome.Builder_0.10.0_aarch64.AppImage",      "size": 178442910},
+    {"name": "ESPHome Builder_0.10.0_aarch64.AppImage.sig",  "url": "https://github.com/esphome/esphome-desktop/releases/download/v0.10.0/ESPHome.Builder_0.10.0_aarch64.AppImage.sig",  "size": 200},
+    {"name": "ESPHome Builder_0.10.0_amd64.deb",             "url": "https://github.com/esphome/esphome-desktop/releases/download/v0.10.0/ESPHome.Builder_0.10.0_amd64.deb",             "size": 162342111},
+    {"name": "ESPHome Builder_0.10.0_arm64.deb",             "url": "https://github.com/esphome/esphome-desktop/releases/download/v0.10.0/ESPHome.Builder_0.10.0_arm64.deb",             "size": 156323184},
+    {"name": "ESPHome Builder-0.10.0-1.x86_64.rpm",          "url": "https://github.com/esphome/esphome-desktop/releases/download/v0.10.0/ESPHome.Builder-0.10.0-1.x86_64.rpm",          "size": 162812455},
+    {"name": "ESPHome Builder-0.10.0-1.aarch64.rpm",         "url": "https://github.com/esphome/esphome-desktop/releases/download/v0.10.0/ESPHome.Builder-0.10.0-1.aarch64.rpm",         "size": 156811220},
+    {"name": "ESPHome Builder_0.10.0_aarch64.dmg",           "url": "https://github.com/esphome/esphome-desktop/releases/download/v0.10.0/ESPHome.Builder_0.10.0_aarch64.dmg",           "size": 152043287},
+    {"name": "ESPHome Builder_0.10.0_x64.dmg",               "url": "https://github.com/esphome/esphome-desktop/releases/download/v0.10.0/ESPHome.Builder_0.10.0_x64.dmg",               "size": 158129443},
+    {"name": "ESPHome Builder_aarch64.app.tar.gz",           "url": "https://github.com/esphome/esphome-desktop/releases/download/v0.10.0/ESPHome.Builder_aarch64.app.tar.gz",           "size": 153000000},
+    {"name": "ESPHome Builder_aarch64.app.tar.gz.sig",       "url": "https://github.com/esphome/esphome-desktop/releases/download/v0.10.0/ESPHome.Builder_aarch64.app.tar.gz.sig",       "size": 200},
+    {"name": "ESPHome Builder_x64.app.tar.gz",               "url": "https://github.com/esphome/esphome-desktop/releases/download/v0.10.0/ESPHome.Builder_x64.app.tar.gz",               "size": 158000000},
+    {"name": "ESPHome Builder_x64.app.tar.gz.sig",           "url": "https://github.com/esphome/esphome-desktop/releases/download/v0.10.0/ESPHome.Builder_x64.app.tar.gz.sig",           "size": 200}
+  ]
+}


### PR DESCRIPTION
# What does this implement/fix?

Wires up `tauri-plugin-updater` so that macOS DMG, Windows NSIS, and Linux AppImage (x86_64 + aarch64) installs can self-update from GitHub Releases. Linux `.deb` / `.rpm` and AUR installs still update via their system package manager (no updater bundle target).

Release builds now produce signed per-platform updater artifacts plus a `latest.json` manifest, validated against a JSON Schema (`.github/latest.schema.json`) before upload so a malformed manifest fails CI rather than shipping. The AppImage is re-signed after the DwarFS Python-injection step (otherwise the build-time `.AppImage.sig` is stale), and the macOS `.app.tar.gz` is renamed per-arch so the two macOS builds don't collide on the release.

The desktop self-update runs **first** in both the background loop and the "Check for Updates" tray flow. A self-update ships a fresh bundled Python tree that would otherwise overwrite any user-pip-installed ESPHome bumps (see #95). When the wipe happens, `ensure_user_python` now also snapshots the previously-installed `esphome` / `esphome-device-builder` versions and reinstalls them after the bundled tree is copied in — but only when the saved version is newer than the bundled one, so users who explicitly bumped past the bundle keep their pin and everyone else benefits from the fresh bundle. The restore's `pip install` runs synchronously with a 5-minute wall-clock timeout and a background stderr drainer so a stalled network can't hang app startup and a flooded pipe buffer can't defeat the timeout.

A separate "Check for App Updates..." tray item is added for the verbose app-only check.

## latest.json is also useful outside the in-app updater

The manifest carries more than just the Tauri updater payload so a download page (or any other consumer) can reuse it:

- `platforms` — Tauri updater bundles + signatures (consumed by `tauri-plugin-updater`; unknown fields are ignored, so the extras below are safe).
- `downloads` — every distributable installer URL grouped by platform, including the formats the updater doesn't ship (.deb, .rpm, .dmg), each entry with `kind` / `url` / `size`.
- `release_url`, `pub_date`, `notes`, `$schema` — release metadata + a pointer to the JSON Schema.

The deploy-pages workflow mirrors `latest.json` and `latest.schema.json` next to the download page so JS consumers can fetch `https://desktop.esphome.io/latest.json` same-origin (GitHub release assets aren't CORS-friendly for `fetch()` — link hrefs still work fine).

The generator lives at `.github/scripts/generate_latest_json.py` (a pure `build_manifest()` plus a CLI for local runs). `tests/fixtures/release.json` + `tests/fixtures/artifacts/` ship a mocked release so the script can be exercised offline:

```bash
python3 .github/scripts/generate_latest_json.py \
    --tag v0.10.0 --repo esphome/esphome-desktop \
    --release-fixture tests/fixtures/release.json \
    --artifacts-dir tests/fixtures/artifacts \
    --output /tmp/latest.json
```

**Notes for shipping:**
- Requires `TAURI_SIGNING_PRIVATE_KEY` / `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` GitHub Actions secrets to be populated with the keypair matching the `pubkey` in `tauri.conf.json`.
- The `latest.json` endpoint only becomes reachable via `https://github.com/.../releases/latest/download/latest.json` once the first release built with this change is **published** (not left as a draft). The Pages mirror at `https://desktop.esphome.io/latest.json` populates after the corresponding deploy-pages run finishes (~30–60s after publish).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).