### PR TITLE
Update esphome-docs repo references to esphome.io

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,7 +5,7 @@ contact_links:
     url: https://github.com/esphome/esphome/issues/new/choose
     about: For issues with ESPHome firmware, compilation, validation, or components.
   - name: Report an issue with the ESPHome documentation
-    url: https://github.com/esphome/esphome-docs/issues/new/choose
+    url: https://github.com/esphome/esphome.io/issues/new/choose
     about: Report an issue with the ESPHome documentation.
   - name: Make a Feature Request
     url: https://github.com/orgs/esphome/discussions


### PR DESCRIPTION
# What does this implement/fix?

The ESPHome documentation repository was renamed from `esphome/esphome-docs` to `esphome/esphome.io`. Update the issue template's "Report an issue with the ESPHome documentation" link to point at the new repo so users don't land on a redirected/renamed repo URL.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes <link to issue>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).