### PR TITLE
Skip the cargo pre-commit hooks on pre-commit.ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,16 @@
 # CI pins Rust to a fixed toolchain (see `toolchain:` in lint-test.yml) so a new
 # release can't introduce a fresh lint on an unrelated PR. The cargo hooks use
 # your default toolchain; if a result differs locally, match the pinned version.
+
+# pre-commit.ci runs in a sandbox without a Rust toolchain, so the local cargo
+# hooks fail there with "cargo: command not found". They are already enforced
+# by the `Lint & Test` GitHub Actions workflow, so skip them on pre-commit.ci;
+# they still run locally on commit and via `pre-commit run`.
+ci:
+  skip:
+    - cargo-fmt
+    - cargo-clippy
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0


### PR DESCRIPTION
# What does this implement/fix?

pre-commit.ci is failing on the local cargo hooks added in #139. It runs in a sandbox without a Rust toolchain, so cargo fmt and cargo clippy exit with "cargo: command not found" (exit 127).

Those Rust checks are already enforced on real CI by the Lint & Test workflow, so this adds a ci.skip block telling pre-commit.ci to skip the two cargo hooks. They still run locally on commit and via pre-commit run, only the hosted pre-commit.ci service skips them.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- N/A

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).
