### PR TITLE
Strip assets-pending warning from latest.json notes

### DIFF
--- a/.github/scripts/generate_latest_json.py
+++ b/.github/scripts/generate_latest_json.py
@@ -73,10 +73,28 @@ DOWNLOAD_MATCHERS: list[tuple[str, str, re.Pattern[str]]] = [
 
 SCHEMA_URL = "https://desktop.esphome.io/latest.schema.json"
 
+# Matches the assets-pending caution block emitted by release-drafter
+# (see .github/release-drafter.yml). The release body still carries this
+# block while latest.json is generated because the workflow only strips
+# it from the release body *after* the manifest is uploaded — so we
+# strip it here too, to keep the warning out of the published notes.
+ASSETS_PENDING_BLOCK_RE = re.compile(
+    r"^> \[!CAUTION\].*?<!-- ASSETS_PENDING -->\n?",
+    re.DOTALL | re.MULTILINE,
+)
+
 
 def _warn(msg: str) -> None:
     """Emit a GitHub-Actions-style warning to stderr (also readable locally)."""
     print(f"::warning::{msg}", file=sys.stderr)
+
+
+def _strip_assets_pending_warning(body: str) -> str:
+    """Remove the release-drafter assets-pending caution block from a release body."""
+    stripped = ASSETS_PENDING_BLOCK_RE.sub("", body)
+    # Belt-and-braces: drop any stray markers left behind by manual edits.
+    stripped = stripped.replace("<!-- ASSETS_PENDING -->", "")
+    return stripped.lstrip("\n")
 
 
 def _asset_url(download_base: str, name: str) -> str:
@@ -181,7 +199,7 @@ def build_manifest(
     return {
         "$schema": SCHEMA_URL,
         "version": version,
-        "notes": release.get("body") or "",
+        "notes": _strip_assets_pending_warning(release.get("body") or ""),
         "pub_date": pub_date,
         "release_url": f"https://github.com/{repo}/releases/tag/{tag}",
         "platforms": platforms,

--- a/tests/fixtures/release.json
+++ b/tests/fixtures/release.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Mock output of `gh release view <tag> --json body,publishedAt,assets`. Used as a manual fixture for `.github/scripts/generate_latest_json.py`. Asset names and URLs are the dot-substituted form GitHub serves (spaces in productName become dots); sizes are illustrative.",
-  "body": "## What's Changed\n\n* Fixture release used to exercise the latest.json generator.\n\n**Full Changelog**: https://github.com/esphome/esphome-desktop/compare/v0.9.0...v0.10.0",
+  "body": "> [!CAUTION]\n> **DO NOT PUBLISH THIS RELEASE YET!**\n> Build assets have not been uploaded. Wait for the build workflow to complete\n> and this notice to be removed before publishing.\n<!-- ASSETS_PENDING -->\n\n## What's Changed\n\n* Fixture release used to exercise the latest.json generator.\n\n**Full Changelog**: https://github.com/esphome/esphome-desktop/compare/v0.9.0...v0.10.0",
   "publishedAt": "2026-05-22T14:31:08Z",
   "assets": [
     {"name": "ESPHome.Device.Builder_0.10.0_x64-setup.exe",         "url": "https://github.com/esphome/esphome-desktop/releases/download/v0.10.0/ESPHome.Device.Builder_0.10.0_x64-setup.exe",         "size": 175342211},


### PR DESCRIPTION
# What does this implement/fix?

The release body still carries the release-drafter "DO NOT PUBLISH" caution block when `latest.json` is generated, because the build workflow only strips that block from the release body *after* the manifest has been uploaded. That left the warning sitting in the `notes` field of every published `latest.json`. This strips the same block in the generator so the warning never reaches downstream consumers.

The `tests/fixtures/release.json` fixture is updated to include the caution block so the local-run instructions in the script's docstring exercise the new strip path.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes <link to issue>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).