### PR TITLE
Split macOS updater upload into two artifact steps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -329,9 +329,14 @@ jobs:
         if: matrix.platform == 'macos' && github.event_name == 'workflow_run'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          path: |
-            src-tauri/target/${{ matrix.rust_target && format('{0}/', matrix.rust_target) || '' }}release/bundle/macos/*.app.tar.gz
-            src-tauri/target/${{ matrix.rust_target && format('{0}/', matrix.rust_target) || '' }}release/bundle/macos/*.app.tar.gz.sig
+          path: src-tauri/target/${{ matrix.rust_target && format('{0}/', matrix.rust_target) || '' }}release/bundle/macos/*.app.tar.gz
+          archive: false
+
+      - name: Upload macOS updater signature
+        if: matrix.platform == 'macos' && github.event_name == 'workflow_run'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          path: src-tauri/target/${{ matrix.rust_target && format('{0}/', matrix.rust_target) || '' }}release/bundle/macos/*.app.tar.gz.sig
           archive: false
 
   # Persist PR metadata so the companion "PR Comment" workflow (which runs


### PR DESCRIPTION
# What does this implement/fix?

`actions/upload-artifact@v7` with `archive: false` only supports a single file pattern per step. The combined upload covering both `*.app.tar.gz` and `*.app.tar.gz.sig` therefore fails when the macOS updater bundle step runs. Split it into two steps — one for the tarball, one for the signature — so each uploads its lone file.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes <link to issue>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).