### PR TITLE
Build the macOS arm64 DMG for its own target so it isn't labeled x64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,7 @@ jobs:
           - platform: macos
             os: macos-15
             target: macos-arm64
+            rust_target: aarch64-apple-darwin
             bundles: dmg
             updater_target: darwin-aarch64
           - platform: macos


### PR DESCRIPTION
# What does this implement/fix?

The macOS Apple Silicon job was building without an explicit `--target`, so Tauri labeled its DMG `x64`, the same name as the Intel job; both jobs uploaded an artifact called `..._x64.dmg`, so the build artifacts comment showed two x64 entries and no aarch64 build. This sets `rust_target: aarch64-apple-darwin` on the arm64 entry, mirroring the x64 entry, so the build targets that triple, the DMG is named `aarch64`, and the existing upload and updater steps that key off `rust_target` resolve the right path automatically.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes <link to issue>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).
