### PR TITLE
Keep bundled MinGit up to date via the nightly bump job

### DIFF
--- a/.github/scripts/bump_bundle_versions.py
+++ b/.github/scripts/bump_bundle_versions.py
@@ -264,7 +264,12 @@ def _asset_sha256(asset: dict[str, Any]) -> str:
     digest = asset.get("digest") or ""
     if digest.startswith("sha256:"):
         return digest.split(":", 1)[1]
-    return _download_sha256(asset["browser_download_url"])
+    url = asset.get("browser_download_url")
+    if not url:
+        raise ResolutionError(
+            f"asset {asset.get('name')!r} has no digest or download URL"
+        )
+    return _download_sha256(url)
 
 
 def resolve_latest_mingit() -> tuple[str, str, str]:
@@ -344,9 +349,25 @@ def resolve_python_bump(text: str) -> tuple[BumpResult, str]:
     return result, title
 
 
+def _version_tuple(version: str) -> tuple[int, ...]:
+    """Parse a dotted MinGit version (e.g. "2.54.0" or rebuild "2.53.0.3")."""
+    return tuple(int(part) for part in version.split("."))
+
+
 def resolve_mingit_bump(text: str) -> tuple[BumpResult, str]:
     """Resolve the latest MinGit and compute the bump over `text`."""
+    current = read_assignment(text, "MINGIT_VERSION")
     version, url, sha256 = resolve_latest_mingit()
