### PR TITLE
macOS: Don't show the app icon in the Dock or Cmd+Tab switcher.

### DIFF
--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>LSUIElement</key>
+    <true/>
+</dict>
+</plist>

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -232,6 +232,9 @@ pub fn run(cli: Cli) {
             // No-op on non-macOS and after the user has answered once.
             platform::cleanup_legacy_macos_app(app.handle());
 
+            // Perform platform-specific initialization
+            platform::init(app.handle());
+
             // Initialize app state
             let state = Arc::new(AppState::new(app.handle())?);
             app.manage(state.clone());

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -701,9 +701,10 @@ pub fn send_ctrl_break(pid: u32) -> bool {
 }
 
 /// Platform-specific initialization
-pub fn init() {
+#[cfg_attr(not(target_os = "macos"), allow(unused_variables))]
+pub fn init(app_handle: &AppHandle) {
     #[cfg(target_os = "macos")]
-    macos::init();
+    macos::init(app_handle);
 
     #[cfg(target_os = "windows")]
     windows::init();
@@ -714,9 +715,14 @@ pub fn init() {
 
 #[cfg(target_os = "macos")]
 mod macos {
-    pub fn init() {
-        // macOS-specific initialization
-        // e.g., set activation policy for menu bar app
+    use tauri::{ActivationPolicy, AppHandle};
+
+    pub fn init(app_handle: &AppHandle) {
+        // Tray-only app with no windows: mark it as an accessory app so it
+        // doesn't appear in the Dock or the Cmd+Tab switcher.
+        if let Err(e) = app_handle.set_activation_policy(ActivationPolicy::Accessory) {
+            tracing::warn!("Failed to set macOS activation policy to Accessory: {e}");
+        }
     }
 }
 


### PR DESCRIPTION
# What does this implement/fix?

This is a tray-only app on macOS, but it currently appears in the Dock and the Cmd+Tab switcher: selecting either of these does nothing.

To make it neater, this change initialises the app as an accessory app, making it only appear in the tray.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tested on the relevant platform(s) (macOS, Windows, Linux).
