### PR TITLE
Re-add MinGit Windows bundling

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -60,13 +60,13 @@ jobs:
           workspaces: src-tauri
           key: lint-test
 
-      # `tauri.conf.json` lists `python` as a bundle resource. That directory is
-      # gitignored and absent on a fresh checkout (it's populated by
-      # prepare_bundle.sh only for real bundling). A plain `cargo test`/`clippy`
-      # never bundles, but create an empty stub so config parsing can't trip on
-      # the missing path.
-      - name: Stub bundle resource dir
-        run: mkdir -p src-tauri/python
+      # `tauri.conf.json` lists `python` and `git` as bundle resources. Those
+      # directories are gitignored and absent on a fresh checkout (they're
+      # populated by prepare_bundle.sh only for real bundling). A plain
+      # `cargo test`/`clippy` never bundles, but create empty stubs so config
+      # parsing can't trip on the missing paths.
+      - name: Stub bundle resource dirs
+        run: mkdir -p src-tauri/python src-tauri/git
 
       # Required gates. clippy and rustfmt were introduced as advisory in the
       # first iteration of this workflow because they had never run in CI and the

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ pnpm-debug.log*
 
 # Python bundles (downloaded by build scripts)
 src-tauri/python/
+# Bundled MinGit on Windows (downloaded by build scripts)
+src-tauri/git/
 resources/
 
 # Python

--- a/build-scripts/prepare_bundle.sh
+++ b/build-scripts/prepare_bundle.sh
@@ -17,10 +17,25 @@ PYTHON_VERSION="3.13.12"
 PBS_VERSION="20260203"
 BASE_URL="https://github.com/astral-sh/python-build-standalone/releases/download/${PBS_VERSION}"
 
+# MinGit (minimal Git for Windows) is bundled on Windows only. ESPHome,
+# PlatformIO and esphome-device-builder shell out to `git` for external
+# components, github:// packages, voice models, ESP-IDF managed components and
+# git+https:// deps; Windows ships no git, so without this the most common
+# configs fail with a cryptic Python traceback (see issue #160). macOS prompts
+# for the Command Line Tools and Linux ships git, so neither needs bundling.
+# The full MinGit tree is required, not just git.exe: its bundled CA bundle
+# (mingw64/etc/ssl/certs/ca-bundle.crt) and system gitconfig are what make
+# HTTPS clones work without a system cert store or $HOME.
+MINGIT_VERSION="2.54.0"
+MINGIT_FILENAME="MinGit-${MINGIT_VERSION}-64-bit.zip"
+MINGIT_URL="https://github.com/git-for-windows/git/releases/download/v${MINGIT_VERSION}.windows.1/${MINGIT_FILENAME}"
+MINGIT_SHA256="04f937e1f0918b17b9be6f2294cb2bb66e96e1d9832d1c298e2de088a1d0e668"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 BUILD_DIR="$PROJECT_DIR/build"
 BUNDLE_DIR="$PROJECT_DIR/src-tauri/python"
