### PR TITLE
Add pre-commit config enforcing Rust lint gates locally

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,44 @@
+# Install with: pre-commit install
+#
+# Base hooks mirror the esphome/device-builder-frontend config. The local cargo
+# hooks mirror the required Rust gates in the `Lint & Test` CI workflow
+# (.github/workflows/lint-test.yml). PR #134 made clippy and rustfmt blocking
+# gates for the src-tauri crate; these hooks catch the same failures before a
+# commit instead of after CI runs.
+#
+# CI pins Rust to a fixed toolchain (see `toolchain:` in lint-test.yml) so a new
+# release can't introduce a fresh lint on an unrelated PR. The cargo hooks use
+# your default toolchain; if a result differs locally, match the pinned version.
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-merge-conflict
+      - id: check-added-large-files
+      - id: check-yaml
+      - id: check-json
+      - id: mixed-line-ending
+        args: [--fix=lf]
+  - repo: local
+    hooks:
+      - id: forbid-nul-bytes
+        name: forbid NUL bytes in source files
+        language: pygrep
+        entry: "\\x00"
+        types: [text]
+
+      - id: cargo-fmt
+        name: cargo fmt (src-tauri)
+        entry: cargo fmt --manifest-path src-tauri/Cargo.toml --all --check
+        language: system
+        types: [rust]
+        pass_filenames: false
+
+      - id: cargo-clippy
+        name: cargo clippy (src-tauri)
+        entry: cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --all-features -- -D warnings
+        language: system
+        types: [rust]
+        pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,16 +29,19 @@ repos:
         entry: "\\x00"
         types: [text]
 
+      # Run inside src-tauri so rustup discovers src-tauri/rust-toolchain.toml
+      # and resolves the same pinned toolchain CI uses (requires git-bash on
+      # Windows).
       - id: cargo-fmt
         name: cargo fmt (src-tauri)
-        entry: cargo fmt --manifest-path src-tauri/Cargo.toml --all --check
+        entry: bash -c 'cd src-tauri && cargo fmt --all --check'
         language: system
         types: [rust]
         pass_filenames: false
 
       - id: cargo-clippy
         name: cargo clippy (src-tauri)
-        entry: cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --all-features -- -D warnings
+        entry: bash -c 'cd src-tauri && cargo clippy --all-targets --all-features -- -D warnings'
         language: system
         types: [rust]
         pass_filenames: false

--- a/src-tauri/rust-toolchain.toml
+++ b/src-tauri/rust-toolchain.toml
@@ -1,0 +1,9 @@
+# Pin the toolchain so local rustup resolves the same Rust version the
+# `Lint & Test` CI workflow enforces (see toolchain: in
+# .github/workflows/lint-test.yml). Keeping clippy and rustfmt deterministic
+# means a new Rust release can't introduce a fresh lint on an unrelated change.
+# Bump this deliberately to adopt newer lints, and keep it in sync with the
+# toolchain: value in lint-test.yml.
+[toolchain]
+channel = "1.96.0"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
# What does this implement/fix?

Adds a `.pre-commit-config.yaml` so the Rust gates run before a commit instead of only in CI; #134 made `cargo fmt` and `cargo clippy` required gates for the src-tauri crate, and this catches the same failures locally. It also pulls in the base hooks used by device-builder-frontend (trailing whitespace, end of file fixer, merge conflict, large file, yaml and json checks, mixed line ending, and a NUL byte guard).

Install with `pre-commit install`. The cargo hooks use your default toolchain, so if a clippy result differs locally, match the version pinned in `lint-test.yml`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes <link to issue>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).
