### PR TITLE
fix(bump-python): raise instead of returning 1 on a refused downgrade

### DIFF
--- a/.github/scripts/bump_bundle_versions.py
+++ b/.github/scripts/bump_bundle_versions.py
@@ -367,12 +367,14 @@ def resolve_python_bump(text: str) -> tuple[BumpResult, str]:
     # missing-variable / unresolvable-upstream paths above.
     current_python = read_assignment(text, "PYTHON_VERSION")
     if is_downgrade(current_python, python_version):
-        _error(
+        # A broken upstream assumption, not a routine skip. Raise so main's
+        # ResolutionError handler logs it and returns 1; returning 1 here would
+        # be unpacked as a (result, title) tuple and crash.
+        raise ResolutionError(
             f"latest {PBS_REPO} release ships CPython {python_version}, older "
             f"than the pinned {current_python}; refusing to downgrade the "
             "bundled interpreter. Investigate upstream before bumping."
         )
-        return 1
 
     result = apply_bumps(
         text, {"PYTHON_VERSION": python_version, "PBS_VERSION": pbs_version}


### PR DESCRIPTION
# What does this implement/fix?

The nightly Python bump crashed instead of failing cleanly when upstream ships a lower CPython patch than we pin. resolve_python_bump is typed to return a (BumpResult, title) tuple, but the downgrade refusal path returned the int 1, which main then unpacked and crashed with a TypeError.

Raise ResolutionError on the refused downgrade instead; main's existing handler logs the message and exits 1, which is the intended behavior. The fix is covered by test_main_refuses_patch_downgrade, which was failing before and passes now.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes <link to issue>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).
