### PR TITLE
Add nightly workflow to bump the bundled Python version

### DIFF
--- a/.github/scripts/bump_bundle_versions.py
+++ b/.github/scripts/bump_bundle_versions.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""Bump the pinned bundled Python version in build-scripts/prepare_bundle.sh.
+
+Run nightly by .github/workflows/bump-bundle-versions.yml. It resolves the
+latest python-build-standalone release, rewrites the pinned version in
+prepare_bundle.sh, and emits GitHub Actions outputs that the workflow turns
+into a pull request.
+
+Policy: PBS_VERSION (the build-date tag) always moves to the latest release;
+PYTHON_VERSION only takes a newer *patch* within the currently pinned minor
+(e.g. 3.13.x), never a minor or major jump, which could break
+ESPHome/PlatformIO. A deliberate minor bump stays a manual change.
+
+The script fails loudly (non-zero exit) if the expected variables aren't found
+in prepare_bundle.sh, or if the latest upstream release can't be resolved —
+both mean a broken assumption, and a silent no-op would let the bundled Python
+drift and ship a stale, vulnerable version unnoticed. The only routine no-op is
+"already up to date".
+
+The version-rewriting transforms are pure and unit-tested
+(tests/test_bump_bundle_versions.py); the network resolution lives in
+resolve_latest_python, exercised against the real upstream API when the
+workflow runs.
+
+Usage (GITHUB_TOKEN keeps the API calls off the anonymous rate limit):
+
+    GITHUB_TOKEN=... python3 .github/scripts/bump_bundle_versions.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, TypeVar
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+PREPARE_BUNDLE = REPO_ROOT / "build-scripts" / "prepare_bundle.sh"
+
+PBS_REPO = "astral-sh/python-build-standalone"
+
+# Per-request network timeout. A stalled connection otherwise blocks the nightly
+# job until the workflow's multi-hour default timeout fires; failing fast lets
+# the run report a clean no-op instead.
+HTTP_TIMEOUT = 30
+
+# The Linux x86_64 asset is used to enumerate the CPython patch releases present
+# in a python-build-standalone release; it's the canonical name shape and every
+# release ships it. `{minor}` is filled in with the currently pinned minor.
+PBS_ASSET_RE_TEMPLATE = (
+    r"cpython-(?P<py>{minor}\.\d+)\+(?P<pbs>\d+)-"
+    r"x86_64-unknown-linux-gnu-install_only_stripped\.tar\.gz"
+)
+
+
+def _warn(msg: str) -> None:
+    """Emit a GitHub-Actions-style warning to stderr (also readable locally)."""
+    print(f"::warning::{msg}", file=sys.stderr)
+
+
+def _error(msg: str) -> None:
+    """Emit a GitHub-Actions-style error to stderr (also readable locally)."""
+    print(f"::error::{msg}", file=sys.stderr)
+
+
+# --------------------------------------------------------------------------- #
+# Pure transforms over the prepare_bundle.sh text (unit-tested).
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class BumpResult:
+    """Outcome of applying a bump to the prepare_bundle.sh text.
+
+    `changed` is true when at least one variable's value actually moved.
+    `var_changes` maps each changed variable to its (old, new) pair, used to
+    build the PR body. `text` is the rewritten file content.
+    """
+
+    changed: bool
+    text: str
+    var_changes: dict[str, tuple[str, str]] = field(default_factory=dict)
+
+
+def _assignment_re(var: str) -> re.Pattern[str]:
+    # Matches a top-level `VAR="value"` assignment, capturing the quoted value.
+    return re.compile(rf'^({re.escape(var)}=")([^"]*)(")', re.MULTILINE)
+
+
+def has_assignment(text: str, var: str) -> bool:
+    return _assignment_re(var).search(text) is not None
+
+
+def read_assignment(text: str, var: str) -> str:
+    m = _assignment_re(var).search(text)
+    if m is None:
+        raise KeyError(var)
+    return m.group(2)
+
+
+def replace_assignment(text: str, var: str, value: str) -> str:
+    pattern = _assignment_re(var)
+    if pattern.search(text) is None:
+        raise KeyError(var)
+    # Function replacement so any backslashes/specials in `value` stay literal.
+    return pattern.sub(lambda m: f"{m.group(1)}{value}{m.group(3)}", text, count=1)
+
+
+def apply_bumps(text: str, updates: dict[str, str]) -> BumpResult:
+    """Apply `var -> new value` updates, recording only the ones that move."""
+    new = text
+    changes: dict[str, tuple[str, str]] = {}
+    for var, value in updates.items():
+        old = read_assignment(new, var)
+        if old != value:
+            new = replace_assignment(new, var, value)
+            changes[var] = (old, value)
+    return BumpResult(changed=bool(changes), text=new, var_changes=changes)
+
+
+def current_python_minor(text: str) -> str:
+    """Return the `major.minor` of the currently pinned PYTHON_VERSION."""
+    pinned = read_assignment(text, "PYTHON_VERSION")
+    m = re.match(r"(\d+\.\d+)\.\d+$", pinned)
+    if m is None:
+        raise ValueError(f"Unexpected PYTHON_VERSION format: {pinned!r}")
+    return m.group(1)
+
+
+# --------------------------------------------------------------------------- #
+# Upstream resolution (network).
+# --------------------------------------------------------------------------- #
+
+
+_T = TypeVar("_T")
+
+# How many times to attempt a network op before giving up, and the linear
+# backoff base between attempts.
+HTTP_RETRIES = 3
+HTTP_RETRY_BACKOFF = 2
+
+
+def _with_retries(op: Callable[[], _T]) -> _T:
+    """Run `op`, retrying transient network failures with linear backoff.
+
+    We deliberately do NOT swallow a persistent failure into a no-op: if the
+    job can't reach GitHub it should fail loudly (a red nightly run) so the bump
+    is noticed and fixed. The opposite — quietly reporting "nothing to bump" on
+    every error — is the worse failure mode, because the bundled dependency
+    would silently drift and could ship a stale, vulnerable version for a long
+    time before anyone noticed. Retries only paper over momentary blips so a
+    single transient 5xx/timeout doesn't raise a false alarm.
+    """
+    last_exc: Exception | None = None
+    for attempt in range(1, HTTP_RETRIES + 1):
+        try:
+            return op()
+        except (urllib.error.URLError, TimeoutError, ConnectionError) as exc:
+            last_exc = exc
+            _warn(f"network attempt {attempt}/{HTTP_RETRIES} failed: {exc}")
+            if attempt < HTTP_RETRIES:
+                time.sleep(HTTP_RETRY_BACKOFF * attempt)
+    assert last_exc is not None  # loop ran at least once and didn't return
+    raise last_exc
+
+
+def _gh_headers() -> dict[str, str]:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "esphome-desktop-version-bump",
+    }
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _api_get(url: str) -> Any:
+    def fetch() -> Any:
+        req = urllib.request.Request(url, headers=_gh_headers())
+        with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:  # noqa: S310
+            return json.load(resp)
+
+    return _with_retries(fetch)
+
+
+def resolve_latest_python(minor: str) -> tuple[str, str] | None:
+    """Latest `(PBS_VERSION, PYTHON_VERSION)` for the given minor (e.g. "3.13").
+
+    Returns the newest python-build-standalone release tag together with the
+    highest `minor.patch` CPython build it ships. None if that release has no
+    build for `minor` (e.g. the line was dropped upstream), so the caller skips
+    the bump rather than jumping minors.
+    """
+    release = _api_get(f"https://api.github.com/repos/{PBS_REPO}/releases/latest")
+    pbs_version = release["tag_name"]
+    asset_re = re.compile(PBS_ASSET_RE_TEMPLATE.format(minor=re.escape(minor)))
+
+    patches: list[tuple[int, ...]] = []
+    for asset in release.get("assets", []):
+        m = asset_re.fullmatch(asset.get("name", ""))
+        if m is not None:
+            patches.append(tuple(int(p) for p in m.group("py").split(".")))
+
+    if not patches:
+        _warn(f"No CPython {minor}.x build in {PBS_REPO} release {pbs_version}")
+        return None
+
+    best = max(patches)
+    return pbs_version, ".".join(str(p) for p in best)
+
+
+# --------------------------------------------------------------------------- #
+# Output + CLI glue.
+# --------------------------------------------------------------------------- #
+
+
+def _emit_outputs(**outputs: str) -> None:
+    """Write step outputs to $GITHUB_OUTPUT (or stdout when run locally)."""
+    lines: list[str] = []
+    for key, value in outputs.items():
+        if "\n" in value:
+            delimiter = f"__BUMP_EOF_{key.upper()}__"
+            lines += [f"{key}<<{delimiter}", value, delimiter]
+        else:
+            lines.append(f"{key}={value}")
+    payload = "\n".join(lines) + "\n"
+
+    target = os.environ.get("GITHUB_OUTPUT")
+    if target:
+        with open(target, "a", encoding="utf-8") as fh:
+            fh.write(payload)
+    else:
+        sys.stdout.write(payload)
+
+
+def _build_body(var_changes: dict[str, tuple[str, str]]) -> str:
+    """Short, human-readable PR body describing the bump."""
+    bullets = "\n".join(
+        f"* {var} {old} to {new}" for var, (old, new) in var_changes.items()
+    )
+    return (
+        "Automated nightly bump of the bundled Python interpreter.\n\n"
+        f"{bullets}\n\n"
+        "CI builds and tests this branch; merge once the platform builds pass."
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--file",
+        default=str(PREPARE_BUNDLE),
+        help="Path to prepare_bundle.sh (defaults to the in-repo copy).",
+    )
+    args = parser.parse_args(argv)
+
+    path = Path(args.file)
+    text = path.read_text(encoding="utf-8")
+
+    # These variables are expected to exist. A missing one means
+    # prepare_bundle.sh was renamed/restructured and this script needs
+    # updating, so fail loudly rather than silently reporting "nothing to bump"
+    # — a quiet no-op would let the bundled Python drift and could ship a stale,
+    # vulnerable version unnoticed.
+    required = ("PYTHON_VERSION", "PBS_VERSION")
+    missing = [var for var in required if not has_assignment(text, var)]
+    if missing:
+        _error(
+            f"{', '.join(missing)} not found in {path.name}; "
+            "the Python bump script needs updating"
+        )
+        return 1
+
+    latest = resolve_latest_python(current_python_minor(text))
+    if latest is None:
+        # The pinned minor has no build in the latest release (resolver already
+        # logged why). That's a broken assumption, not a routine skip, so fail
+        # rather than silently never bumping.
+        _error("could not resolve the latest Python for the pinned minor")
+        return 1
+
+    pbs_version, python_version = latest
+    result = apply_bumps(
+        text, {"PYTHON_VERSION": python_version, "PBS_VERSION": pbs_version}
+    )
+    # When only the PBS build-date tag moves (same CPython patch), don't claim a
+    # version bump that didn't happen; name the build instead.
+    if "PYTHON_VERSION" in result.var_changes:
+        title = f"Bump bundled Python to {python_version}"
+    else:
+        title = f"Bump bundled Python build to {pbs_version} ({python_version})"
+
+    if not result.changed:
+        print("Bundled Python already up to date; nothing to bump.")
+        _emit_outputs(changed="false")
+        return 0
+
+    path.write_text(result.text, encoding="utf-8")
+    print("Bumped bundled Python:")
+    for var, (old, new) in result.var_changes.items():
+        print(f"  {var}: {old} -> {new}")
+
+    _emit_outputs(
+        changed="true",
+        title=title,
+        body=_build_body(result.var_changes),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/bump_bundle_versions.py
+++ b/.github/scripts/bump_bundle_versions.py
@@ -49,7 +49,7 @@ PBS_REPO = "astral-sh/python-build-standalone"
 
 # Per-request network timeout. A stalled connection otherwise blocks the nightly
 # job until the workflow's multi-hour default timeout fires; failing fast lets
-# the run report a clean no-op instead.
+# the run fail promptly (after retries) and surface a clear error.
 HTTP_TIMEOUT = 30
 
 # The Linux x86_64 asset is used to enumerate the CPython patch releases present

--- a/.github/scripts/bump_bundle_versions.py
+++ b/.github/scripts/bump_bundle_versions.py
@@ -196,9 +196,9 @@ def resolve_latest_python(minor: str) -> tuple[str, str] | None:
     """Latest `(PBS_VERSION, PYTHON_VERSION)` for the given minor (e.g. "3.13").
 
     Returns the newest python-build-standalone release tag together with the
-    highest `minor.patch` CPython build it ships. None if that release has no
-    build for `minor` (e.g. the line was dropped upstream), so the caller skips
-    the bump rather than jumping minors.
+    highest `minor.patch` CPython build it ships. Returns None if that release
+    has no build for `minor` (e.g. the line was dropped upstream); callers
+    should treat this as an error rather than jumping to a different minor.
     """
     release = _api_get(f"https://api.github.com/repos/{PBS_REPO}/releases/latest")
     pbs_version = release["tag_name"]

--- a/.github/workflows/bump-bundle-versions.yml
+++ b/.github/workflows/bump-bundle-versions.yml
@@ -1,0 +1,70 @@
+name: Bump bundle versions
+
+# Nightly check for a newer pinned bundled Python in
+# build-scripts/prepare_bundle.sh and open a PR when one is available. The
+# Python interpreter (python-build-standalone) stays on its current minor and
+# only takes newer patches. The PR (not a direct push) runs the full Build +
+# lint/test CI so a human merges only after the platforms are green.
+
+on:
+  schedule:
+    # 06:00 UTC daily, after upstream nightly releases have settled.
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  bump:
+    name: Bump Python
+    runs-on: ubuntu-22.04
+    # Backstop the whole job well under the 6h default. The work is a couple of
+    # API calls plus a PR open; the per-request urlopen timeouts cover the
+    # network, this covers anything else that could wedge.
+    timeout-minutes: 20
+    # Authenticate as the ESPHome GitHub App using the org-level client id
+    # (variable) and private key (secret) shared across all workflows. The app
+    # token, rather than the default GITHUB_TOKEN, is what lets the opened PR
+    # trigger the Build + lint/test workflows.
+    permissions:
+      contents: read
+
+    steps:
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.ESPHOME_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.11"
+
+      - name: Resolve and apply bump
+        id: bump
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: python3 .github/scripts/bump_bundle_versions.py
+
+      - name: Create or update pull request
+        if: steps.bump.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          branch: auto/bump-python
+          base: main
+          delete-branch: true
+          title: ${{ steps.bump.outputs.title }}
+          body: ${{ steps.bump.outputs.body }}
+          commit-message: ${{ steps.bump.outputs.title }}

--- a/.github/workflows/bump-bundle-versions.yml
+++ b/.github/workflows/bump-bundle-versions.yml
@@ -47,7 +47,7 @@ jobs:
           token: ${{ steps.generate-token.outputs.token }}
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.11"
 

--- a/tests/test_bump_bundle_versions.py
+++ b/tests/test_bump_bundle_versions.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""Tests for .github/scripts/bump_bundle_versions.py.
+
+The nightly bump job rewrites the pinned bundled Python version in
+prepare_bundle.sh and opens a PR. A bug here could pin a non-existent version,
+jump CPython minors (risking ESPHome/PlatformIO breakage), or mangle the script,
+so the pure transforms and the upstream-resolution logic get a regression net.
+Network access is monkeypatched out; nothing here touches GitHub.
+
+pytest suite (maintainer-requested framework, fully typed, no classes).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import urllib.error
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT_PATH = REPO_ROOT / ".github" / "scripts" / "bump_bundle_versions.py"
+
+# A trimmed prepare_bundle.sh carrying the assignments the script touches, in
+# the same shape as the real file.
+SAMPLE_SCRIPT = """\
+#!/bin/bash
+set -e
+
+PYTHON_VERSION="3.13.12"
+PBS_VERSION="20260203"
+BASE_URL="https://example/${PBS_VERSION}"
+"""
+
+
+def _load_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("bump_bundle_versions", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    # Register before exec so dataclasses can resolve the module's annotations
+    # (it looks the module up in sys.modules during class processing).
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+bump = _load_module()
+
+
+# --------------------------------------------------------------------------- #
+# Pure transforms.
+# --------------------------------------------------------------------------- #
+
+
+def test_read_assignment_returns_quoted_value() -> None:
+    assert bump.read_assignment(SAMPLE_SCRIPT, "PYTHON_VERSION") == "3.13.12"
+    assert bump.read_assignment(SAMPLE_SCRIPT, "PBS_VERSION") == "20260203"
+
+
+def test_read_assignment_missing_raises_keyerror() -> None:
+    with pytest.raises(KeyError):
+        bump.read_assignment(SAMPLE_SCRIPT, "NOPE")
+
+
+def test_has_assignment() -> None:
+    assert bump.has_assignment(SAMPLE_SCRIPT, "PBS_VERSION")
+    assert not bump.has_assignment(SAMPLE_SCRIPT, "MISSING")
+
+
+def test_replace_assignment_only_touches_target_line() -> None:
+    out = bump.replace_assignment(SAMPLE_SCRIPT, "PYTHON_VERSION", "3.13.13")
+    assert 'PYTHON_VERSION="3.13.13"' in out
+    # Replacing one var must leave every other assignment untouched, including
+    # the BASE_URL line that embeds ${PBS_VERSION}.
+    assert 'PBS_VERSION="20260203"' in out
+    assert 'BASE_URL="https://example/${PBS_VERSION}"' in out
+
+
+def test_replace_assignment_missing_raises() -> None:
+    with pytest.raises(KeyError):
+        bump.replace_assignment(SAMPLE_SCRIPT, "MISSING", "x")
+
+
+def test_current_python_minor() -> None:
+    assert bump.current_python_minor(SAMPLE_SCRIPT) == "3.13"
+
+
+def test_apply_bumps_reports_only_moved_vars() -> None:
+    result = bump.apply_bumps(
+        SAMPLE_SCRIPT,
+        {"PYTHON_VERSION": "3.13.13", "PBS_VERSION": "20260203"},
+    )
+    assert result.changed
+    # PBS_VERSION was already current, so only PYTHON_VERSION is recorded.
+    assert result.var_changes == {"PYTHON_VERSION": ("3.13.12", "3.13.13")}
+    assert 'PYTHON_VERSION="3.13.13"' in result.text
+
+
+def test_apply_bumps_no_change_is_not_changed() -> None:
+    result = bump.apply_bumps(SAMPLE_SCRIPT, {"PYTHON_VERSION": "3.13.12"})
+    assert not result.changed
+    assert result.var_changes == {}
+    assert result.text == SAMPLE_SCRIPT
+
+
+# --------------------------------------------------------------------------- #
+# Network retry behaviour.
+# --------------------------------------------------------------------------- #
+
+
+def test_with_retries_returns_on_first_success() -> None:
+    calls = []
+
+    def op() -> str:
+        calls.append(1)
+        return "ok"
+
+    assert bump._with_retries(op) == "ok"
+    assert len(calls) == 1
+
+
+def test_with_retries_recovers_after_transient_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(bump.time, "sleep", lambda _s: None)
+
+    attempts = {"n": 0}
+
+    def flaky() -> str:
+        attempts["n"] += 1
+        if attempts["n"] < bump.HTTP_RETRIES:
+            raise urllib.error.URLError("transient")
+        return "recovered"
+
+    assert bump._with_retries(flaky) == "recovered"
+    assert attempts["n"] == bump.HTTP_RETRIES
+
+
+def test_with_retries_reraises_persistent_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A persistent failure must propagate so the nightly job fails loudly
+    # rather than silently reporting "nothing to bump" and letting the bundled
+    # Python drift.
+    monkeypatch.setattr(bump.time, "sleep", lambda _s: None)
+
+    attempts = {"n": 0}
+
+    def always_fail() -> str:
+        attempts["n"] += 1
+        raise urllib.error.URLError("down")
+
+    with pytest.raises(urllib.error.URLError):
+        bump._with_retries(always_fail)
+    assert attempts["n"] == bump.HTTP_RETRIES
+
+
+# --------------------------------------------------------------------------- #
+# Upstream resolution (monkeypatched network).
+# --------------------------------------------------------------------------- #
+
+
+def _pbs_release() -> dict[str, Any]:
+    """A python-build-standalone release shaped like the real API payload."""
+    names = [
+        # Two 3.13 patches: the resolver must pick the higher one.
+        "cpython-3.13.12+20260602-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
+        "cpython-3.13.13+20260602-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
+        # A newer minor that must be ignored under the patch-only policy.
+        "cpython-3.14.1+20260602-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
+        # A different arch of 3.13 that the Linux-x86_64 regex shouldn't match.
+        "cpython-3.13.99+20260602-aarch64-apple-darwin-install_only_stripped.tar.gz",
+    ]
+    return {
+        "tag_name": "20260602",
+        "assets": [{"name": n} for n in names],
+    }
+
+
+def test_resolve_latest_python_picks_highest_patch_in_minor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(bump, "_api_get", lambda url: _pbs_release())
+    assert bump.resolve_latest_python("3.13") == ("20260602", "3.13.13")
+
+
+def test_resolve_latest_python_ignores_other_minor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # 3.12 has no build in this release, so we skip rather than jump to 3.13/3.14.
+    monkeypatch.setattr(bump, "_api_get", lambda url: _pbs_release())
+    assert bump.resolve_latest_python("3.12") is None
+
+
+# --------------------------------------------------------------------------- #
+# CLI behaviour (failure paths, output emission).
+# --------------------------------------------------------------------------- #
+
+
+def test_main_fails_when_variables_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # PBS_VERSION must exist; its absence is a real breakage and must fail the
+    # job (non-zero) rather than silently no-op, which would let the bundled
+    # Python drift unnoticed.
+    script = tmp_path / "prepare_bundle.sh"
+    script.write_text('PYTHON_VERSION="3.13.12"\n')
+    out = tmp_path / "out"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+
+    rc = bump.main(["--file", str(script)])
+    assert rc == 1
+    # A hard failure writes no outputs, so the create-PR step never fires.
+    assert not out.exists() or "changed=true" not in out.read_text()
+
+
+def test_main_fails_when_upstream_unresolvable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Resolver returning None (no build for the pinned minor) is a broken
+    # assumption, not a routine skip, so main must fail loudly.
+    script = tmp_path / "prepare_bundle.sh"
+    script.write_text(SAMPLE_SCRIPT)
+    out = tmp_path / "out"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+    monkeypatch.setattr(bump, "resolve_latest_python", lambda minor: None)
+
+    rc = bump.main(["--file", str(script)])
+    assert rc == 1
+    assert not out.exists() or "changed=true" not in out.read_text()
+
+
+def test_main_writes_file_and_outputs_on_bump(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    script = tmp_path / "prepare_bundle.sh"
+    script.write_text(SAMPLE_SCRIPT)
+    out = tmp_path / "out"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+    monkeypatch.setattr(
+        bump, "resolve_latest_python", lambda minor: ("20260602", "3.13.13")
+    )
+
+    rc = bump.main(["--file", str(script)])
+    assert rc == 0
+    assert 'PYTHON_VERSION="3.13.13"' in script.read_text()
+    assert 'PBS_VERSION="20260602"' in script.read_text()
+
+    output = out.read_text()
+    assert "changed=true" in output
+    assert "Bump bundled Python to 3.13.13" in output
+
+
+def test_main_build_only_bump_titles_the_build_not_the_version(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # New PBS release, same CPython patch: only PBS_VERSION moves, so the title
+    # must name the build rather than claim a (non-existent) version bump.
+    script = tmp_path / "prepare_bundle.sh"
+    script.write_text(SAMPLE_SCRIPT)
+    out = tmp_path / "out"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+    monkeypatch.setattr(
+        bump, "resolve_latest_python", lambda minor: ("20260602", "3.13.12")
+    )
+
+    rc = bump.main(["--file", str(script)])
+    assert rc == 0
+    assert 'PBS_VERSION="20260602"' in script.read_text()
+    assert 'PYTHON_VERSION="3.13.12"' in script.read_text()
+
+    output = out.read_text()
+    assert "changed=true" in output
+    assert "Bump bundled Python build to 20260602 (3.13.12)" in output
+
+
+def test_main_no_op_when_already_current(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    script = tmp_path / "prepare_bundle.sh"
+    script.write_text(SAMPLE_SCRIPT)
+    out = tmp_path / "out"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+    monkeypatch.setattr(
+        bump, "resolve_latest_python", lambda minor: ("20260203", "3.13.12")
+    )
+
+    rc = bump.main(["--file", str(script)])
+    assert rc == 0
+    assert script.read_text() == SAMPLE_SCRIPT
+    assert "changed=false" in out.read_text()


### PR DESCRIPTION
# What does this implement/fix?

The pinned Python interpreter (python-build-standalone) in `build-scripts/prepare_bundle.sh` drifts out of date when bumped by hand. This adds a nightly workflow that resolves the latest release and opens a pull request, so the full Build and lint/test CI runs before a human merges; nothing is pushed to main directly.

Policy: Python stays on its currently pinned minor and only takes newer patches, which avoids a surprise minor jump breaking ESPHome or PlatformIO; the PBS build-date tag always moves to the latest. The version rewriting is a pure, unit tested transform (`tests/test_bump_bundle_versions.py`, gated by the existing Scripts Test workflow). The job fails loudly if the expected variables are missing or the latest upstream release can't be resolved, with retries to absorb transient network blips, so a stale bundled Python can't drift unnoticed.

Auth uses the org-level ESPHome GitHub App credentials (client id variable, private key secret); the app token, not the default token, is what lets the opened PR trigger CI. The app needs pull-requests write for the create-pull-request step.

This is the Python-only rescope of the earlier combined workflow; the MinGit half was split out since bundling git is still under discussion.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- N/A

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).