+GIT_BUNDLE_DIR="$PROJECT_DIR/src-tauri/git"
 
 detect_platform() {
     local os=$(uname -s)
@@ -50,22 +65,55 @@ detect_platform() {
     esac
 }
 
+# Resolve the published SHA-256 for a python-build-standalone asset from the
+# release's SHA256SUMS manifest. Verifying against the same release we download
+# from matches the trust model of pinning the URL and catches a corrupted,
+# truncated, or cache-poisoned tarball. The manifest is cached under $BUILD_DIR.
+pbs_expected_sha256() {
+    local filename="$1"
+    local sums_file="$BUILD_DIR/SHA256SUMS-${PBS_VERSION}"
+
+    if [[ ! -f "$sums_file" ]]; then
+        curl -fL --retry 3 -o "${sums_file}.partial" "${BASE_URL}/SHA256SUMS"
+        mv -f "${sums_file}.partial" "$sums_file"
+    fi
+
+    local expected
+    expected=$(awk -v f="$filename" '$2 == f {print $1}' "$sums_file")
+    if [[ -z "$expected" ]]; then
+        echo "No SHA-256 entry for $filename in SHA256SUMS" >&2
+        exit 1
+    fi
+    echo "$expected"
+}
+
 # Download the python-build-standalone tarball for the given platform and
-# extract it to $BUILD_DIR/python-${platform}. Tarball downloads are cached
-# in /tmp so re-runs don't re-download.
+# extract it to $BUILD_DIR/python-${platform}. Downloads are cached under
+# $BUILD_DIR (which we own) so re-runs don't re-download, and verified against
+# the release's published SHA-256.
 download_and_extract_python() {
     local platform="$1"
     local filename="$2"
     local python_dir="$BUILD_DIR/python-${platform}"
     local url="${BASE_URL}/${filename}"
-    local temp_file="/tmp/${filename}"
+    # Cache under $BUILD_DIR rather than the shared, world-writable /tmp so a
+    # stale file owned by another user can't collide.
+    local temp_file="$BUILD_DIR/${filename}"
 
     echo ""
     echo "=== Downloading Python ${PYTHON_VERSION} for ${platform} ==="
-    if [[ ! -f "$temp_file" ]]; then
-        curl -L -o "$temp_file" "$url"
-    else
+    local expected_sha
+    expected_sha=$(pbs_expected_sha256 "$filename")
+    if [[ -f "$temp_file" ]]; then
         echo "Using cached download: $temp_file"
+        verify_sha256 "$temp_file" "$expected_sha"
+    else
+        # Atomic: download to .partial and promote to the cache path only once
+        # the checksum passes, so an interrupted or corrupt download never
+        # becomes a sticky, always-failing cache entry.
+        curl -fL --retry 3 -o "${temp_file}.partial" "$url"
+        verify_sha256 "${temp_file}.partial" "$expected_sha"
+        mv -f "${temp_file}.partial" "$temp_file"
     fi
 
     echo ""
@@ -73,6 +121,88 @@ download_and_extract_python() {
     rm -rf "$python_dir"
     mkdir -p "$python_dir"
     tar -xzf "$temp_file" -C "$python_dir" --strip-components=1
+}
+
+# Verify a file against an expected SHA-256, using whichever hashing tool the
+# runner provides (sha256sum on Linux / git-bash, shasum on macOS). Exits on
+# mismatch so a corrupted or tampered download can never make it into a bundle.
+verify_sha256() {
+    local file="$1"
+    local expected="$2"
+    local actual
+
+    if command -v sha256sum >/dev/null 2>&1; then
+        actual=$(sha256sum "$file" | cut -d' ' -f1)
+    elif command -v shasum >/dev/null 2>&1; then
+        actual=$(shasum -a 256 "$file" | cut -d' ' -f1)
+    else
+        echo "No SHA-256 tool (sha256sum/shasum) available; cannot verify $file"
+        exit 1
+    fi
+
+    if [[ "$actual" != "$expected" ]]; then
+        echo "SHA-256 mismatch for $file"
+        echo "  expected: $expected"
+        echo "  actual:   $actual"
+        exit 1
+    fi
+    echo "SHA-256 OK: $file"
+}
+
+# Stage git into $GIT_BUNDLE_DIR (src-tauri/git), bundled as a Tauri resource.
+#
+# Windows: download the pinned MinGit zip, verify its SHA-256, and extract the
+# full tree (cmd/git.exe, mingw64/..., the CA bundle and system gitconfig). At
+# runtime the app prepends git/cmd to PATH so ESPHome can find it.
+#
+# Other platforms: leave an empty directory so the "git" resource path in
+# tauri.conf.json resolves; git is never bundled there (Linux ships it, macOS
+# prompts for the Command Line Tools).
+prepare_git_for_platform() {
+    local platform="$1"
+
+    rm -rf "$GIT_BUNDLE_DIR"
+    mkdir -p "$GIT_BUNDLE_DIR"
+
+    if [[ "$platform" != "windows-x64" ]]; then
+        echo ""
+        echo "=== Skipping git bundle (${platform}); empty git/ placeholder created ==="
+        return
+    fi
+
+    # Cache under $BUILD_DIR (which we own and created) rather than the shared,
+    # world-writable /tmp so a stale file owned by another user can't collide.
+    local temp_file="$BUILD_DIR/${MINGIT_FILENAME}"
+
+    echo ""
+    echo "=== Downloading MinGit ${MINGIT_VERSION} ==="
+    if [[ -f "$temp_file" ]]; then
+        echo "Using cached download: $temp_file"
+        verify_sha256 "$temp_file" "$MINGIT_SHA256"
+    else
+        # `--fail` so an HTTP error is a non-zero exit (not a 200-status error
+        # body written to disk) and `--retry` to ride out transient blips.
+        # Download to a .partial and only rename onto the cache path once the
+        # checksum passes, so an interrupted or corrupt download never becomes a
+        # sticky, always-failing cache entry (the fixed-path cache trap from
+        # #152/#153).
+        curl -fL --retry 3 -o "${temp_file}.partial" "$MINGIT_URL"
+        verify_sha256 "${temp_file}.partial" "$MINGIT_SHA256"
+        mv -f "${temp_file}.partial" "$temp_file"
+    fi
+
+    echo ""
+    echo "=== Extracting MinGit into ${GIT_BUNDLE_DIR} ==="
+    # Extract with the standalone Python we just unpacked rather than `unzip`,
+    # which is not shipped with Git for Windows / git-bash and so is exactly the
+    # tool most likely to be missing on the only runner this path runs on.
+    # `python -m zipfile` is stdlib and guaranteed present here.
+    local python_exe="$BUILD_DIR/python-${platform}/python.exe"
+    if [[ ! -f "$python_exe" ]]; then
+        echo "Bundled Python not found at $python_exe; cannot extract MinGit"
+        exit 1
+    fi
+    "$python_exe" -m zipfile -e "$temp_file" "$GIT_BUNDLE_DIR"
 }
 
 # Rewrite pip-generated script shebangs so the bundle is relocatable.
@@ -217,6 +347,7 @@ rm -rf "$BUNDLE_DIR"
 mkdir -p "$BUILD_DIR"
 
 prepare_python_for_platform "$PLATFORM"
+prepare_git_for_platform "$PLATFORM"
 
 PYTHON_DIR="$BUILD_DIR/python-${PLATFORM}"
 
@@ -233,5 +364,9 @@ echo ""
 echo "=== Bundle ready ==="
 echo "Location: $BUNDLE_DIR"
 echo "Size: $BUNDLE_SIZE"
+if [[ "$PLATFORM" == "windows-x64" ]]; then
+    GIT_BUNDLE_SIZE=$(du -sh "$GIT_BUNDLE_DIR" | cut -f1)
+    echo "Bundled git: $GIT_BUNDLE_DIR ($GIT_BUNDLE_SIZE)"
+fi
 echo ""
 echo "You can now run 'cargo tauri build' to create the app bundle."

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -228,6 +228,16 @@ pub fn run(cli: Cli) {
                 // Continue anyway - might work with bundled Python
             }
 
+            // Make a git available to the ESPHome backend. On Windows this
+            // always prepends the bundled MinGit to PATH; no-op elsewhere. Runs
+            // before the daemon task spawns so the child (which inherits this
+            // process's PATH) and the missing-git check both observe it.
+            // Log-and-continue: a failure here only means git-dependent
+            // features fall back to the existing notification.
+            if let Err(e) = platform::ensure_git_on_path(app.handle()) {
+                error!("Failed to set up bundled git: {}", e);
+            }
+
             // One-shot prompt to remove the pre-rename `/Applications/ESPHome Builder.app`.
             // No-op on non-macOS and after the user has answered once.
             platform::cleanup_legacy_macos_app(app.handle());

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -5,6 +5,7 @@
 #![allow(dead_code)]
 
 use anyhow::{Context, Result};
+use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
 use tauri::{AppHandle, Manager};
 use tracing::debug;
@@ -160,6 +161,87 @@ pub fn get_python_bin(app_handle: &AppHandle) -> Result<PathBuf> {
     let bundled_bin = resource_dir.join("python").join("bin");
 
     Ok(bundled_bin)
+}
+
+/// Directory inside the bundled `git` resource that holds `git.exe`.
+///
+/// MinGit lays out a `cmd/git.exe` wrapper (alongside `mingw64/bin/git.exe`);
+/// `cmd` is the directory Git-for-Windows recommends putting on `PATH`.
+#[cfg(target_os = "windows")]
+pub fn get_bundled_git_dir(app_handle: &AppHandle) -> Result<PathBuf> {
+    let resource_dir = get_bundled_resource_dir(app_handle)?;
+    Ok(resource_dir.join("git").join("cmd"))
+}
+
+/// Build a `PATH` value with `dir` prepended to `existing`.
+///
+/// Pure (no environment mutation) so the prepend ordering, separator
+/// correctness, and non-Unicode `PATH` preservation can be unit-tested with a
+/// synthetic value rather than touching the real process environment — the same
+/// split-the-logic pattern `git_check::git_executable_in_path` uses. Going
+/// through `split_paths`/`join_paths` keeps the platform separator correct and
+/// round-trips a non-Unicode `PATH` instead of lossily dropping it.
+fn path_with_prepended(existing: &OsStr, dir: &Path) -> Result<OsString> {
+    // An empty `existing` (PATH unset) would split into a single empty entry,
+    // leaving a trailing "" in the result — which Windows search semantics
+    // treat as the current directory. Return just `dir` in that case.
+    if existing.is_empty() {
+        return Ok(dir.as_os_str().to_os_string());
+    }
+    let mut entries = vec![dir.to_path_buf()];
+    entries.extend(std::env::split_paths(existing));
+    std::env::join_paths(entries).context("Failed to build PATH with bundled git prepended")
+}
+
+/// Ensure a usable `git` is on `PATH` for the ESPHome backend we spawn.
+///
+/// ESPHome / PlatformIO / esphome-device-builder shell out to `git` for
+/// external components, `github://` packages, voice models, ESP-IDF managed
+/// components, and `git+https://` deps. Windows ships no git, so we bundle
+/// MinGit (which covers every git feature these use: HTTPS clone + submodules)
+/// and make it discoverable here (see issue #160).
+///
+/// Windows only: prepend the bundled MinGit `cmd` directory to this process's
+/// `PATH`. The spawned daemon inherits the process environment (it never sets
+/// `PATH` itself), and `git_check::notify_if_git_missing` reads the same
+/// `PATH`, so this single mutation both lets ESPHome find git and silences the
+/// missing-git notification. We always use the bundled git rather than probing
+/// for a system one — MinGit does everything we need, so there's no reason to
+/// add the complexity of preferring (and validating) whatever git a user
+/// happens to have.
+///
+/// No-op on macOS (the Command Line Tools prompt covers a missing git) and
+/// Linux (git ships on all but the most minimal installs).
+pub fn ensure_git_on_path(app_handle: &AppHandle) -> Result<()> {
+    #[cfg(target_os = "windows")]
+    {
+        use tracing::{info, warn};
+
+        let git_dir = get_bundled_git_dir(app_handle)?;
+        let git_exe = git_dir.join("git.exe");
+        if !git_exe.exists() {
+            warn!(
+                "Bundled MinGit missing at {:?}; git-dependent features will \
+                 fail until git is on PATH",
+                git_exe
+            );
+            return Ok(());
+        }
+
+        // Prepend the bundled git dir to PATH (see path_with_prepended for why
+        // it goes through split/join).
+        let existing = std::env::var_os("PATH").unwrap_or_default();
+        let new_path = path_with_prepended(&existing, &git_dir)?;
+        std::env::set_var("PATH", &new_path);
+        info!("Using bundled MinGit at {:?}", git_exe);
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = app_handle;
+    }
+
+    Ok(())
 }
 
 /// Filename of the marker recording which desktop-app version copied the
@@ -862,6 +944,49 @@ pub fn is_tray_supported() -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn path_with_prepended_puts_dir_first() {
+        let existing = std::env::join_paths(["/usr/bin", "/bin"]).unwrap();
+        let joined = path_with_prepended(&existing, Path::new("/opt/git/cmd")).unwrap();
+        let entries: Vec<PathBuf> = std::env::split_paths(&joined).collect();
+        assert_eq!(
+            entries,
+            vec![
+                PathBuf::from("/opt/git/cmd"),
+                PathBuf::from("/usr/bin"),
+                PathBuf::from("/bin"),
+            ],
+            "bundled git dir must come first so it shadows anything already on PATH"
+        );
+    }
+
+    #[test]
+    fn path_with_prepended_onto_empty_yields_just_dir() {
+        // var_os("PATH") missing degrades to an empty value; the result must be
+        // exactly the bundled git dir with no trailing empty entry (an empty
+        // PATH entry means the current directory under Windows search rules).
+        let joined = path_with_prepended(OsStr::new(""), Path::new("/opt/git/cmd")).unwrap();
+        let entries: Vec<PathBuf> = std::env::split_paths(&joined).collect();
+        assert_eq!(entries, vec![PathBuf::from("/opt/git/cmd")]);
+    }
+
+    /// A non-Unicode `PATH` is legal on Unix; the prepend must round-trip its
+    /// bytes verbatim rather than lossily mangling them (the whole reason the
+    /// helper works in `OsStr`/`OsString` instead of `str`).
+    #[cfg(unix)]
+    #[test]
+    fn path_with_prepended_preserves_non_unicode_existing() {
+        use std::os::unix::ffi::{OsStrExt, OsStringExt};
+
+        // 0xFF is not valid UTF-8 and is not the path separator, so it survives
+        // both the join and a re-split.
+        let existing = OsString::from_vec(b"/weird\xffdir".to_vec());
+        let joined = path_with_prepended(&existing, Path::new("/opt/git/cmd")).unwrap();
+        let entries: Vec<PathBuf> = std::env::split_paths(&joined).collect();
+        assert_eq!(entries[0], PathBuf::from("/opt/git/cmd"));
+        assert_eq!(entries[1].as_os_str().as_bytes(), b"/weird\xffdir");
+    }
 
     /// Unique temp dir per call. Combines the process id with a monotonic
     /// counter so tests running in parallel within the same process can never

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -44,7 +44,8 @@
       }
     },
     "resources": [
-      "python"
+      "python",
+      "git"
     ]
   },
   "plugins": {


### PR DESCRIPTION
# What does this implement/fix?

Reapplies #161 (bundling MinGit on Windows so ESPHome's git features work out of the box), which was reverted in #164. Opened unmerged so the team can decide direction: bundle MinGit for a works-out-of-the-box experience, or keep the current install-git popup and have users run the Git for Windows installer themselves.

No code changes from the original #161; this is a straight revert of the revert. The tradeoff for discussion: bundling means any git issue can become an ESPHome issue, versus a one-time "click next through the installer" ask that some new users find daunting.

Context: on Windows there is no system git, so external components, github:// packages, voice models, ESP-IDF managed components, and git+https deps fail with a cryptic Python traceback. macOS prompts for the Command Line Tools and Linux ships git, so this was Windows only. The change bundled the full MinGit tree (verified by SHA-256) and put it on PATH for the spawned backend.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes https://github.com/esphome/esphome-desktop/issues/160

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).