### PR TITLE
docs(pr-comment): fetch macOS sign script via curl, no clone needed

### DIFF
--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -99,7 +99,7 @@ jobs:
           > These macOS builds are not signed or notarized, so Gatekeeper will refuse to open them. To run one, download the dmg, then re-sign it locally with the helper script from this repo. It needs no Apple certificate; by default it applies an ad-hoc signature that lets the app open on your own machine. No local clone required — download the script and run it directly:
           >
           > ```bash
-          > curl -fsSL https://raw.githubusercontent.com/esphome/esphome-desktop/main/build-scripts/sign_macos_local.sh -o sign_macos_local.sh
+          > curl -fsSL https://raw.githubusercontent.com/${{ github.repository }}/main/build-scripts/sign_macos_local.sh -o sign_macos_local.sh
           > bash sign_macos_local.sh ~/Downloads/the-downloaded.dmg
           > ```
           >

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -96,10 +96,11 @@ jobs:
           cat >> comment.md <<'EOF'
 
           > [!NOTE]
-          > These macOS builds are not signed or notarized, so Gatekeeper will refuse to open them. To run one, download the dmg, then re-sign it locally with the helper in this repo. It needs no Apple certificate; by default it applies an ad-hoc signature that lets the app open on your own machine.
+          > These macOS builds are not signed or notarized, so Gatekeeper will refuse to open them. To run one, download the dmg, then re-sign it locally with the helper script from this repo. It needs no Apple certificate; by default it applies an ad-hoc signature that lets the app open on your own machine. No local clone required — download the script and run it directly:
           >
           > ```bash
-          > ./build-scripts/sign_macos_local.sh ~/Downloads/the-downloaded.dmg
+          > curl -fsSL https://raw.githubusercontent.com/esphome/esphome-desktop/main/build-scripts/sign_macos_local.sh -o sign_macos_local.sh
+          > bash sign_macos_local.sh ~/Downloads/the-downloaded.dmg
           > ```
           >
           > Mount the resulting `*-signed.dmg`, drag the app to Applications, and it will open. Pass `--help` for Developer ID signing and other options.


### PR DESCRIPTION
# What does this implement/fix?

The build-artifacts comment posted on PRs told reviewers to re-sign unsigned macOS dmgs by running `./build-scripts/sign_macos_local.sh`, which only works if they have the repo cloned. This updates the instructions to `curl` the script straight from `main` and run it directly, so an unsigned dmg can be re-signed without a local clone.

The script is downloaded to a file (rather than `curl | bash`) on purpose: it reads `${BASH_SOURCE[0]}` for both its `--help` output and the entitlements path, both of which break when the script is piped from stdin. The default ad-hoc path needs no entitlements file, so a standalone download works for the common case.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes <link to issue>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).