### PR TITLE
Remove duplicate tray menu update item

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,7 @@ Right-click (or left-click on some platforms) the tray icon to access:
 - **Open Dashboard** - Open the dashboard in your browser
 - **Status** - Shows if the daemon is running
 - **Port** - Shows the configured port
-- **Check for Updates** - Check for new ESPHome (Python) versions
-- **Check for App Updates** - Check for a new ESPHome Device Builder desktop release and install it in-place
+- **Check for Updates** - Check for a new ESPHome Device Builder desktop release, then new ESPHome (Python) and device-builder versions
 - **View Logs** - Open the logs folder
 - **Open Config Folder** - Open where your ESPHome configs are stored
 - **Restart Dashboard** - Restart the ESPHome process

--- a/src-tauri/src/app_update/mod.rs
+++ b/src-tauri/src/app_update/mod.rs
@@ -135,7 +135,7 @@ pub async fn check_and_notify(app_handle: &AppHandle) -> NextStep {
                 .builder()
                 .title("ESPHome Device Builder Update Available")
                 .body(format!(
-                    "Version {} is available (you have {}). Open the tray menu and choose \"Check for App Updates...\" to install.",
+                    "Version {} is available (you have {}). Open the tray menu and choose \"Check for Updates...\" to install.",
                     update.version, update.current_version
                 ))
                 .show()

--- a/src-tauri/src/tray/mod.rs
+++ b/src-tauri/src/tray/mod.rs
@@ -25,7 +25,6 @@ mod ids {
     pub const BUILDER_VERSION: &str = "builder_version";
     pub const PORT: &str = "port";
     pub const CHECK_UPDATES: &str = "check_updates";
-    pub const CHECK_APP_UPDATES: &str = "check_app_updates";
     pub const VIEW_LOGS: &str = "view_logs";
     pub const OPEN_CONFIG: &str = "open_config";
     pub const RESTART: &str = "restart";
@@ -171,10 +170,6 @@ pub fn build_tray_menu(app_handle: &AppHandle, state: &Arc<AppState>) -> Result<
         .item(&channel_submenu)
         .item(
             &MenuItemBuilder::with_id(ids::CHECK_UPDATES, "Check for Updates...")
-                .build(app_handle)?,
-        )
-        .item(
-            &MenuItemBuilder::with_id(ids::CHECK_APP_UPDATES, "Check for App Updates...")
                 .build(app_handle)?,
         )
         .separator()
@@ -555,14 +550,6 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>, _a
                         }
                     }
                 }
-            });
-        }
-        ids::CHECK_APP_UPDATES => {
-            let app = app_handle.clone();
-            async_runtime::spawn(async move {
-                // Verbose mode: this menu item is app-only, so surface "no
-                // updates available" feedback too.
-                crate::app_update::check_for_user(&app, true).await;
             });
         }
         ids::CHANNEL_STABLE | ids::CHANNEL_BETA | ids::CHANNEL_DEV => {


### PR DESCRIPTION
# What does this implement/fix?

Removes the redundant "Check for App Updates..." item from the system tray menu. "Check for Updates..." already chains app → ESPHome → device-builder checks in sequence, so the separate app-only entry was duplicate UI and confusing to users.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes <link to issue>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).