### PR TITLE
Install a prebuilt Tauri CLI in build CI instead of compiling it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,8 @@ jobs:
             os: ubuntu-22.04
             target: linux-x64
             bundles: appimage
-            tauri_branch: feat/truly-portable-appimage
+            # Pinned commit of tauri-apps/tauri feat/truly-portable-appimage.
+            tauri_rev: 105550cf9986a1a752eafb288baa562d6a564cce
             updater_target: linux-x86_64
           - platform: linux
             os: ubuntu-22.04
@@ -51,7 +52,8 @@ jobs:
             os: ubuntu-22.04-arm
             target: linux-arm64
             bundles: appimage
-            tauri_branch: feat/truly-portable-appimage
+            # Pinned commit of tauri-apps/tauri feat/truly-portable-appimage.
+            tauri_rev: 105550cf9986a1a752eafb288baa562d6a564cce
             updater_target: linux-aarch64
           - platform: linux
             os: ubuntu-22.04-arm
@@ -105,15 +107,74 @@ jobs:
           # produces broken cargo/rustc symlinks on the new macOS runner image.
           cache-bin: false
 
-      - name: Install Tauri CLI
-        run: |
-          if [[ -n "${{ matrix.tauri_branch }}" ]]; then
-            # Custom tauri-cli branch (e.g. for portable AppImage format)
-            cargo install tauri-cli --git https://github.com/tauri-apps/tauri --branch ${{ matrix.tauri_branch }} --locked --force
-          else
-            cargo install tauri-cli --locked
-          fi
+      # Resolve a tauri-cli version from the locked `tauri` crate version so it
+      # tracks Dependabot's cargo bumps automatically (no hardcoded version to go
+      # stale). Used for the prebuilt install on the stock jobs below. The
+      # AppImage jobs build a pinned fork instead, so they skip this.
+      - name: Resolve Tauri CLI version
+        if: ${{ !matrix.tauri_rev }}
         shell: bash
+        run: |
+          set -euo pipefail
+          ver=$(awk '/^name = "tauri"$/{getline; print}' src-tauri/Cargo.lock \
+            | sed -E 's/version = "(.+)"/\1/' | head -1)
+          # Validate against a strict version charset before trusting it: the
+          # value comes from a PR-editable Cargo.lock, so reject anything with
+          # shell metacharacters / quotes / newlines (defends the $GITHUB_ENV
+          # write and every later use).
+          if [[ ! "$ver" =~ ^[0-9][0-9A-Za-z.+-]*$ ]]; then
+            echo "::error::unexpected tauri version from src-tauri/Cargo.lock: '$ver'"
+            exit 1
+          fi
+          echo "TAURI_CLI_VERSION=$ver" >> "$GITHUB_ENV"
+          echo "Resolved tauri-cli version: $ver"
+
+      # Stock jobs install a prebuilt cargo-tauri via cargo-binstall (seconds)
+      # rather than compiling tauri-cli from source, which dominated the per-job
+      # time at 5-10 min. No cache is involved, so this is immune to the cache
+      # eviction that makes a small per-binary cache unreliable at the repo's
+      # 10 GB cache cap. binstall only falls back to compiling if a platform has
+      # no prebuilt (e.g. aarch64 Linux).
+      - name: Install cargo-binstall
+        if: ${{ !matrix.tauri_rev }}
+        uses: cargo-bins/cargo-binstall@aaa84a43aec4955a42c5ffc65d258961e39f276e # v1.19.1
+
+      # Version reaches the script only through env, never via ${{ }}
+      # interpolation into the run block, so a crafted Cargo.lock cannot inject
+      # shell commands. GITHUB_TOKEN lets binstall query GitHub releases without
+      # hitting the anonymous rate limit.
+      - name: Install Tauri CLI (prebuilt)
+        if: ${{ !matrix.tauri_rev }}
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cargo binstall --no-confirm \
+            --strategies crate-meta-data,quick-install,compile \
+            tauri-cli --version "$TAURI_CLI_VERSION"
+
+      # The AppImage jobs build tauri-cli from a pinned upstream fork (the
+      # "truly portable AppImage" format, tauri-apps/tauri#12491, not yet
+      # released), so there is no prebuilt to binstall. Cache the single compiled
+      # binary, keyed on the fork commit, so only the first run per commit pays
+      # the ~5 min compile. Caching just the binary (not all of ~/.cargo/bin)
+      # sidesteps the broken symlink restore behind Swatinem/rust-cache#341. Only
+      # two such caches exist (one per arch), so eviction pressure is minimal.
+      - name: Cache Tauri CLI (AppImage fork)
+        id: tauri-cli-cache
+        if: ${{ matrix.tauri_rev }}
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cargo/bin/cargo-tauri*
+          key: tauri-cli-${{ runner.os }}-${{ runner.arch }}-${{ matrix.tauri_rev }}
+
+      # TAURI_REV is a workflow-defined SHA, passed through env for consistency.
+      - name: Build Tauri CLI from fork (AppImage)
+        if: ${{ matrix.tauri_rev && steps.tauri-cli-cache.outputs.cache-hit != 'true' }}
+        shell: bash
+        env:
+          TAURI_REV: ${{ matrix.tauri_rev }}
+        run: cargo install tauri-cli --git https://github.com/tauri-apps/tauri --rev "$TAURI_REV" --locked
 
       - name: Prepare Python bundle
         shell: bash


### PR DESCRIPTION
# What does this implement/fix?

The Build workflow compiled tauri-cli from source on every job, which was the dominant per job cost; about 10 minutes on Windows, 8 on macOS. The stock platforms only compiled because cargo install was the default install command, nothing actually required it.

The stock jobs now install a prebuilt cargo-tauri with cargo-binstall; on Windows this took 7 seconds total instead of the 10 minute compile. No cache is involved, so it is immune to the cache eviction that makes a small per-binary cache unreliable at the repo's 10 GB cache cap. The version is resolved from the locked tauri crate in Cargo.lock so it tracks Dependabot with nothing hardcoded to go stale, and the resolved value is passed through env vars rather than expression interpolation so a crafted Cargo.lock cannot inject shell commands. binstall falls back to compiling only where a platform has no prebuilt.

The AppImage jobs build tauri-cli from a pinned upstream fork that has no prebuilt, so they still compile from source; that single binary is cached per fork commit, which is the only place a cache is now used. Pinning the fork by commit instead of a moving branch also makes those builds reproducible.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- N/A

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).
