### PR TITLE
Add Launch at Login option for remote builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Right-click (or left-click on some platforms) the tray icon to access:
 
 To keep a machine acting as an always-on builder, leave **Startup → Launch at Login** enabled (the default) so the app relaunches after a reboot. It registers a per-user login item (a macOS LaunchAgent, a Windows `HKCU\...\Run` entry, or a Linux `~/.config/autostart` entry), not a system service, so it starts when a desktop session logs in rather than at boot. For an unattended box that reboots on its own, enable your OS's automatic login so a session starts without someone at the keyboard; otherwise the builder stays offline until someone logs in. The login launch is silent (tray only, no browser).
 
+Turn autostart off with **Startup → Don't Launch at Login**, not the OS's own login-items UI: the app reconciles the login item to its saved preference on every launch, so an entry removed through *System Settings → Login Items* (macOS), *Startup Apps* (Windows), or `~/.config/autostart` (Linux) is re-created on the next start.
+
 ### Data Locations
 
 Application data (bundled Python, logs, settings):

--- a/README.md
+++ b/README.md
@@ -50,11 +50,18 @@ Right-click (or left-click on some platforms) the tray icon to access:
 - **Open Dashboard** - Open the dashboard in your browser
 - **Status** - Shows if the daemon is running
 - **Port** - Shows the configured port
