### PR TITLE
Correct macOS path in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Settings are stored in `settings.json`:
 The app is code-signed and notarized. If you still encounter this message (e.g., from a development build), run:
 
 ```bash
-xattr -c "/Applications/ESPHome Device Builder.app"
+xattr -c "/Applications/ESPHome Builder.app"
 ```
 
 Then try opening the app again.


### PR DESCRIPTION
This is still not sufficient to get dev builds to run on macOS, but that's a separate issue

# What does this implement/fix?

Typo fix:

```
❯ xattr -c "/Applications/ESPHome Device Builder.app"
xattr: No such file: /Applications/ESPHome Device Builder.app
❯ xattr -c "/Applications/ESPHome Builder.app"
❯ 
```
(no error means success)

<!-- Quick description and explanation of changes -->

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

## Checklist:
  - [ ] The code change is tested and works locally.
  - [X] Tested on the relevant platform(s) (macOS, Windows, Linux).
