### PR TITLE
Limit build CI matrix to 4 concurrent jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,7 @@ jobs:
       contents: read
     strategy:
       fail-fast: false
+      max-parallel: 4
       matrix:
         include:
           - platform: windows


### PR DESCRIPTION
# What does this implement/fix?

Adds `max-parallel: 4` to the build workflow's matrix strategy so that at most 4 of the 7 platform build jobs run concurrently.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue (if applicable):**

- fixes <link to issue>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).