### PR TITLE
fix(update): stop the device-builder update loop on an unparseable version

### DIFF
--- a/src-tauri/src/update/mod.rs
+++ b/src-tauri/src/update/mod.rs
@@ -708,8 +708,10 @@ fn find_latest_any(releases: &HashMap<String, Vec<PyPIRelease>>) -> Option<Strin
 /// Get the installed `esphome-device-builder` package version.
 ///
 /// - `Ok(Some(v))` — package is installed, returns the version string.
-/// - `Ok(None)` — Python ran successfully but the package is not installed
-///   (importlib.metadata raised `PackageNotFoundError`).
+/// - `Ok(None)` — Python ran successfully but the version is not determinable:
+///   the package is not installed (importlib.metadata raised
+///   `PackageNotFoundError`), or the lookup returned an empty/`"None"` result
+///   because duplicate dist-info dirs confused it (#190).
 /// - `Err(e)` — detection itself failed (bundled Python missing, spawn
 ///   error, etc.); the caller should surface this rather than treat it as
 ///   "not installed".
@@ -727,8 +729,12 @@ pub fn get_installed_device_builder_version(app_handle: &AppHandle) -> Result<Op
 
     if output.status.success() {
         let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        if version.is_empty() {
-            anyhow::bail!("esphome-device-builder version is empty");
+        // An empty result, or the literal "None" that `importlib.metadata` prints
+        // when duplicate dist-info dirs confuse the lookup, means we could not
+        // determine the version. Treat it as "not determinable" rather than a
+        // real version, so the updater does not offer an endless update (#190).
+        if version.is_empty() || version == "None" {
+            return Ok(None);
         }
         Ok(Some(version))
     } else {
@@ -989,6 +995,16 @@ pub(crate) fn is_newer_version(latest: &str, installed: &str) -> bool {
     let latest_parts = parse_version(latest);
     let installed_parts = parse_version(installed);
 
+    // An installed version we cannot parse (e.g. "None", "") must not be treated
+    // as infinitely old, or every check would offer an update forever (#190).
+    if installed_parts.is_empty() {
+        return false;
+    }
+    // Symmetric: an unparseable "latest" is never newer than a real installed one.
+    if latest_parts.is_empty() {
+        return false;
+    }
+
     latest_parts > installed_parts
 }
 
@@ -1026,6 +1042,20 @@ mod tests {
         assert!(!is_newer_version("2026.5.0-dev", "2026.5.0"));
         // A newer base version dev is still newer than an older stable
         assert!(is_newer_version("2026.5.0-dev", "2026.4.0"));
+    }
+
+    #[test]
+    fn test_unparseable_installed_version_is_not_offered_an_update() {
+        // Regression for #190: duplicate dist-info dirs make the version lookup
+        // return "None"/"", which must never be treated as infinitely old.
+        assert!(!is_newer_version("1.0.10", "None"));
+        assert!(!is_newer_version("1.0.10", ""));
+        assert!(!is_newer_version("2025.5.0", "None"));
+        // An unparseable "latest" is never newer than a real installed version.
+        assert!(!is_newer_version("None", "1.0.10"));
+        // Sanity: real comparisons still work.
+        assert!(is_newer_version("1.0.10", "1.0.9"));
+        assert!(!is_newer_version("1.0.10", "1.0.10"));
     }
 
     #[test]


### PR DESCRIPTION
# What does this implement/fix?

The device builder updater could loop forever offering an update that never sticks. When the bundled Python has duplicate esphome-device-builder dist-info dirs, importlib.metadata returns the literal "None" (or an empty result), and the old code treated that as infinitely old, so it offered an update on every check.

This is the safety net half of the fix; an empty or "None" lookup is now treated as not determinable, and is_newer_version refuses to call an unparseable installed or latest version newer. A follow up PR cleans up the duplicate dist-info dirs that trigger this in the first place.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- part of #190

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).
