### PR TITLE
Fix Windows device builder not stopping on quit

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -61,7 +61,7 @@ nix = { version = "0.31", features = ["signal"] }
 cocoa = "0.26"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.62", features = ["Win32_System_Threading", "Win32_Foundation"] }
+windows = { version = "0.62", features = ["Win32_System_Threading", "Win32_Foundation", "Win32_System_Console"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libloading = "0.9"

--- a/src-tauri/src/daemon/mod.rs
+++ b/src-tauri/src/daemon/mod.rs
@@ -155,6 +155,23 @@ impl DaemonManager {
             // Redirect stdout/stderr to single log file
             .stdout(Stdio::from(log_file))
             .stderr(Stdio::from(log_file_clone));
+
+        // On Windows, give the daemon a NUL stdin instead of inheriting ours.
+        //
+        // The shutdown path calls `platform::send_ctrl_break`, whose
+        // `AttachConsole`/`FreeConsole` dance mutates this (GUI, console-less)
+        // process's standard handles: `STD_INPUT_HANDLE` starts out NULL but is
+        // left dangling once we attach to and then free the child's console. A
+        // subsequent restart respawn would inherit that invalid handle, and
+        // because stdout/stderr are redirected (so `STARTF_USESTDHANDLES` is
+        // set and *all three* handles must be valid) `CreateProcess` fails with
+        // ERROR_INVALID_HANDLE (os error 6) — leaving the daemon dead after
+        // every restart. stdin is the only standard handle we'd otherwise
+        // inherit, so pinning it to NUL makes the spawn independent of our
+        // console-handle state. The dashboard/device-builder never reads stdin.
+        #[cfg(windows)]
+        cmd.stdin(Stdio::null());
+
         // On Unix, intentionally NOT setting `kill_on_drop(true)`. That
         // would have tokio send SIGKILL to the Child when it gets
         // dropped (either when stop()'s wait times out, or when

--- a/src-tauri/src/daemon/mod.rs
+++ b/src-tauri/src/daemon/mod.rs
@@ -162,11 +162,12 @@ impl DaemonManager {
         // dashboard and corrupts its state. Our Unix shutdown is
         // SIGTERM only — see `stop()` and `terminate_blocking()`.
         //
-        // On Windows there is no SIGTERM equivalent; the only way to
-        // stop the child reliably is TerminateProcess (what
-        // `Child::kill()` and `kill_on_drop(true)` invoke). Keep the
-        // drop-time safety net there so the dashboard doesn't orphan
-        // on Windows app exit.
+        // On Windows the graceful signal is CTRL_BREAK_EVENT (see `stop()`
+        // and `terminate_blocking()`), with TerminateProcess as the hard
+        // fallback. Keep `kill_on_drop(true)` as a last-ditch drop-time net
+        // for any path that drops the Child without going through those
+        // (note it does NOT fire on the normal quit path, which calls
+        // `std::process::exit()` and skips Drop).
         #[cfg(windows)]
         cmd.kill_on_drop(true);
 
@@ -174,8 +175,10 @@ impl DaemonManager {
         #[cfg(unix)]
         cmd.process_group(0);
 
-        // Prevent a console window from staying open on Windows
-        platform::configure_no_window_tokio_command(&mut cmd);
+        // Prevent a console window from staying open on Windows, and put the
+        // child in its own process group so we can later deliver a graceful
+        // CTRL_BREAK_EVENT to it on shutdown (see daemon stop/terminate).
+        platform::configure_daemon_tokio_command(&mut cmd);
 
         // Set environment variables
         cmd.env("ESPHOME_DASHBOARD", "1");
@@ -333,37 +336,50 @@ impl DaemonManager {
                 }
             }
 
-            // Wait up to 30 s for the dashboard to honor SIGTERM and exit
-            // cleanly. The dashboard's shutdown can drain in-flight work
-            // (firmware queue, partial writes, lock release) and we have
-            // measured this taking up to 30 s in the wild. We do NOT
-            // escalate to SIGKILL on timeout — force-killing here
-            // corrupts dashboard state. If the dashboard doesn't honor
-            // SIGTERM within the window, that's a dashboard-side bug;
-            // we log a warning and let the child finish on its own
-            // (it may briefly outlive us as an orphan of launchd).
+            // On Windows the graceful signal is CTRL_BREAK_EVENT to the
+            // child's process group (Python surfaces it as SIGBREAK). Send
+            // it up front, then wait the same patient window as Unix. Until
+            // the backend installs a SIGBREAK handler the default action
+            // terminates the child, so the wait returns promptly; once it
+            // drains gracefully, the window gives it time. TerminateProcess
+            // is the hard fallback on timeout (the only guarantee Windows
+            // offers for a child that ignored the break).
+            #[cfg(windows)]
+            {
+                if let Some(pid) = child.id() {
+                    let _ = crate::platform::send_ctrl_break(pid);
+                }
+            }
+
+            // Wait up to 30 s for the child to honor the signal and drain
+            // in-flight work (firmware queue, partial writes, lock release);
+            // we have measured up to 30 s in the wild.
             let timeout = tokio::time::timeout(tokio::time::Duration::from_secs(30), child.wait());
 
             match timeout.await {
                 Ok(Ok(status)) => info!("{} exited with status: {}", backend_name, status),
                 Ok(Err(e)) => warn!("Error waiting for process: {}", e),
-                #[cfg(unix)]
-                Err(_) => warn!(
-                    "Timeout waiting for {} to honor SIGTERM after 30 s; \
-                     proceeding with exit without force-killing.",
-                    backend_name
-                ),
-                // On Windows the loop above sent no graceful signal
-                // (there is no SIGTERM analog reachable from here),
-                // so the timeout is really "we waited 30 s for nothing
-                // to happen." TerminateProcess via Child::kill() is
-                // the only termination path; without it the dashboard
-                // would orphan on app exit. State preservation on
-                // Windows is out of scope for this fix.
-                #[cfg(not(unix))]
                 Err(_) => {
-                    warn!("Timeout waiting for {} to exit; force-killing.", backend_name);
-                    let _ = child.kill().await;
+                    // On Unix we do NOT escalate to SIGKILL — force-killing
+                    // corrupts dashboard state; we log and let the child
+                    // finish on its own (it may briefly outlive us as an
+                    // orphan). On Windows there is no gentler hard kill than
+                    // TerminateProcess, so we use it as the last resort.
+                    #[cfg(unix)]
+                    warn!(
+                        "Timeout waiting for {} to honor SIGTERM after 30 s; \
+                         proceeding with exit without force-killing.",
+                        backend_name
+                    );
+                    #[cfg(windows)]
+                    {
+                        warn!(
+                            "Timeout waiting for {} to honor CTRL_BREAK after 30 s; \
+                             force-killing.",
+                            backend_name
+                        );
+                        let _ = child.kill().await;
+                    }
                 }
             }
         }
@@ -373,11 +389,15 @@ impl DaemonManager {
         Ok(())
     }
 
-    /// Synchronously send SIGTERM to the dashboard's process group.
+    /// Synchronously terminate the dashboard child process. On Unix this
+    /// sends SIGTERM to its process group; on Windows it delivers a
+    /// graceful `CTRL_BREAK_EVENT` to its process group, with
+    /// `TerminateProcess` as the fallback if the break can't be delivered.
+    ///
     /// Safe to call from any context (including a tauri `RunEvent::Exit`
     /// callback where the tokio runtime is already winding down) — no
     /// async involvement. No-op if the daemon is not running or if a
-    /// previous call already fired the signal.
+    /// previous call already fired the kill.
     ///
     /// Idempotent via an atomic swap on `dashboard_pid` — repeated
     /// calls after the first are cheap no-ops, so it's safe to call
@@ -385,22 +405,36 @@ impl DaemonManager {
     /// run loop.
     ///
     /// Does NOT touch the `running` flag, so a concurrent / subsequent
-    /// `stop()` still runs its graceful 30 s wait. The PID atomic is
-    /// only used for the synchronous kill path; `stop()` reads
-    /// `child.id()` directly off the stored `Child` handle.
+    /// `stop()` still runs its wait. The PID atomic is only used for the
+    /// synchronous kill path; `stop()` reads `child.id()` directly off
+    /// the stored `Child` handle.
     ///
-    /// SIGTERM only — the dashboard is expected to honor it and clean
-    /// up its own state. If it doesn't, that's a dashboard-side bug.
+    /// On Unix this is SIGTERM only — the dashboard is expected to honor
+    /// it and clean up its own state. On Windows the graceful signal is
+    /// `CTRL_BREAK_EVENT`; we never hard-kill when the break was
+    /// delivered (so a backend that handles SIGBREAK can drain), only
+    /// when delivery fails. `TerminateProcess` is then the fallback
+    /// because it is the only hard guarantee Windows offers.
     ///
-    /// Guards against PID-reuse via `getpgid()`: if the dashboard child
-    /// exited independently (crash / external kill) and tokio reaped
-    /// it before we got here, the kernel may have handed our recorded
-    /// PID to an unrelated process. We spawned the dashboard with
-    /// `process_group(0)`, so the child is its own pgleader (pgid ==
-    /// pid). An unrelated process inheriting the recycled PID is
-    /// almost certainly not its own pgleader, so a `getpgid(pid) !=
-    /// pid` result short-circuits the signal and we don't disturb the
+    /// PID-reuse safety, Unix: guarded via `getpgid()`. If the dashboard
+    /// child exited independently (crash / external kill) and tokio
+    /// reaped it before we got here, the kernel may have handed our
+    /// recorded PID to an unrelated process. We spawned the dashboard
+    /// with `process_group(0)`, so the child is its own pgleader (pgid
+    /// == pid). An unrelated process inheriting the recycled PID is
+    /// almost certainly not its own pgleader, so a `getpgid(pid) != pid`
+    /// result short-circuits the signal and we don't disturb the
     /// stranger.
+    ///
+    /// PID-reuse safety, Windows: structural. While tokio's `Child`
+    /// handle for the process is open, Windows will not recycle that PID
+    /// (a PID is freed only once all handles to the process object
+    /// close). The handle lives in `process` and is dropped only by
+    /// `stop()` or the exit-watcher, both of which also zero this
+    /// atomic. So whenever `dashboard_pid != 0` the handle still pins
+    /// the PID; no `getpgid` equivalent is needed. A stale/exited PID
+    /// just makes `send_ctrl_break` (or the `OpenProcess` fallback) fail
+    /// harmlessly.
     pub fn terminate_blocking(&self) {
         let pid = self.dashboard_pid.swap(0, Ordering::SeqCst);
         if pid == 0 {
@@ -422,6 +456,41 @@ impl DaemonManager {
                          signaling a recycled-PID stranger.",
                         pid
                     );
+                }
+            }
+        }
+        #[cfg(windows)]
+        {
+            // Graceful first: deliver CTRL_BREAK to the child's process
+            // group. PID is stored as i32 to share the atomic with the Unix
+            // path; the process-group id equals the child PID because we
+            // spawned it with CREATE_NEW_PROCESS_GROUP.
+            if !crate::platform::send_ctrl_break(pid as u32) {
+                // The break could not be delivered (child gone, or no
+                // reachable console). Fall back to TerminateProcess so the
+                // child can never orphan.
+                use ::windows::Win32::Foundation::CloseHandle;
+                use ::windows::Win32::System::Threading::{
+                    OpenProcess, TerminateProcess, PROCESS_TERMINATE,
+                };
+                // SAFETY: FFI into Win32. We pass a valid PID and immediately
+                // close any handle we open; the handle never escapes this
+                // block.
+                unsafe {
+                    match OpenProcess(PROCESS_TERMINATE, false, pid as u32) {
+                        Ok(handle) => {
+                            if let Err(e) = TerminateProcess(handle, 1) {
+                                warn!("TerminateProcess on dashboard pid {} failed: {}", pid, e);
+                            }
+                            if let Err(e) = CloseHandle(handle) {
+                                warn!("CloseHandle on dashboard pid {} failed: {}", pid, e);
+                            }
+                        }
+                        Err(e) => warn!(
+                            "OpenProcess on dashboard pid {} failed (already exited?): {}",
+                            pid, e
+                        ),
+                    }
                 }
             }
         }

--- a/src-tauri/src/daemon/mod.rs
+++ b/src-tauri/src/daemon/mod.rs
@@ -6,7 +6,7 @@ use anyhow::{Context, Result};
 use std::fs::File;
 use std::path::PathBuf;
 use std::process::Stdio;
-use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tauri::AppHandle;
 use tauri_plugin_notification::NotificationExt;
@@ -16,6 +16,21 @@ use tracing::{debug, error, info, warn};
 
 use crate::platform;
 use crate::settings::Settings;
+
+/// Width-correct atomic and integer types for the dashboard child PID.
+/// Windows PIDs are a `DWORD` (`u32`); Unix PIDs are a `pid_t` (`i32`).
+/// Matching the native width lets `child.id()` round-trip losslessly on both:
+/// a Windows `u32` PID above `i32::MAX` would otherwise wrap negative when
+/// forced through an `i32` and the shutdown path would target the wrong
+/// process.
+#[cfg(windows)]
+type AtomicPid = std::sync::atomic::AtomicU32;
+#[cfg(unix)]
+type AtomicPid = std::sync::atomic::AtomicI32;
+#[cfg(windows)]
+type PidInt = u32;
+#[cfg(unix)]
+type PidInt = i32;
 
 /// Manages the ESPHome dashboard process
 pub struct DaemonManager {
@@ -38,7 +53,7 @@ pub struct DaemonManager {
     /// without going through `ExitRequested`) can SIGTERM the process
     /// group without locking the tokio mutex. Zero when no child is
     /// running.
-    dashboard_pid: Arc<AtomicI32>,
+    dashboard_pid: Arc<AtomicPid>,
     /// Use `esphome-device-builder` instead of `esphome dashboard`
     use_device_builder: Arc<AtomicBool>,
     /// AppHandle for emitting notifications / updating the tray when the
@@ -75,7 +90,7 @@ impl DaemonManager {
             logs_dir,
             port: settings.port,
             running: Arc::new(AtomicBool::new(false)),
-            dashboard_pid: Arc::new(AtomicI32::new(0)),
+            dashboard_pid: Arc::new(AtomicPid::new(0)),
             use_device_builder: Arc::new(AtomicBool::new(settings.backend.is_builder())),
             app_handle: app_handle.clone(),
         })
@@ -118,7 +133,9 @@ impl DaemonManager {
         // Open log file for stdout and stderr combined
         let log_path = self.logs_dir.join("dashboard.log");
         let log_file = File::create(&log_path).context("Failed to create log file")?;
-        let log_file_clone = log_file.try_clone().context("Failed to clone log file handle")?;
+        let log_file_clone = log_file
+            .try_clone()
+            .context("Failed to clone log file handle")?;
 
         info!("{} logs: {:?}", backend_name, log_path);
 
@@ -219,7 +236,7 @@ impl DaemonManager {
 
         let child = cmd.spawn().context("Failed to spawn ESPHome process")?;
         if let Some(pid) = child.id() {
-            self.dashboard_pid.store(pid as i32, Ordering::SeqCst);
+            self.dashboard_pid.store(pid as PidInt, Ordering::SeqCst);
         }
 
         let mut process = self.process.lock().await;
@@ -479,10 +496,9 @@ impl DaemonManager {
         #[cfg(windows)]
         {
             // Graceful first: deliver CTRL_BREAK to the child's process
-            // group. PID is stored as i32 to share the atomic with the Unix
-            // path; the process-group id equals the child PID because we
+            // group. The process-group id equals the child PID because we
             // spawned it with CREATE_NEW_PROCESS_GROUP.
-            if !crate::platform::send_ctrl_break(pid as u32) {
+            if !crate::platform::send_ctrl_break(pid) {
                 // The break could not be delivered (child gone, or no
                 // reachable console). Fall back to TerminateProcess so the
                 // child can never orphan.
@@ -494,7 +510,7 @@ impl DaemonManager {
                 // close any handle we open; the handle never escapes this
                 // block.
                 unsafe {
-                    match OpenProcess(PROCESS_TERMINATE, false, pid as u32) {
+                    match OpenProcess(PROCESS_TERMINATE, false, pid) {
                         Ok(handle) => {
                             if let Err(e) = TerminateProcess(handle, 1) {
                                 warn!("TerminateProcess on dashboard pid {} failed: {}", pid, e);

--- a/src-tauri/src/daemon/mod.rs
+++ b/src-tauri/src/daemon/mod.rs
@@ -173,20 +173,21 @@ impl DaemonManager {
             .stdout(Stdio::from(log_file))
             .stderr(Stdio::from(log_file_clone));
 
-        // On Windows, give the daemon a NUL stdin instead of inheriting ours.
+        // Give the daemon a null stdin instead of inheriting ours. The
+        // dashboard/device-builder never reads stdin, so there is no reason to
+        // hold a handle to it on any platform.
         //
-        // The shutdown path calls `platform::send_ctrl_break`, whose
-        // `AttachConsole`/`FreeConsole` dance mutates this (GUI, console-less)
-        // process's standard handles: `STD_INPUT_HANDLE` starts out NULL but is
-        // left dangling once we attach to and then free the child's console. A
-        // subsequent restart respawn would inherit that invalid handle, and
-        // because stdout/stderr are redirected (so `STARTF_USESTDHANDLES` is
-        // set and *all three* handles must be valid) `CreateProcess` fails with
-        // ERROR_INVALID_HANDLE (os error 6) — leaving the daemon dead after
-        // every restart. stdin is the only standard handle we'd otherwise
-        // inherit, so pinning it to NUL makes the spawn independent of our
-        // console-handle state. The dashboard/device-builder never reads stdin.
-        #[cfg(windows)]
+        // On Windows this is also load-bearing for restart: the shutdown path
+        // calls `platform::send_ctrl_break`, whose `AttachConsole`/`FreeConsole`
+        // dance mutates this (GUI, console-less) process's standard handles.
+        // `STD_INPUT_HANDLE` starts out NULL but is left dangling once we attach
+        // to and then free the child's console. A subsequent restart respawn
+        // would inherit that invalid handle, and because stdout/stderr are
+        // redirected (so `STARTF_USESTDHANDLES` is set and *all three* handles
+        // must be valid) `CreateProcess` fails with ERROR_INVALID_HANDLE (os
+        // error 6) — leaving the daemon dead after every restart. Pinning stdin
+        // to a known-good handle makes the spawn independent of our
+        // console-handle state.
         cmd.stdin(Stdio::null());
 
         // On Unix, intentionally NOT setting `kill_on_drop(true)`. That

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -535,8 +535,8 @@ pub fn configure_daemon_tokio_command(cmd: &mut tokio::process::Command) {
 #[cfg(target_os = "windows")]
 pub fn send_ctrl_break(pid: u32) -> bool {
     use ::windows::Win32::System::Console::{
-        AttachConsole, FreeConsole, GenerateConsoleCtrlEvent, SetConsoleCtrlHandler,
-        CTRL_BREAK_EVENT,
+        AttachConsole, FreeConsole, GenerateConsoleCtrlEvent, GetStdHandle, SetConsoleCtrlHandler,
+        SetStdHandle, CTRL_BREAK_EVENT, STD_ERROR_HANDLE, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE,
     };
 
     // Serialize: AttachConsole/FreeConsole/SetConsoleCtrlHandler mutate
@@ -545,16 +545,45 @@ pub fn send_ctrl_break(pid: u32) -> bool {
     static CONSOLE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
     let _guard = CONSOLE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
 
-    // SAFETY: serialized Win32 console FFI. We restore the ctrl handler and
-    // detach the console before returning regardless of outcome; no handle or
-    // console state escapes this function.
+    // SAFETY: serialized Win32 console FFI. We restore the ctrl handler, the
+    // standard handles, and detach the console before returning regardless of
+    // outcome; no handle or console state escapes this function.
     unsafe {
+        // Save our standard handles up front and restore them on every exit
+        // path. AttachConsole/FreeConsole mutate whole-process console state
+        // and leave this (GUI, console-less) process's STD_INPUT_HANDLE
+        // dangling — NULL at launch, but an invalid non-NULL value once we
+        // attach to and then free the child's console. Anything we spawn after
+        // a shutdown attempt (notably the daemon respawn on restart) would then
+        // inherit that invalid handle, and because the daemon command
+        // redirects stdout/stderr (setting STARTF_USESTDHANDLES, which requires
+        // all three standard handles to be valid) CreateProcess fails with
+        // ERROR_INVALID_HANDLE. Restoring the saved values keeps our handle
+        // state exactly as it was before the call. (The daemon command also
+        // pins stdin to NUL as a belt-and-suspenders measure; this restore
+        // protects any other post-shutdown spawn too.)
+        let saved_in = GetStdHandle(STD_INPUT_HANDLE);
+        let saved_out = GetStdHandle(STD_OUTPUT_HANDLE);
+        let saved_err = GetStdHandle(STD_ERROR_HANDLE);
+        let restore_std_handles = || {
+            if let Ok(h) = saved_in {
+                let _ = SetStdHandle(STD_INPUT_HANDLE, h);
+            }
+            if let Ok(h) = saved_out {
+                let _ = SetStdHandle(STD_OUTPUT_HANDLE, h);
+            }
+            if let Ok(h) = saved_err {
+                let _ = SetStdHandle(STD_ERROR_HANDLE, h);
+            }
+        };
+
         // Detach from any console we currently hold; otherwise AttachConsole
         // fails with ERROR_ACCESS_DENIED (a process can attach to at most one
         // console). Harmless if we have none.
         let _ = FreeConsole();
         if AttachConsole(pid).is_err() {
             // Child gone, or its console is not reachable.
+            restore_std_handles();
             return false;
         }
         // Make ourselves ignore the event we are about to broadcast so we
@@ -564,6 +593,7 @@ pub fn send_ctrl_break(pid: u32) -> bool {
         let delivered = GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, pid).is_ok();
         let _ = SetConsoleCtrlHandler(None, false);
         let _ = FreeConsole();
+        restore_std_handles();
         delivered
     }
 }

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -251,7 +251,10 @@ pub fn ensure_user_python(app_handle: &AppHandle) -> Result<()> {
 
             info!("User Python ready at {:?}", user_python);
         } else {
-            debug!("User Python already up-to-date (version {})", current_version);
+            debug!(
+                "User Python already up-to-date (version {})",
+                current_version
+            );
         }
 
         Ok(())
@@ -278,7 +281,10 @@ fn restore_preserved_versions(python_bin: &Path, preserved: &PreservedVersions) 
 
     for (package, saved) in [
         ("esphome", preserved.esphome.as_deref()),
-        ("esphome-device-builder", preserved.esphome_device_builder.as_deref()),
+        (
+            "esphome-device-builder",
+            preserved.esphome_device_builder.as_deref(),
+        ),
     ] {
         let Some(saved) = saved else { continue };
         let Some(bundled) = read_package_version(python_bin, package) else {
@@ -532,11 +538,19 @@ pub fn configure_daemon_tokio_command(cmd: &mut tokio::process::Command) {
 /// mutates whole-process console state, so it is serialized under a lock; it
 /// is also known to be finicky, hence the caller's `TerminateProcess`
 /// fallback.
+///
+/// A release build is a GUI (windows-subsystem) process and owns no console,
+/// so the detach is a no-op. A dev/console build run from a terminal (so the
+/// daemon's tracing is visible) does own one; detaching it would tear that
+/// terminal down, so we record it up front and reattach to it before
+/// returning on every exit path.
 #[cfg(target_os = "windows")]
 pub fn send_ctrl_break(pid: u32) -> bool {
+    use ::windows::Win32::Foundation::HANDLE;
     use ::windows::Win32::System::Console::{
-        AttachConsole, FreeConsole, GenerateConsoleCtrlEvent, GetStdHandle, SetConsoleCtrlHandler,
-        SetStdHandle, CTRL_BREAK_EVENT, STD_ERROR_HANDLE, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE,
+        AttachConsole, FreeConsole, GenerateConsoleCtrlEvent, GetConsoleWindow, GetStdHandle,
+        SetConsoleCtrlHandler, SetStdHandle, ATTACH_PARENT_PROCESS, CTRL_BREAK_EVENT,
+        STD_ERROR_HANDLE, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE,
     };
 
     // Serialize: AttachConsole/FreeConsole/SetConsoleCtrlHandler mutate
@@ -546,9 +560,16 @@ pub fn send_ctrl_break(pid: u32) -> bool {
     let _guard = CONSOLE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
 
     // SAFETY: serialized Win32 console FFI. We restore the ctrl handler, the
-    // standard handles, and detach the console before returning regardless of
-    // outcome; no handle or console state escapes this function.
+    // standard handles, and our original console attachment before returning
+    // regardless of outcome; no handle or console state escapes this function.
     unsafe {
+        // Record whether we own a real console (one with a window) before we
+        // touch any console state. A GUI release build owns none, so this is
+        // false and the detach below is a no-op. A dev/console build run from
+        // a terminal owns one; we reattach to it on the way out so a shutdown
+        // attempt doesn't tear the terminal down.
+        let had_console = !GetConsoleWindow().0.is_null();
+
         // Save our standard handles up front and restore them on every exit
         // path. AttachConsole/FreeConsole mutate whole-process console state
         // and leave this (GUI, console-less) process's STD_INPUT_HANDLE
@@ -562,19 +583,26 @@ pub fn send_ctrl_break(pid: u32) -> bool {
         // state exactly as it was before the call. (The daemon command also
         // pins stdin to NUL as a belt-and-suspenders measure; this restore
         // protects any other post-shutdown spawn too.)
-        let saved_in = GetStdHandle(STD_INPUT_HANDLE);
-        let saved_out = GetStdHandle(STD_OUTPUT_HANDLE);
-        let saved_err = GetStdHandle(STD_ERROR_HANDLE);
-        let restore_std_handles = || {
-            if let Ok(h) = saved_in {
-                let _ = SetStdHandle(STD_INPUT_HANDLE, h);
+        //
+        // GetStdHandle returns Err only for INVALID_HANDLE_VALUE; a console-
+        // less process legitimately has NULL standard handles, which come back
+        // as Ok(NULL). We coerce either case to a concrete HANDLE and restore
+        // it unconditionally, so a process that started with NULL handles ends
+        // with NULL handles rather than whatever the console churn left behind.
+        let null_handle = HANDLE(std::ptr::null_mut());
+        let saved_in = GetStdHandle(STD_INPUT_HANDLE).unwrap_or(null_handle);
+        let saved_out = GetStdHandle(STD_OUTPUT_HANDLE).unwrap_or(null_handle);
+        let saved_err = GetStdHandle(STD_ERROR_HANDLE).unwrap_or(null_handle);
+        let restore = || {
+            // Reattach to our original (parent's) console first for dev/console
+            // builds; AttachConsole resets the standard handles, so the handle
+            // restore must come after it.
+            if had_console {
+                let _ = AttachConsole(ATTACH_PARENT_PROCESS);
             }
-            if let Ok(h) = saved_out {
-                let _ = SetStdHandle(STD_OUTPUT_HANDLE, h);
-            }
-            if let Ok(h) = saved_err {
-                let _ = SetStdHandle(STD_ERROR_HANDLE, h);
-            }
+            let _ = SetStdHandle(STD_INPUT_HANDLE, saved_in);
+            let _ = SetStdHandle(STD_OUTPUT_HANDLE, saved_out);
+            let _ = SetStdHandle(STD_ERROR_HANDLE, saved_err);
         };
 
         // Detach from any console we currently hold; otherwise AttachConsole
@@ -583,7 +611,7 @@ pub fn send_ctrl_break(pid: u32) -> bool {
         let _ = FreeConsole();
         if AttachConsole(pid).is_err() {
             // Child gone, or its console is not reachable.
-            restore_std_handles();
+            restore();
             return false;
         }
         // Make ourselves ignore the event we are about to broadcast so we
@@ -593,7 +621,7 @@ pub fn send_ctrl_break(pid: u32) -> bool {
         let delivered = GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, pid).is_ok();
         let _ = SetConsoleCtrlHandler(None, false);
         let _ = FreeConsole();
-        restore_std_handles();
+        restore();
         delivered
     }
 }

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -13,7 +13,7 @@ use tracing::debug;
 use std::os::windows::process::CommandExt;
 
 #[cfg(target_os = "windows")]
-use ::windows::Win32::System::Threading::CREATE_NO_WINDOW;
+use ::windows::Win32::System::Threading::{CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW};
 
 /// Get the application data directory
 ///
@@ -492,6 +492,79 @@ pub fn configure_no_window_tokio_command(cmd: &mut tokio::process::Command) {
     #[cfg(not(target_os = "windows"))]
     {
         let _ = cmd;
+    }
+}
+
+/// Configure the daemon child's creation flags on Windows: no console window
+/// AND a new process group. The new process group makes the child its own
+/// group leader (pgid == pid) so we can later deliver a graceful
+/// `CTRL_BREAK_EVENT` to it (and its descendants) for shutdown via
+/// `send_ctrl_break`. Sets both flags in one call so neither overwrites the
+/// other. No-op on non-Windows (Unix uses `process_group(0)` instead).
+pub fn configure_daemon_tokio_command(cmd: &mut tokio::process::Command) {
+    #[cfg(target_os = "windows")]
+    {
+        cmd.creation_flags((CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP).0);
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = cmd;
+    }
+}
+
+/// Deliver a graceful `CTRL_BREAK_EVENT` to a child process group on Windows.
+///
+/// Returns `true` if the event was delivered, `false` if it could not be (the
+/// child already exited, or its console is unreachable) — the caller should
+/// then fall back to `TerminateProcess`.
+///
+/// `pid` must be the PID of a child spawned with `CREATE_NEW_PROCESS_GROUP`
+/// (see `configure_daemon_tokio_command`); for such a child the process-group
+/// id equals its PID. `CTRL_BREAK_EVENT` is the only usable signal here:
+/// `CREATE_NEW_PROCESS_GROUP` disables CTRL+C for the group, and unlike
+/// `CTRL_C_EVENT` a break can target a specific group id.
+///
+/// The desktop app is a GUI process with no console, so a bare
+/// `GenerateConsoleCtrlEvent` would have nothing to signal through. We
+/// transiently attach to the child's (hidden) console, suppress the event in
+/// ourselves so we don't self-terminate, broadcast it, then detach. This
+/// mutates whole-process console state, so it is serialized under a lock; it
+/// is also known to be finicky, hence the caller's `TerminateProcess`
+/// fallback.
+#[cfg(target_os = "windows")]
+pub fn send_ctrl_break(pid: u32) -> bool {
+    use ::windows::Win32::System::Console::{
+        AttachConsole, FreeConsole, GenerateConsoleCtrlEvent, SetConsoleCtrlHandler,
+        CTRL_BREAK_EVENT,
+    };
+
+    // Serialize: AttachConsole/FreeConsole/SetConsoleCtrlHandler mutate
+    // per-process (not per-thread) console state, so two concurrent sends
+    // would corrupt each other.
+    static CONSOLE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    let _guard = CONSOLE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+    // SAFETY: serialized Win32 console FFI. We restore the ctrl handler and
+    // detach the console before returning regardless of outcome; no handle or
+    // console state escapes this function.
+    unsafe {
+        // Detach from any console we currently hold; otherwise AttachConsole
+        // fails with ERROR_ACCESS_DENIED (a process can attach to at most one
+        // console). Harmless if we have none.
+        let _ = FreeConsole();
+        if AttachConsole(pid).is_err() {
+            // Child gone, or its console is not reachable.
+            return false;
+        }
+        // Make ourselves ignore the event we are about to broadcast so we
+        // don't terminate the desktop along with the child. AttachConsole
+        // resets the handler table, so this must come after it.
+        let _ = SetConsoleCtrlHandler(None, true);
+        let delivered = GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, pid).is_ok();
+        let _ = SetConsoleCtrlHandler(None, false);
+        let _ = FreeConsole();
+        delivered
     }
 }
 


### PR DESCRIPTION
# What does this implement/fix?

On Windows the desktop did not reliably stop the bundled device builder when you quit; it could orphan and keep holding port 6052. `terminate_blocking()` previously did nothing on Windows, so any quit path that fires only `RunEvent::Exit` left the child alive, and the `kill_on_drop` safety net never runs because `app.exit(0)` calls `process::exit` and skips `Drop`.

The child now starts in its own process group, and shutdown delivers a graceful `CTRL_BREAK_EVENT` to that group; the device builder handles it as `SIGBREAK` and drains cleanly, and we fall back to `TerminateProcess` only when the break cannot be delivered. `stop()` sends the break up front instead of waiting 30 s for a signal it never sent, so a backend restart is prompt too.

Sending the break means transiently attaching to the child's console, which mutates this GUI process's standard handles. `send_ctrl_break` saves and restores those handles around the attach dance, and the daemon now spawns with stdin pinned to NUL; without this a restart respawn inherited a stale handle and `CreateProcess` failed with ERROR_INVALID_HANDLE, leaving the backend dead after every restart.

This is the Windows counterpart to the recent macOS shutdown fix; tested on Windows (every quit path frees port 6052, and restart is prompt).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tested on the relevant platform(s) (macOS, Windows, Linux).