+- **Backend** - Choose the classic ESPHome dashboard or the ESPHome Device Builder backend
+- **Release Channel** - Choose the update channel (Stable, Beta, Dev)
+- **Startup** - Choose whether the app launches automatically at login (on by default; see [Running as a remote builder](#running-as-a-remote-builder))
 - **Check for Updates** - Check for a new ESPHome Device Builder desktop release, then new ESPHome (Python) and device-builder versions
 - **View Logs** - Open the logs folder
 - **Open Config Folder** - Open where your ESPHome configs are stored
 - **Restart Dashboard** - Restart the ESPHome process
 - **Quit ESPHome** - Stop the daemon and exit
+
+### Running as a remote builder
+
+To keep a machine acting as an always-on builder, leave **Startup → Launch at Startup** enabled (the default) so the app relaunches after a reboot. It registers a per-user login item (a macOS LaunchAgent, a Windows `HKCU\...\Run` entry, or a Linux `~/.config/autostart` entry), not a system service, so it starts when a desktop session logs in rather than at boot. For an unattended box that reboots on its own, enable your OS's automatic login so a session starts without someone at the keyboard; otherwise the builder stays offline until someone logs in. The login launch is silent (tray only, no browser).
 
 ### Data Locations
 
@@ -142,6 +149,7 @@ Settings are stored in `settings.json`:
   "port": 6052,
   "config_dir": null,
   "open_on_start": true,
+  "launch_at_startup": true,
   "check_updates": true
 }
 ```
@@ -149,6 +157,7 @@ Settings are stored in `settings.json`:
 - `port` - Dashboard port (default: 6052)
 - `config_dir` - Custom config directory (null = use default)
 - `open_on_start` - Open browser when app starts
+- `launch_at_startup` - Launch the app automatically at login (default: true; see [Running as a remote builder](#running-as-a-remote-builder))
 - `check_updates` - Check for ESPHome updates automatically
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Right-click (or left-click on some platforms) the tray icon to access:
 
 ### Running as a remote builder
 
-To keep a machine acting as an always-on builder, leave **Startup → Launch at Startup** enabled (the default) so the app relaunches after a reboot. It registers a per-user login item (a macOS LaunchAgent, a Windows `HKCU\...\Run` entry, or a Linux `~/.config/autostart` entry), not a system service, so it starts when a desktop session logs in rather than at boot. For an unattended box that reboots on its own, enable your OS's automatic login so a session starts without someone at the keyboard; otherwise the builder stays offline until someone logs in. The login launch is silent (tray only, no browser).
+To keep a machine acting as an always-on builder, leave **Startup → Launch at Login** enabled (the default) so the app relaunches after a reboot. It registers a per-user login item (a macOS LaunchAgent, a Windows `HKCU\...\Run` entry, or a Linux `~/.config/autostart` entry), not a system service, so it starts when a desktop session logs in rather than at boot. For an unattended box that reboots on its own, enable your OS's automatic login so a session starts without someone at the keyboard; otherwise the builder stays offline until someone logs in. The login launch is silent (tray only, no browser).
 
 ### Data Locations
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -267,6 +267,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto-launch"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f012b8cc0c850f34117ec8252a44418f2e34a2cf501de89e29b241ae5f79471"
+dependencies = [
+ "dirs 4.0.0",
+ "thiserror 1.0.69",
+ "winreg 0.10.1",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -902,11 +913,31 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -917,7 +948,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
 
@@ -1044,7 +1075,7 @@ dependencies = [
  "rustc_version",
  "toml 0.9.11+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -1123,7 +1154,7 @@ dependencies = [
  "anyhow",
  "clap",
  "cocoa",
- "dirs",
+ "dirs 6.0.0",
  "libloading 0.9.0",
  "log",
  "nix",
@@ -1133,6 +1164,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-autostart",
  "tauri-plugin-dialog",
  "tauri-plugin-notification",
  "tauri-plugin-process",
@@ -3428,6 +3460,17 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
@@ -4405,7 +4448,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "cookie",
- "dirs",
+ "dirs 6.0.0",
  "dunce",
  "embed_plist",
  "getrandom 0.3.4",
@@ -4455,7 +4498,7 @@ checksum = "4aa1f9055fc23919a54e4e125052bed16ed04aef0487086e758fe01a67b451c7"
 dependencies = [
  "anyhow",
  "cargo_toml",
- "dirs",
+ "dirs 6.0.0",
  "glob",
  "heck 0.5.0",
  "json-patch",
@@ -4524,6 +4567,20 @@ dependencies = [
  "tauri-utils",
  "toml 0.9.11+spec-1.1.0",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-autostart"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459383cebc193cdd03d1ba4acc40f2c408a7abce419d64bdcd2d745bc2886f70"
+dependencies = [
+ "auto-launch",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4640,7 +4697,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
 dependencies = [
  "base64 0.22.1",
- "dirs",
+ "dirs 6.0.0",
  "flate2",
  "futures-util",
  "http",
@@ -5203,7 +5260,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15edbb0d80583e85ee8df283410038e17314df5cba30da2087a54a85216c0773"
 dependencies = [
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "libappindicator",
  "muda",
  "objc2",
@@ -6152,6 +6209,15 @@ checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 
 [[package]]
 name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winreg"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
@@ -6182,7 +6248,7 @@ dependencies = [
  "block2",
  "cookie",
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "dom_query",
  "dpi",
  "dunce",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -24,6 +24,7 @@ tauri-plugin-notification = "2"
 tauri-plugin-process = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-updater = "2"
+tauri-plugin-autostart = "2"
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -20,6 +20,7 @@ use tauri::{
     tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
     AppHandle, Manager, RunEvent,
 };
+use tauri_plugin_autostart::{MacosLauncher, ManagerExt};
 use tokio::sync::RwLock;
 use tracing::{error, info, warn};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
@@ -207,6 +208,14 @@ pub fn run(cli: Cli) {
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
+        // Launch silently on login (tray only, no browser) so a remote builder
+        // comes back online after a reboot; manual launches still open the
+        // dashboard. Whether the login item is registered is reconciled to the
+        // `launch_at_startup` setting in setup() below.
+        .plugin(tauri_plugin_autostart::init(
+            MacosLauncher::LaunchAgent,
+            Some(vec!["--no-open-dashboard"]),
+        ))
         .plugin(tauri_plugin_single_instance::init(|app, args, cwd| {
             // Another instance tried to start - open the dashboard instead
             info!(
@@ -274,6 +283,28 @@ pub fn run(cli: Cli) {
             } else {
                 false
             };
+
+            // Reconcile the OS login item to the persisted preference. This
+            // applies the on-by-default on first run and re-asserts a user's
+            // choice on every launch (so an "off" sticks and drift self-heals).
+            {
+                let want = async_runtime::block_on(state.settings.read()).launch_at_startup;
+                let manager = app.autolaunch();
+                match manager.is_enabled() {
+                    Ok(current) if current != want => {
+                        let result = if want {
+                            manager.enable()
+                        } else {
+                            manager.disable()
+                        };
+                        if let Err(e) = result {
+                            warn!("Failed to set autostart to {}: {}", want, e);
+                        }
+                    }
+                    Err(e) => warn!("Failed to query autostart state: {}", e),
+                    _ => {}
+                }
+            }
 
             // Build and set up the tray menu (if tray support is available)
             let tray_available = if platform::is_tray_supported() {

--- a/src-tauri/src/settings/mod.rs
+++ b/src-tauri/src/settings/mod.rs
@@ -83,6 +83,12 @@ pub struct Settings {
     #[serde(default = "default_true")]
     pub open_on_start: bool,
 
+    /// Launch the app automatically at system login/boot. On by default so a
+    /// remote builder comes back online after a reboot; the OS login item is
+    /// reconciled to this value on every launch.
+    #[serde(default = "default_true")]
+    pub launch_at_startup: bool,
+
     /// Check for updates automatically
     #[serde(default = "default_true")]
     pub check_updates: bool,
@@ -114,6 +120,7 @@ impl Default for Settings {
             port: DEFAULT_PORT,
             config_dir: None,
             open_on_start: true,
+            launch_at_startup: true,
             check_updates: true,
             release_channel: ReleaseChannel::default(),
             backend: Backend::default(),

--- a/src-tauri/src/tray/mod.rs
+++ b/src-tauri/src/tray/mod.rs
@@ -404,7 +404,13 @@ fn set_launch_at_startup(app_handle: &AppHandle, state: &Arc<AppState>, enable: 
             e
         );
     }
-    update_startup_checks(enable);
+    // Reflect the actual OS state rather than the requested one: enable/disable
+    // can fail (permissions, policy, platform limits), and showing the requested
+    // state would mislead. Fall back to the requested value only if the query
+    // itself fails. The persisted setting keeps the user's intent, so the
+    // launch-time reconcile retries.
+    let actual = manager.is_enabled().unwrap_or(enable);
+    update_startup_checks(actual);
 }
 
 /// Re-detect the installed version and update the tray version display.

--- a/src-tauri/src/tray/mod.rs
+++ b/src-tauri/src/tray/mod.rs
@@ -204,8 +204,13 @@ pub fn build_tray_menu(app_handle: &AppHandle, state: &Arc<AppState>) -> Result<
         .item(&backend_builder_beta)
         .build()?;
 
-    // Startup submenu items (radio group, mirroring Backend)
-    let launch_at_startup = settings.launch_at_startup;
+    // Startup submenu items (radio group, mirroring Backend). Label from the
+    // actual OS login-item state so a failed startup reconcile doesn't show a
+    // lie; fall back to the persisted intent only if the query itself errors.
+    let launch_at_startup = app_handle
+        .autolaunch()
+        .is_enabled()
+        .unwrap_or(settings.launch_at_startup);
     let startup_enable = MenuItemBuilder::with_id(
         ids::STARTUP_ENABLE,
         radio_label("Launch at Login", launch_at_startup),
@@ -382,15 +387,17 @@ fn update_startup_checks(enabled: bool) {
 fn set_launch_at_startup(app_handle: &AppHandle, state: &Arc<AppState>, enable: bool) {
     {
         let mut settings = async_runtime::block_on(state.settings.write());
-        if settings.launch_at_startup == enable {
-            return;
-        }
-        settings.launch_at_startup = enable;
-        if let Err(e) = settings.save(app_handle) {
-            warn!("Failed to save settings: {}", e);
+        if settings.launch_at_startup != enable {
+            settings.launch_at_startup = enable;
+            if let Err(e) = settings.save(app_handle) {
+                warn!("Failed to save settings: {}", e);
+            }
         }
     }
 
+    // Always (re)apply the OS call, even when the persisted value already
+    // matches, so clicking an already-selected item retries a registration that
+    // failed earlier (e.g. the startup reconcile) instead of no-opping.
     let manager = app_handle.autolaunch();
     let result = if enable {
         manager.enable()

--- a/src-tauri/src/tray/mod.rs
+++ b/src-tauri/src/tray/mod.rs
@@ -208,12 +208,12 @@ pub fn build_tray_menu(app_handle: &AppHandle, state: &Arc<AppState>) -> Result<
     let launch_at_startup = settings.launch_at_startup;
     let startup_enable = MenuItemBuilder::with_id(
         ids::STARTUP_ENABLE,
-        radio_label("Launch at Startup", launch_at_startup),
+        radio_label("Launch at Login", launch_at_startup),
     )
     .build(app_handle)?;
     let startup_disable = MenuItemBuilder::with_id(
         ids::STARTUP_DISABLE,
-        radio_label("Don't Launch at Startup", !launch_at_startup),
+        radio_label("Don't Launch at Login", !launch_at_startup),
     )
     .build(app_handle)?;
 
@@ -369,10 +369,10 @@ fn update_backend_checks(backend: Backend) {
 /// Update the startup menu item labels to reflect whether autostart is enabled.
 fn update_startup_checks(enabled: bool) {
     if let Some(item) = STARTUP_ENABLE_ITEM.get() {
-        let _ = item.set_text(radio_label("Launch at Startup", enabled));
+        let _ = item.set_text(radio_label("Launch at Login", enabled));
     }
     if let Some(item) = STARTUP_DISABLE_ITEM.get() {
-        let _ = item.set_text(radio_label("Don't Launch at Startup", !enabled));
+        let _ = item.set_text(radio_label("Don't Launch at Login", !enabled));
     }
 }
 

--- a/src-tauri/src/tray/mod.rs
+++ b/src-tauri/src/tray/mod.rs
@@ -9,6 +9,7 @@ use tauri::{
     menu::{Menu, MenuBuilder, MenuItem, MenuItemBuilder, SubmenuBuilder},
     AppHandle,
 };
+use tauri_plugin_autostart::ManagerExt;
 use tauri_plugin_dialog::{DialogExt, MessageDialogKind};
 use tauri_plugin_notification::NotificationExt;
 use tracing::{error, info, warn};
@@ -77,6 +78,10 @@ mod ids {
     pub const BACKEND_CLASSIC: &str = "backend_classic";
     pub const BACKEND_BUILDER_STABLE: &str = "backend_builder_stable";
     pub const BACKEND_BUILDER_BETA: &str = "backend_builder_beta";
+
+    // Startup submenu items
+    pub const STARTUP_ENABLE: &str = "startup_enable";
+    pub const STARTUP_DISABLE: &str = "startup_disable";
 }
 
 /// Build the tray menu
@@ -199,6 +204,27 @@ pub fn build_tray_menu(app_handle: &AppHandle, state: &Arc<AppState>) -> Result<
         .item(&backend_builder_beta)
         .build()?;
 
+    // Startup submenu items (radio group, mirroring Backend)
+    let launch_at_startup = settings.launch_at_startup;
+    let startup_enable = MenuItemBuilder::with_id(
+        ids::STARTUP_ENABLE,
+        radio_label("Launch at Startup", launch_at_startup),
+    )
+    .build(app_handle)?;
+    let startup_disable = MenuItemBuilder::with_id(
+        ids::STARTUP_DISABLE,
+        radio_label("Don't Launch at Startup", !launch_at_startup),
+    )
+    .build(app_handle)?;
+
+    let _ = STARTUP_ENABLE_ITEM.set(startup_enable.clone());
+    let _ = STARTUP_DISABLE_ITEM.set(startup_disable.clone());
+
+    let startup_submenu = SubmenuBuilder::with_id(app_handle, "startup", "Startup")
+        .item(&startup_enable)
+        .item(&startup_disable)
+        .build()?;
+
     let menu = MenuBuilder::new(app_handle)
         .item(
             &MenuItemBuilder::with_id(ids::OPEN_DASHBOARD, "Open Dashboard")
@@ -218,6 +244,7 @@ pub fn build_tray_menu(app_handle: &AppHandle, state: &Arc<AppState>) -> Result<
         .separator()
         .item(&backend_submenu)
         .item(&channel_submenu)
+        .item(&startup_submenu)
         .item(
             &MenuItemBuilder::with_id(ids::CHECK_UPDATES, "Check for Updates...")
                 .build(app_handle)?,
@@ -263,6 +290,10 @@ static BACKEND_BUILDER_STABLE_ITEM: std::sync::OnceLock<MenuItem<tauri::Wry>> =
     std::sync::OnceLock::new();
 static BACKEND_BUILDER_BETA_ITEM: std::sync::OnceLock<MenuItem<tauri::Wry>> =
     std::sync::OnceLock::new();
+
+/// Startup menu items stored globally for radio-button behavior
+static STARTUP_ENABLE_ITEM: std::sync::OnceLock<MenuItem<tauri::Wry>> = std::sync::OnceLock::new();
+static STARTUP_DISABLE_ITEM: std::sync::OnceLock<MenuItem<tauri::Wry>> = std::sync::OnceLock::new();
 
 /// Update the tray status text
 pub fn update_status(_app_handle: &AppHandle, running: bool) {
@@ -335,6 +366,47 @@ fn update_backend_checks(backend: Backend) {
     }
 }
 
+/// Update the startup menu item labels to reflect whether autostart is enabled.
+fn update_startup_checks(enabled: bool) {
+    if let Some(item) = STARTUP_ENABLE_ITEM.get() {
+        let _ = item.set_text(radio_label("Launch at Startup", enabled));
+    }
+    if let Some(item) = STARTUP_DISABLE_ITEM.get() {
+        let _ = item.set_text(radio_label("Don't Launch at Startup", !enabled));
+    }
+}
+
+/// Persist the autostart preference, reconcile the OS login item, and refresh
+/// the tray radio labels. Runs inline: registering the login item is a quick OS
+/// operation with no daemon work, unlike the channel/backend switch sequences.
+fn set_launch_at_startup(app_handle: &AppHandle, state: &Arc<AppState>, enable: bool) {
+    {
+        let mut settings = async_runtime::block_on(state.settings.write());
+        if settings.launch_at_startup == enable {
+            return;
+        }
+        settings.launch_at_startup = enable;
+        if let Err(e) = settings.save(app_handle) {
+            warn!("Failed to save settings: {}", e);
+        }
+    }
+
+    let manager = app_handle.autolaunch();
+    let result = if enable {
+        manager.enable()
+    } else {
+        manager.disable()
+    };
+    if let Err(e) = result {
+        error!(
+            "Failed to {} autostart: {}",
+            if enable { "enable" } else { "disable" },
+            e
+        );
+    }
+    update_startup_checks(enable);
+}
+
 /// Re-detect the installed version and update the tray version display.
 fn refresh_version_display(app_handle: &AppHandle) {
     let version =
@@ -391,6 +463,8 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>, _a
                 error!("Failed to open browser: {}", e);
             }
         }
+        ids::STARTUP_ENABLE => set_launch_at_startup(app_handle, state, true),
+        ids::STARTUP_DISABLE => set_launch_at_startup(app_handle, state, false),
         ids::CHECK_UPDATES => {
             let state = state.clone();
             let app = app_handle.clone();


### PR DESCRIPTION
# What does this implement/fix?

Adds an autostart option so the app relaunches itself after a reboot, the main blocker for running it as an always on remote builder (#184). It bundles `tauri-plugin-autostart` and adds a **Startup** submenu to the tray, a radio choice between `Launch at Login` and `Don't Launch at Login` that mirrors the existing Backend submenu.

Autostart registers a per-user login item (a macOS LaunchAgent, a Windows `HKCU\...\Run` entry, or a Linux `~/.config/autostart` entry), not a boot-time system service, so it starts when a desktop session logs in. For an unattended box that reboots on its own this needs OS automatic login to come back without someone at the keyboard; that prerequisite is documented in the new "Running as a remote builder" README section.

Autostart is **on by default** so a remote builder works out of the box; this is a deliberate maintainer call and is called out in the README. The login launch is silent (tray only, no browser) via the existing `--no-open-dashboard` flag, while manual launches still open the dashboard. The choice persists in `settings.json` as `launch_at_startup`, and the OS login item is reconciled to that value on every launch, so turning it off sticks and the on by default applies on first run. After a toggle the radio reflects the actual `is_enabled()` state, so a failed enable/disable does not show a misleading label. No capabilities change is needed since the app drives the plugin from Rust, like it already does for dialogs and notifications.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes #184

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).