+    # Git for Windows releases move forward, so a resolved version older than the
+    # current pin means upstream republished an old tag as `latest` or unpublished
+    # a release. That's a broken assumption, not a routine skip: fail loudly
+    # rather than open a PR moving bundled git backwards (the sha check would pass
+    # on a genuine older release, so only this guard catches it).
+    if _version_tuple(version) < _version_tuple(current):
+        raise ResolutionError(
+            f"latest MinGit {version} is older than the pinned {current}; "
+            "refusing to downgrade"
+        )
     result = apply_bumps(
         text,
         {"MINGIT_VERSION": version, "MINGIT_URL": url, "MINGIT_SHA256": sha256},

--- a/.github/scripts/bump_bundle_versions.py
+++ b/.github/scripts/bump_bundle_versions.py
@@ -1,15 +1,19 @@
 #!/usr/bin/env python3
-"""Bump the pinned bundled Python version in build-scripts/prepare_bundle.sh.
+"""Bump pinned bundled dependencies in build-scripts/prepare_bundle.sh.
 
-Run nightly by .github/workflows/bump-bundle-versions.yml. It resolves the
-latest python-build-standalone release, rewrites the pinned version in
-prepare_bundle.sh, and emits GitHub Actions outputs that the workflow turns
-into a pull request.
+Run nightly by .github/workflows/bump-bundle-versions.yml, once per target
+(`--target python` and `--target mingit`). Each resolves the latest upstream
+release, rewrites the pinned values in prepare_bundle.sh, and emits GitHub
+Actions outputs that the workflow turns into its own pull request.
 
-Policy: PBS_VERSION (the build-date tag) always moves to the latest release;
-PYTHON_VERSION only takes a newer *patch* within the currently pinned minor
-(e.g. 3.13.x), never a minor or major jump, which could break
+Python policy: PBS_VERSION (the build-date tag) always moves to the latest
+release; PYTHON_VERSION only takes a newer *patch* within the currently pinned
+minor (e.g. 3.13.x), never a minor or major jump, which could break
 ESPHome/PlatformIO. A deliberate minor bump stays a manual change.
+
+MinGit policy: always track the latest git-for-windows release. Git is invoked
+as a subprocess, so a new minor or major won't break ESPHome/PlatformIO the way
+a Python minor could, and Git for Windows only maintains the newest line.
 
 The script fails loudly (non-zero exit) if the expected variables aren't found
 in prepare_bundle.sh, or if the latest upstream release can't be resolved —
@@ -24,12 +28,14 @@ workflow runs.
 
 Usage (GITHUB_TOKEN keeps the API calls off the anonymous rate limit):
 
-    GITHUB_TOKEN=... python3 .github/scripts/bump_bundle_versions.py
+    GITHUB_TOKEN=... python3 .github/scripts/bump_bundle_versions.py --target python
+    GITHUB_TOKEN=... python3 .github/scripts/bump_bundle_versions.py --target mingit
 """
 
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import re
@@ -46,6 +52,13 @@ REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 PREPARE_BUNDLE = REPO_ROOT / "build-scripts" / "prepare_bundle.sh"
 
 PBS_REPO = "astral-sh/python-build-standalone"
+
+GFW_REPO = "git-for-windows/git"
+
+# The plain 64-bit MinGit zip — not busybox, arm64 or 32-bit. The version token
+# is digits/dots only, so MinGit-2.54.0-busybox-64-bit.zip can't match while
+# rebuilds like MinGit-2.53.0.3-64-bit.zip still do.
+MINGIT_ASSET_RE = re.compile(r"MinGit-(?P<ver>[\d.]+)-64-bit\.zip")
 
 # Per-request network timeout. A stalled connection otherwise blocks the nightly
 # job until the workflow's multi-hour default timeout fires; failing fast lets
@@ -69,6 +82,14 @@ def _warn(msg: str) -> None:
 def _error(msg: str) -> None:
     """Emit a GitHub-Actions-style error to stderr (also readable locally)."""
     print(f"::error::{msg}", file=sys.stderr)
+
+
+class ResolutionError(Exception):
+    """An upstream assumption broke (missing asset, unresolvable release).
+
+    Raised so the nightly job fails loudly rather than silently no-opping and
+    letting a bundled dependency drift to a stale, vulnerable version.
+    """
 
 
 # --------------------------------------------------------------------------- #
@@ -218,6 +239,52 @@ def resolve_latest_python(minor: str) -> tuple[str, str] | None:
     return pbs_version, ".".join(str(p) for p in best)
 
 
+def _download_sha256(url: str) -> str:
+    """Stream a URL and return its SHA-256 hex digest."""
+
+    def fetch() -> str:
+        req = urllib.request.Request(url, headers=_gh_headers())
+        digest = hashlib.sha256()
+        with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:  # noqa: S310
+            for chunk in iter(lambda: resp.read(1 << 20), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
+
+    return _with_retries(fetch)
+
+
+def _asset_sha256(asset: dict[str, Any]) -> str:
+    """SHA-256 hex of a release asset.
+
+    Prefer the digest GitHub reports on the asset (no download); fall back to
+    streaming the asset and hashing it if the API ever omits it. A wrong value
+    can't ship: prepare_bundle.sh verifies the download at build time, so the
+    Windows build goes red on mismatch rather than bundling the wrong bytes.
+    """
+    digest = asset.get("digest") or ""
+    if digest.startswith("sha256:"):
+        return digest.split(":", 1)[1]
+    return _download_sha256(asset["browser_download_url"])
+
+
+def resolve_latest_mingit() -> tuple[str, str, str]:
+    """Return `(version, url, sha256)` for the latest 64-bit MinGit zip.
+
+    Picks the plain x86-64 MinGit asset from the latest git-for-windows release
+    and reads its checksum, so the literal download URL and digest land in
+    prepare_bundle.sh even for `.windows.N` rebuilds whose filename carries the
+    build number.
+    """
+    release = _api_get(f"https://api.github.com/repos/{GFW_REPO}/releases/latest")
+    for asset in release.get("assets", []):
+        m = MINGIT_ASSET_RE.fullmatch(asset.get("name", ""))
+        if m is not None:
+            return m.group("ver"), asset["browser_download_url"], _asset_sha256(asset)
+    raise ResolutionError(
+        f"no 64-bit MinGit asset in {GFW_REPO} release {release.get('tag_name')!r}"
+    )
+
+
 # --------------------------------------------------------------------------- #
 # Output + CLI glue.
 # --------------------------------------------------------------------------- #
@@ -242,51 +309,27 @@ def _emit_outputs(**outputs: str) -> None:
         sys.stdout.write(payload)
 
 
-def _build_body(var_changes: dict[str, tuple[str, str]]) -> str:
+def _build_body(subject: str, var_changes: dict[str, tuple[str, str]]) -> str:
     """Short, human-readable PR body describing the bump."""
     bullets = "\n".join(
         f"* {var} {old} to {new}" for var, (old, new) in var_changes.items()
     )
     return (
-        "Automated nightly bump of the bundled Python interpreter.\n\n"
+        f"Automated nightly bump of the bundled {subject}.\n\n"
         f"{bullets}\n\n"
         "CI builds and tests this branch; merge once the platform builds pass."
     )
 
 
-def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "--file",
-        default=str(PREPARE_BUNDLE),
-        help="Path to prepare_bundle.sh (defaults to the in-repo copy).",
-    )
-    args = parser.parse_args(argv)
-
-    path = Path(args.file)
-    text = path.read_text(encoding="utf-8")
-
-    # These variables are expected to exist. A missing one means
-    # prepare_bundle.sh was renamed/restructured and this script needs
-    # updating, so fail loudly rather than silently reporting "nothing to bump"
-    # — a quiet no-op would let the bundled Python drift and could ship a stale,
-    # vulnerable version unnoticed.
-    required = ("PYTHON_VERSION", "PBS_VERSION")
-    missing = [var for var in required if not has_assignment(text, var)]
-    if missing:
-        _error(
-            f"{', '.join(missing)} not found in {path.name}; "
-            "the Python bump script needs updating"
-        )
-        return 1
-
+def resolve_python_bump(text: str) -> tuple[BumpResult, str]:
+    """Resolve the latest Python and compute the bump over `text`."""
     latest = resolve_latest_python(current_python_minor(text))
     if latest is None:
         # The pinned minor has no build in the latest release (resolver already
-        # logged why). That's a broken assumption, not a routine skip, so fail
-        # rather than silently never bumping.
-        _error("could not resolve the latest Python for the pinned minor")
-        return 1
+        # logged why). That's a broken assumption, not a routine skip.
+        raise ResolutionError(
+            "could not resolve the latest Python for the pinned minor"
+        )
 
     pbs_version, python_version = latest
     result = apply_bumps(
@@ -298,21 +341,94 @@ def main(argv: list[str] | None = None) -> int:
         title = f"Bump bundled Python to {python_version}"
     else:
         title = f"Bump bundled Python build to {pbs_version} ({python_version})"
+    return result, title
+
+
+def resolve_mingit_bump(text: str) -> tuple[BumpResult, str]:
+    """Resolve the latest MinGit and compute the bump over `text`."""
+    version, url, sha256 = resolve_latest_mingit()
+    result = apply_bumps(
+        text,
+        {"MINGIT_VERSION": version, "MINGIT_URL": url, "MINGIT_SHA256": sha256},
+    )
+    return result, f"Bump bundled MinGit to {version}"
+
+
+# Resolves the latest upstream release and computes the bump over the file text.
+_Resolver = Callable[[str], tuple[BumpResult, str]]
+
+# Each target names the prepare_bundle.sh variables that must exist (a missing
+# one means the file was restructured and this script needs updating), the
+# resolver that computes its bump, and the noun used in the PR body.
+TARGETS: dict[str, tuple[tuple[str, ...], _Resolver, str]] = {
+    "python": (
+        ("PYTHON_VERSION", "PBS_VERSION"),
+        resolve_python_bump,
+        "Python interpreter",
+    ),
+    "mingit": (
+        ("MINGIT_VERSION", "MINGIT_URL", "MINGIT_SHA256"),
+        resolve_mingit_bump,
+        "MinGit (Git for Windows)",
+    ),
+}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--target",
+        choices=sorted(TARGETS),
+        default="python",
+        help="Which bundled dependency to bump.",
+    )
+    parser.add_argument(
+        "--file",
+        default=str(PREPARE_BUNDLE),
+        help="Path to prepare_bundle.sh (defaults to the in-repo copy).",
+    )
+    args = parser.parse_args(argv)
+
+    required, resolve_bump, subject = TARGETS[args.target]
+
+    path = Path(args.file)
+    text = path.read_text(encoding="utf-8")
+
+    # These variables are expected to exist. A missing one means
+    # prepare_bundle.sh was renamed/restructured and this script needs
+    # updating, so fail loudly rather than silently reporting "nothing to bump"
+    # — a quiet no-op would let the bundled dependency drift and could ship a
+    # stale, vulnerable version unnoticed.
+    missing = [var for var in required if not has_assignment(text, var)]
+    if missing:
+        _error(
+            f"{', '.join(missing)} not found in {path.name}; "
+            "the bump script needs updating"
+        )
+        return 1
+
+    try:
+        result, title = resolve_bump(text)
+    except ResolutionError as exc:
+        # A broken upstream assumption, not a routine skip: fail loudly rather
+        # than silently never bumping.
+        _error(str(exc))
+        return 1
 
     if not result.changed:
-        print("Bundled Python already up to date; nothing to bump.")
+        print(f"Bundled {subject} already up to date; nothing to bump.")
         _emit_outputs(changed="false")
         return 0
 
     path.write_text(result.text, encoding="utf-8")
-    print("Bumped bundled Python:")
+    print(f"Bumped bundled {subject}:")
     for var, (old, new) in result.var_changes.items():
         print(f"  {var}: {old} -> {new}")
 
     _emit_outputs(
         changed="true",
         title=title,
-        body=_build_body(result.var_changes),
+        body=_build_body(subject, result.var_changes),
     )
     return 0
 

--- a/.github/workflows/bump-bundle-versions.yml
+++ b/.github/workflows/bump-bundle-versions.yml
@@ -1,10 +1,11 @@
 name: Bump bundle versions
 
-# Nightly check for a newer pinned bundled Python in
-# build-scripts/prepare_bundle.sh and open a PR when one is available. The
-# Python interpreter (python-build-standalone) stays on its current minor and
-# only takes newer patches. The PR (not a direct push) runs the full Build +
-# lint/test CI so a human merges only after the platforms are green.
+# Nightly check for newer pinned bundled dependencies in
+# build-scripts/prepare_bundle.sh, one PR per target when an update is
+# available. Python (python-build-standalone) stays on its current minor and
+# only takes newer patches; MinGit (Git for Windows) tracks the latest release.
+# The PR (not a direct push) runs the full Build + lint/test CI so a human
+# merges only after the platforms are green.
 
 on:
   schedule:
@@ -20,7 +21,7 @@ concurrency:
 
 jobs:
   bump:
-    name: Bump Python
+    name: Bump ${{ matrix.target }}
     runs-on: ubuntu-22.04
     # Backstop the whole job well under the 6h default. The work is a couple of
     # API calls plus a PR open; the per-request urlopen timeouts cover the
@@ -32,6 +33,12 @@ jobs:
     # trigger the Build + lint/test workflows.
     permissions:
       contents: read
+    strategy:
+      # Each target is independent; a transient failure resolving one must not
+      # cancel the other's bump.
+      fail-fast: false
+      matrix:
+        target: [python, mingit]
 
     steps:
       - name: Generate a token
@@ -55,14 +62,14 @@ jobs:
         id: bump
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-        run: python3 .github/scripts/bump_bundle_versions.py
+        run: python3 .github/scripts/bump_bundle_versions.py --target ${{ matrix.target }}
 
       - name: Create or update pull request
         if: steps.bump.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ steps.generate-token.outputs.token }}
-          branch: auto/bump-python
+          branch: auto/bump-${{ matrix.target }}
           base: main
           delete-branch: true
           title: ${{ steps.bump.outputs.title }}

--- a/build-scripts/prepare_bundle.sh
+++ b/build-scripts/prepare_bundle.sh
@@ -26,9 +26,13 @@ BASE_URL="https://github.com/astral-sh/python-build-standalone/releases/download
 # The full MinGit tree is required, not just git.exe: its bundled CA bundle
 # (mingw64/etc/ssl/certs/ca-bundle.crt) and system gitconfig are what make
 # HTTPS clones work without a system cert store or $HOME.
+# MINGIT_VERSION is display-only; MINGIT_URL is the literal asset URL rather
+# than something rebuilt from the version, because Git for Windows rebuilds
+# encode their build number differently in the tag and the filename (e.g. tag
+# v2.53.0.windows.3 ships MinGit-2.53.0.3-64-bit.zip). All three are rewritten
+# by the nightly `bump_bundle_versions.py --target mingit` job.
 MINGIT_VERSION="2.54.0"
-MINGIT_FILENAME="MinGit-${MINGIT_VERSION}-64-bit.zip"
-MINGIT_URL="https://github.com/git-for-windows/git/releases/download/v${MINGIT_VERSION}.windows.1/${MINGIT_FILENAME}"
+MINGIT_URL="https://github.com/git-for-windows/git/releases/download/v2.54.0.windows.1/MinGit-2.54.0-64-bit.zip"
 MINGIT_SHA256="04f937e1f0918b17b9be6f2294cb2bb66e96e1d9832d1c298e2de088a1d0e668"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -189,7 +193,7 @@ prepare_git_for_platform() {
 
     # Cache under $BUILD_DIR (which we own and created) rather than the shared,
     # world-writable /tmp so a stale file owned by another user can't collide.
-    local temp_file="$BUILD_DIR/${MINGIT_FILENAME}"
+    local temp_file="$BUILD_DIR/$(basename "$MINGIT_URL")"
 
     echo ""
     echo "=== Downloading MinGit ${MINGIT_VERSION} ==="

--- a/tests/test_bump_bundle_versions.py
+++ b/tests/test_bump_bundle_versions.py
@@ -277,6 +277,13 @@ def test_asset_sha256_falls_back_to_download(monkeypatch: pytest.MonkeyPatch) ->
     assert bump._asset_sha256(asset) == "ef" * 32
 
 
+def test_asset_sha256_raises_resolution_error_without_digest_or_url() -> None:
+    # Neither a usable digest nor a download URL: a clean ResolutionError rather
+    # than a bare KeyError, matching the rest of the broken-upstream handling.
+    with pytest.raises(bump.ResolutionError):
+        bump._asset_sha256({"name": "MinGit-2.54.0-64-bit.zip"})
+
+
 # --------------------------------------------------------------------------- #
 # CLI behaviour (failure paths, output emission).
 # --------------------------------------------------------------------------- #
@@ -424,6 +431,36 @@ def test_main_mingit_no_op_when_already_current(
     assert rc == 0
     assert script.read_text() == SAMPLE_SCRIPT
     assert "changed=false" in out.read_text()
+
+
+def test_main_mingit_refuses_downgrade(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Current pin is 2.53.0; a resolved older release (upstream republished an
+    # old tag as latest) must fail loudly rather than open a backwards PR.
+    script = tmp_path / "prepare_bundle.sh"
+    script.write_text(SAMPLE_SCRIPT)
+    out = tmp_path / "out"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+    old_url = (
+        "https://github.com/git-for-windows/git/releases/download/"
+        "v2.52.0.windows.1/MinGit-2.52.0-64-bit.zip"
+    )
+    monkeypatch.setattr(
+        bump, "resolve_latest_mingit", lambda: ("2.52.0", old_url, "aa" * 32)
+    )
+
+    rc = bump.main(["--target", "mingit", "--file", str(script)])
+    assert rc == 1
+    # The file is untouched and no bump output is written.
+    assert script.read_text() == SAMPLE_SCRIPT
+    assert not out.exists() or "changed=true" not in out.read_text()
+
+
+def test_version_tuple_orders_rebuilds_after_base() -> None:
+    # A .windows.N rebuild (2.53.0.3) must sort after the base release (2.53.0).
+    assert bump._version_tuple("2.53.0.3") > bump._version_tuple("2.53.0")
+    assert bump._version_tuple("2.54.0") > bump._version_tuple("2.53.0.3")
 
 
 def test_main_mingit_fails_when_variables_absent(

--- a/tests/test_bump_bundle_versions.py
+++ b/tests/test_bump_bundle_versions.py
@@ -33,6 +33,10 @@ set -e
 PYTHON_VERSION="3.13.12"
 PBS_VERSION="20260203"
 BASE_URL="https://example/${PBS_VERSION}"
+
+MINGIT_VERSION="2.53.0"
+MINGIT_URL="https://github.com/git-for-windows/git/releases/download/v2.53.0.windows.1/MinGit-2.53.0-64-bit.zip"
+MINGIT_SHA256="0000000000000000000000000000000000000000000000000000000000000000"
 """
 
 
@@ -195,6 +199,84 @@ def test_resolve_latest_python_ignores_other_minor(
     assert bump.resolve_latest_python("3.12") is None
 
 
+def _gfw_release(tag: str, mingit_ver: str) -> dict[str, Any]:
+    """A git-for-windows release shaped like the real API payload.
+
+    The plain 64-bit MinGit zip must be chosen over the busybox, arm64 and
+    32-bit siblings, and the version token must come straight from its name (so
+    a `.windows.N` rebuild's `MinGit-2.53.0.3-64-bit.zip` resolves to 2.53.0.3).
+    """
+    base = f"https://github.com/git-for-windows/git/releases/download/{tag}"
+    names = [
+        f"MinGit-{mingit_ver}-32-bit.zip",
+        f"MinGit-{mingit_ver}-arm64.zip",
+        f"MinGit-{mingit_ver}-busybox-64-bit.zip",
+        f"MinGit-{mingit_ver}-64-bit.zip",
+    ]
+    return {
+        "tag_name": tag,
+        "assets": [
+            {
+                "name": n,
+                "browser_download_url": f"{base}/{n}",
+                "digest": f"sha256:{'ab' * 32}",
+            }
+            for n in names
+        ],
+    }
+
+
+def test_resolve_latest_mingit_picks_plain_64bit_asset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        bump, "_api_get", lambda url: _gfw_release("v2.54.0.windows.1", "2.54.0")
+    )
+    version, url, sha = bump.resolve_latest_mingit()
+    assert version == "2.54.0"
+    assert url.endswith("/v2.54.0.windows.1/MinGit-2.54.0-64-bit.zip")
+    assert sha == "ab" * 32
+
+
+def test_resolve_latest_mingit_handles_rebuild(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A .windows.N rebuild encodes the build number in the filename; the literal
+    # URL and the version both come from the asset, not a reconstruction.
+    monkeypatch.setattr(
+        bump, "_api_get", lambda url: _gfw_release("v2.53.0.windows.3", "2.53.0.3")
+    )
+    version, url, _sha = bump.resolve_latest_mingit()
+    assert version == "2.53.0.3"
+    assert url.endswith("/v2.53.0.windows.3/MinGit-2.53.0.3-64-bit.zip")
+
+
+def test_resolve_latest_mingit_raises_when_no_asset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        bump, "_api_get", lambda url: {"tag_name": "v2.54.0.windows.1", "assets": []}
+    )
+    with pytest.raises(bump.ResolutionError):
+        bump.resolve_latest_mingit()
+
+
+def test_asset_sha256_prefers_digest_without_download(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _no_download(url: str) -> str:
+        raise AssertionError("should not download when a digest is present")
+
+    monkeypatch.setattr(bump, "_download_sha256", _no_download)
+    assert bump._asset_sha256({"digest": f"sha256:{'cd' * 32}"}) == "cd" * 32
+
+
+def test_asset_sha256_falls_back_to_download(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(bump, "_download_sha256", lambda url: "ef" * 32)
+    asset = {"digest": None, "browser_download_url": "https://example/MinGit.zip"}
+    assert bump._asset_sha256(asset) == "ef" * 32
+
+
 # --------------------------------------------------------------------------- #
 # CLI behaviour (failure paths, output emission).
 # --------------------------------------------------------------------------- #
@@ -292,3 +374,68 @@ def test_main_no_op_when_already_current(
     assert rc == 0
     assert script.read_text() == SAMPLE_SCRIPT
     assert "changed=false" in out.read_text()
+
+
+def test_main_mingit_writes_file_and_outputs_on_bump(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    script = tmp_path / "prepare_bundle.sh"
+    script.write_text(SAMPLE_SCRIPT)
+    out = tmp_path / "out"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+    new_url = (
+        "https://github.com/git-for-windows/git/releases/download/"
+        "v2.54.0.windows.1/MinGit-2.54.0-64-bit.zip"
+    )
+    monkeypatch.setattr(
+        bump, "resolve_latest_mingit", lambda: ("2.54.0", new_url, "ff" * 32)
+    )
+
+    rc = bump.main(["--target", "mingit", "--file", str(script)])
+    assert rc == 0
+    text = script.read_text()
+    assert 'MINGIT_VERSION="2.54.0"' in text
+    assert f'MINGIT_URL="{new_url}"' in text
+    assert f'MINGIT_SHA256="{"ff" * 32}"' in text
+    # The Python pins are untouched by a MinGit bump.
+    assert 'PYTHON_VERSION="3.13.12"' in text
+
+    output = out.read_text()
+    assert "changed=true" in output
+    assert "Bump bundled MinGit to 2.54.0" in output
+
+
+def test_main_mingit_no_op_when_already_current(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    script = tmp_path / "prepare_bundle.sh"
+    script.write_text(SAMPLE_SCRIPT)
+    out = tmp_path / "out"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+    current_url = (
+        "https://github.com/git-for-windows/git/releases/download/"
+        "v2.53.0.windows.1/MinGit-2.53.0-64-bit.zip"
+    )
+    monkeypatch.setattr(
+        bump, "resolve_latest_mingit", lambda: ("2.53.0", current_url, "0" * 64)
+    )
+
+    rc = bump.main(["--target", "mingit", "--file", str(script)])
+    assert rc == 0
+    assert script.read_text() == SAMPLE_SCRIPT
+    assert "changed=false" in out.read_text()
+
+
+def test_main_mingit_fails_when_variables_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # No MinGit pins present: a real breakage that must fail the job rather than
+    # silently no-op and let the bundled git drift.
+    script = tmp_path / "prepare_bundle.sh"
+    script.write_text('PYTHON_VERSION="3.13.12"\nPBS_VERSION="20260203"\n')
+    out = tmp_path / "out"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+
+    rc = bump.main(["--target", "mingit", "--file", str(script)])
+    assert rc == 1
+    assert not out.exists() or "changed=true" not in out.read_text()


### PR DESCRIPTION
# What does this implement/fix?

The nightly bump job only tracked the bundled Python; this extends it to MinGit so Git for Windows gets the same automated update PRs instead of sitting on a hand pinned version. The bump script grows a `--target {python,mingit}` mode; the mingit target resolves the latest git-for-windows release, writes the literal `MINGIT_URL` and `MINGIT_SHA256` into `prepare_bundle.sh`, and the workflow runs the two targets as a matrix so each opens its own PR.

`MINGIT_URL` is now stored whole rather than rebuilt from the version, because `.windows.N` rebuilds encode the build number differently in the tag and the filename (tag `v2.53.0.windows.3` ships `MinGit-2.53.0.3-64-bit.zip`), so deriving the URL from the version cannot represent a rebuild. The sha256 comes from the release asset digest the API reports, falling back to hashing the download if it is ever missing; a wrong value cannot ship since the build verifies the download and goes red on mismatch.

Verified locally against the live git-for-windows API: a no op on the current 2.54.0 and a correct rewrite (URL, version, sha256) when pinned to an older version. New unit tests cover asset selection, rebuild naming, digest vs download fallback, and the CLI bump and no op paths.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- follow-up to #166

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).