### PR TITLE
Surface desktop and device-builder versions in tray and backend

### DIFF
--- a/src-tauri/src/daemon/mod.rs
+++ b/src-tauri/src/daemon/mod.rs
@@ -40,6 +40,10 @@ pub struct DaemonManager {
     dashboard_pid: Arc<AtomicI32>,
     /// Use `esphome-device-builder` instead of `esphome dashboard`
     use_device_builder: Arc<AtomicBool>,
+    /// Desktop app version (from tauri.conf.json), forwarded to the child
+    /// via `ESPHOME_DESKTOP_VERSION` so the backend can surface it to the
+    /// frontend. Captured at construction since it doesn't change at runtime.
+    desktop_version: String,
 }
 
 impl DaemonManager {
@@ -71,6 +75,7 @@ impl DaemonManager {
             running: Arc::new(AtomicBool::new(false)),
             dashboard_pid: Arc::new(AtomicI32::new(0)),
             use_device_builder: Arc::new(AtomicBool::new(settings.backend.is_builder())),
+            desktop_version: app_handle.package_info().version.to_string(),
         })
     }
 
@@ -172,6 +177,10 @@ impl DaemonManager {
 
         // Set environment variables
         cmd.env("ESPHOME_DASHBOARD", "1");
+        // Surface the desktop app version to the backend so it can be shown
+        // in the frontend (e.g. an "About" page). Set unconditionally — both
+        // backends get it; classic dashboard can ignore it.
+        cmd.env("ESPHOME_DESKTOP_VERSION", &self.desktop_version);
 
         // On Windows, force the spawned Python (and any subprocesses it
         // spawns for compile/logs) to use UTF-8 for stdin/stdout/stderr.

--- a/src-tauri/src/tray/mod.rs
+++ b/src-tauri/src/tray/mod.rs
@@ -75,17 +75,25 @@ pub fn build_tray_menu(app_handle: &AppHandle, state: &Arc<AppState>) -> Result<
     let _ = VERSION_ITEM.set(version_item.clone());
 
     // Create esphome-device-builder version display item. Always shown so the
-    // menu structure is stable; reads "not installed" when the package is
-    // absent (e.g. when the classic backend is active on a fresh install).
-    let builder_version_text = format!(
-        "Device Builder: {}",
-        crate::update::get_installed_device_builder_version(app_handle)
-            .unwrap_or_else(|_| "not installed".to_string())
-    );
-    let builder_version_item = MenuItemBuilder::with_id(ids::BUILDER_VERSION, builder_version_text)
-        .enabled(false)
-        .build(app_handle)?;
+    // menu structure is stable. Detection spawns a Python subprocess which is
+    // too slow / too risky (could hang) to run synchronously in the setup
+    // path, so we start with a "detecting…" placeholder and refresh from a
+    // background task immediately below.
+    let builder_version_item =
+        MenuItemBuilder::with_id(ids::BUILDER_VERSION, "Device Builder: detecting…")
+            .enabled(false)
+            .build(app_handle)?;
     let _ = BUILDER_VERSION_ITEM.set(builder_version_item.clone());
+
+    // Kick off async detection of the installed `esphome-device-builder`
+    // version. The blocking Python call runs on a dedicated thread so it
+    // can't stall tray creation or other setup work.
+    {
+        let app = app_handle.clone();
+        async_runtime::spawn(async move {
+            refresh_builder_version_display(&app).await;
+        });
+    }
 
     // Create release channel items
     let current_channel = settings.release_channel;
@@ -296,11 +304,27 @@ fn refresh_version_display(app_handle: &AppHandle) {
 }
 
 /// Re-detect the installed `esphome-device-builder` package version and
-/// update the tray display.
-fn refresh_builder_version_display(app_handle: &AppHandle) {
-    let version = crate::update::get_installed_device_builder_version(app_handle)
-        .unwrap_or_else(|_| "not installed".to_string());
-    update_builder_version(&version);
+/// update the tray display. Runs the blocking Python call off the caller's
+/// thread, and distinguishes "package not installed" from "detection
+/// failed" so the latter doesn't get silently misreported.
+async fn refresh_builder_version_display(app_handle: &AppHandle) {
+    let app = app_handle.clone();
+    let label = tokio::task::spawn_blocking(move || {
+        match crate::update::get_installed_device_builder_version(&app) {
+            Ok(Some(v)) => v,
+            Ok(None) => "not installed".to_string(),
+            Err(e) => {
+                warn!("Could not detect esphome-device-builder version: {}", e);
+                "unknown".to_string()
+            }
+        }
+    })
+    .await
+    .unwrap_or_else(|e| {
+        warn!("Device-builder version detection task failed: {}", e);
+        "unknown".to_string()
+    });
+    update_builder_version(&label);
 }
 
 /// Handle menu item clicks
@@ -465,7 +489,7 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>, _a
                                 );
 
                                 // Refresh the device-builder version display in the tray menu
-                                refresh_builder_version_display(&app);
+                                refresh_builder_version_display(&app).await;
 
                                 if let Err(e) = state.daemon.start().await {
                                     error!(
@@ -808,7 +832,7 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>, _a
                         return;
                     }
                     // Install succeeded — refresh the tray version display.
-                    refresh_builder_version_display(&app);
+                    refresh_builder_version_display(&app).await;
                 }
 
                 // Apply the new backend to the daemon and persist it.

--- a/src-tauri/src/tray/mod.rs
+++ b/src-tauri/src/tray/mod.rs
@@ -20,7 +20,9 @@ use crate::AppState;
 mod ids {
     pub const OPEN_DASHBOARD: &str = "open_dashboard";
     pub const STATUS: &str = "status";
+    pub const APP_VERSION: &str = "app_version";
     pub const VERSION: &str = "version";
+    pub const BUILDER_VERSION: &str = "builder_version";
     pub const PORT: &str = "port";
     pub const CHECK_UPDATES: &str = "check_updates";
     pub const CHECK_APP_UPDATES: &str = "check_app_updates";
@@ -55,15 +57,35 @@ pub fn build_tray_menu(app_handle: &AppHandle, state: &Arc<AppState>) -> Result<
         .build(app_handle)?;
     let _ = STATUS_ITEM.set(status_item.clone());
 
-    // Create version display item
+    // Create desktop app version display item (Tauri app version from
+    // tauri.conf.json — fixed for the lifetime of the process, never updated).
+    let app_version_text = format!("Desktop: {}", app_handle.package_info().version);
+    let app_version_item = MenuItemBuilder::with_id(ids::APP_VERSION, app_version_text)
+        .enabled(false)
+        .build(app_handle)?;
+
+    // Create ESPHome version display item
     let version_text = match &settings.installed_version {
-        Some(v) => format!("Version: {}", v),
-        None => "Version: unknown".to_string(),
+        Some(v) => format!("ESPHome: {}", v),
+        None => "ESPHome: unknown".to_string(),
     };
     let version_item = MenuItemBuilder::with_id(ids::VERSION, version_text)
         .enabled(false)
         .build(app_handle)?;
     let _ = VERSION_ITEM.set(version_item.clone());
+
+    // Create esphome-device-builder version display item. Always shown so the
+    // menu structure is stable; reads "not installed" when the package is
+    // absent (e.g. when the classic backend is active on a fresh install).
+    let builder_version_text = format!(
+        "Device Builder: {}",
+        crate::update::get_installed_device_builder_version(app_handle)
+            .unwrap_or_else(|_| "not installed".to_string())
+    );
+    let builder_version_item = MenuItemBuilder::with_id(ids::BUILDER_VERSION, builder_version_text)
+        .enabled(false)
+        .build(app_handle)?;
+    let _ = BUILDER_VERSION_ITEM.set(builder_version_item.clone());
 
     // Create release channel items
     let current_channel = settings.release_channel;
@@ -128,7 +150,9 @@ pub fn build_tray_menu(app_handle: &AppHandle, state: &Arc<AppState>) -> Result<
         )
         .separator()
         .item(&status_item)
+        .item(&app_version_item)
         .item(&version_item)
+        .item(&builder_version_item)
         .item(
             &MenuItemBuilder::with_id(ids::PORT, format!("Port: {}", settings.port))
                 .enabled(false)
@@ -173,6 +197,10 @@ static STATUS_ITEM: std::sync::OnceLock<MenuItem<tauri::Wry>> = std::sync::OnceL
 /// Version menu item stored globally for updates
 static VERSION_ITEM: std::sync::OnceLock<MenuItem<tauri::Wry>> = std::sync::OnceLock::new();
 
+/// `esphome-device-builder` version menu item stored globally for updates
+static BUILDER_VERSION_ITEM: std::sync::OnceLock<MenuItem<tauri::Wry>> =
+    std::sync::OnceLock::new();
+
 /// Release channel items stored globally for radio-button behavior
 static CHANNEL_STABLE_ITEM: std::sync::OnceLock<MenuItem<tauri::Wry>> =
     std::sync::OnceLock::new();
@@ -205,7 +233,14 @@ pub fn update_status(_app_handle: &AppHandle, running: bool) {
 /// Update the version display in the tray menu.
 pub fn update_version(version: &str) {
     if let Some(item) = VERSION_ITEM.get() {
-        let _ = item.set_text(format!("Version: {}", version));
+        let _ = item.set_text(format!("ESPHome: {}", version));
+    }
+}
+
+/// Update the `esphome-device-builder` version display in the tray menu.
+pub fn update_builder_version(version: &str) {
+    if let Some(item) = BUILDER_VERSION_ITEM.get() {
+        let _ = item.set_text(format!("Device Builder: {}", version));
     }
 }
 
@@ -258,6 +293,14 @@ fn refresh_version_display(app_handle: &AppHandle) {
     let version = crate::update::get_installed_version(app_handle)
         .unwrap_or_else(|_| "unknown".to_string());
     update_version(&version);
+}
+
+/// Re-detect the installed `esphome-device-builder` package version and
+/// update the tray display.
+fn refresh_builder_version_display(app_handle: &AppHandle) {
+    let version = crate::update::get_installed_device_builder_version(app_handle)
+        .unwrap_or_else(|_| "not installed".to_string());
+    update_builder_version(&version);
 }
 
 /// Handle menu item clicks
@@ -420,6 +463,9 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>, _a
                                     "Device builder updated successfully to {}",
                                     builder_version
                                 );
+
+                                // Refresh the device-builder version display in the tray menu
+                                refresh_builder_version_display(&app);
 
                                 if let Err(e) = state.daemon.start().await {
                                     error!(
@@ -761,6 +807,8 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>, _a
                         }
                         return;
                     }
+                    // Install succeeded — refresh the tray version display.
+                    refresh_builder_version_display(&app);
                 }
 
                 // Apply the new backend to the daemon and persist it.

--- a/src-tauri/src/update/mod.rs
+++ b/src-tauri/src/update/mod.rs
@@ -451,9 +451,13 @@ impl UpdateChecker {
         }
 
         let installed = match get_installed_device_builder_version(app_handle) {
-            Ok(v) => v,
+            Ok(Some(v)) => v,
+            Ok(None) => {
+                debug!("esphome-device-builder is not installed; skipping update check");
+                return;
+            }
             Err(e) => {
-                debug!("esphome-device-builder version not detected: {}", e);
+                warn!("esphome-device-builder version detection failed: {}", e);
                 return;
             }
         };
@@ -505,7 +509,11 @@ impl UpdateChecker {
         }
 
         let installed = match get_installed_device_builder_version(app_handle) {
-            Ok(v) => v,
+            Ok(Some(v)) => v,
+            Ok(None) => {
+                warn!("esphome-device-builder is not installed");
+                return None;
+            }
             Err(e) => {
                 warn!(
                     "Could not detect installed esphome-device-builder version: {}",
@@ -669,7 +677,14 @@ fn find_latest_any(releases: &HashMap<String, Vec<PyPIRelease>>) -> Option<Strin
 }
 
 /// Get the installed `esphome-device-builder` package version.
-pub fn get_installed_device_builder_version(app_handle: &AppHandle) -> Result<String> {
+///
+/// - `Ok(Some(v))` — package is installed, returns the version string.
+/// - `Ok(None)` — Python ran successfully but the package is not installed
+///   (importlib.metadata raised `PackageNotFoundError`).
+/// - `Err(e)` — detection itself failed (bundled Python missing, spawn
+///   error, etc.); the caller should surface this rather than treat it as
+///   "not installed".
+pub fn get_installed_device_builder_version(app_handle: &AppHandle) -> Result<Option<String>> {
     let python_path = platform::get_python_path(app_handle)?;
 
     let mut cmd = std::process::Command::new(&python_path);
@@ -686,9 +701,12 @@ pub fn get_installed_device_builder_version(app_handle: &AppHandle) -> Result<St
         if version.is_empty() {
             anyhow::bail!("esphome-device-builder version is empty");
         }
-        Ok(version)
+        Ok(Some(version))
     } else {
-        anyhow::bail!("esphome-device-builder not installed")
+        // Non-zero exit means importlib.metadata raised PackageNotFoundError —
+        // the package isn't installed. That's a distinct state from a
+        // detection failure (which would have errored out above).
+        Ok(None)
     }
 }
 


### PR DESCRIPTION
# What does this implement/fix?

Adds two readonly entries to the system tray menu so the user can see, at a glance, which versions are running together: the Tauri desktop app version (from `tauri.conf.json`) and the installed `esphome-device-builder` Python package version. The pre-existing ESPHome version line is renamed from "Version" to "ESPHome" to disambiguate from the new entries. The device-builder line refreshes after a successful "Check for Updates..." pip upgrade and after a backend switch into a builder variant, and reads "not installed" otherwise so the menu structure stays stable.

The desktop app version is also forwarded to the spawned backend process via the `ESPHOME_DESKTOP_VERSION` environment variable. The Python side can read `os.environ.get("ESPHOME_DESKTOP_VERSION")` and surface it through whatever config/status endpoint the frontend already polls (`None` means "running standalone, not under the desktop wrapper").

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes <link to issue>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).