### PR TITLE
fix(update): heal the duplicate dist-info pileup behind the device-builder update loop

### DIFF
--- a/.github/scripts/generate_latest_json.py
+++ b/.github/scripts/generate_latest_json.py
@@ -45,8 +45,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-
 # (Tauri updater target, regex matching the .sig asset name)
+# fmt: off
 PLATFORM_SIG_MATCHERS: list[tuple[str, re.Pattern[str]]] = [
     ("windows-x86_64", re.compile(r".+-setup\.exe\.sig$")),
     ("linux-x86_64",   re.compile(r".+_amd64\.AppImage\.sig$")),
@@ -54,11 +54,13 @@ PLATFORM_SIG_MATCHERS: list[tuple[str, re.Pattern[str]]] = [
     ("darwin-aarch64", re.compile(r".+_aarch64\.app\.tar\.gz\.sig$")),
     ("darwin-x86_64",  re.compile(r".+_x64\.app\.tar\.gz\.sig$")),
 ]
+# fmt: on
 
 # (Tauri updater target, canonical installer kind, regex matching asset name)
 # The .app.tar.gz updater bundles are intentionally absent — they're only
 # useful to the Tauri updater (already covered by `platforms`); a human
 # downloading first-install on macOS wants the .dmg.
+# fmt: off
 DOWNLOAD_MATCHERS: list[tuple[str, str, re.Pattern[str]]] = [
     ("windows-x86_64", "nsis",     re.compile(r"-setup\.exe$")),
     ("linux-x86_64",   "appimage", re.compile(r"_amd64\.AppImage$")),
@@ -70,6 +72,7 @@ DOWNLOAD_MATCHERS: list[tuple[str, str, re.Pattern[str]]] = [
     ("darwin-aarch64", "dmg",      re.compile(r"_aarch64\.dmg$")),
     ("darwin-x86_64",  "dmg",      re.compile(r"_x64\.dmg$")),
 ]
+# fmt: on
 
 SCHEMA_URL = "https://desktop.esphome.io/latest.schema.json"
 
@@ -115,7 +118,7 @@ def build_platforms(
     artifacts_dir: Path,
     download_base: str,
 ) -> dict[str, dict[str, str]]:
-    """Build the Tauri updater `platforms` block from release assets + local .sig files."""
+    """Build the Tauri updater `platforms` block from assets + local .sig files."""
     # GitHub normalizes spaces to dots in release-asset names, but
     # actions/download-artifact preserves the original (spaced) filenames.
     # Match local sig files by regex so either naming works. Filter to
@@ -156,11 +159,13 @@ def build_downloads(
         name = asset["name"]
         for plat, kind, regex in DOWNLOAD_MATCHERS:
             if regex.search(name):
-                downloads.setdefault(plat, []).append({
-                    "kind": kind,
-                    "url": _asset_url(download_base, name),
-                    "size": asset["size"],
-                })
+                downloads.setdefault(plat, []).append(
+                    {
+                        "kind": kind,
+                        "url": _asset_url(download_base, name),
+                        "size": asset["size"],
+                    }
+                )
                 break
     # Stable ordering inside each platform so the manifest doesn't churn
     # between runs purely from asset-listing order.
@@ -214,14 +219,25 @@ def fetch_release(tag: str, repo: str) -> dict[str, Any]:
     """Call `gh` to fetch release info. Requires `gh` to be on PATH and authed."""
     return json.loads(
         subprocess.check_output(
-            ["gh", "release", "view", tag, "--repo", repo, "--json", "body,publishedAt,assets"],
+            [
+                "gh",
+                "release",
+                "view",
+                tag,
+                "--repo",
+                repo,
+                "--json",
+                "body,publishedAt,assets",
+            ],
             text=True,
         )
     )
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     parser.add_argument(
         "--tag",
         default=os.environ.get("TAG"),
@@ -248,7 +264,7 @@ def main() -> int:
         "--release-fixture",
         type=Path,
         help="Load release JSON from a file instead of calling `gh`. "
-             "Useful for local testing without network or gh auth.",
+        "Useful for local testing without network or gh auth.",
     )
     args = parser.parse_args()
 

--- a/.github/workflows/scripts-test.yml
+++ b/.github/workflows/scripts-test.yml
@@ -1,11 +1,12 @@
 name: Scripts Test
 
-# Unit tests for the Python release tooling under .github/scripts/. The
-# release manifest generator (generate_latest_json.py) drives in-app
-# self-updates and the download page; a bug there ships a broken latest.json
-# to every user. The main Build workflow only *runs* the generator during a
-# release — it never exercises it on the fixtures — so this job gates the
-# pure transform logic on every relevant PR.
+# Lint and unit tests for the repo's first-party Python: the release tooling
+# under .github/scripts/ and the runtime helpers under src-tauri/scripts/ that
+# the Rust binary embeds via include_str!. The release manifest generator drives
+# in-app self-updates, and device_builder_maintenance.py heals the bundled
+# install (#190); a bug in either ships to every user, and the main Build
+# workflow only *runs* them during a release, so this job gates the logic on
+# every relevant PR.
 
 on:
   pull_request:
@@ -13,7 +14,9 @@ on:
     paths:
       - ".github/scripts/**"
       - ".github/workflows/scripts-test.yml"
+      - "src-tauri/scripts/**"
       - "tests/**"
+      - "pyproject.toml"
   workflow_dispatch:
 
 concurrency:
@@ -23,8 +26,8 @@ concurrency:
 permissions: {}
 
 jobs:
-  scripts-test:
-    name: Python scripts test
+  lint:
+    name: Python lint (ruff)
     runs-on: ubuntu-22.04
     permissions:
       contents: read
@@ -32,19 +35,49 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      # Pin Python explicitly so the job actually backs the "3.11+ syntax"
-      # the tests use, instead of relying on whatever the runner ships.
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.11"
+          python-version: "3.13"
 
-      # The suite is pytest (maintainer-requested test framework), so this
-      # job installs pytest — it is no longer pure stdlib. Pin to a major so a
-      # breaking/yanked pytest release can't fail this gate on unrelated PRs
+      # Pin ruff exactly: its lint rules and formatter output can change between
+      # releases, so an unpinned upgrade could fail this gate on an unrelated PR
       # (same reasoning the repo pins the Rust toolchain).
+      - name: Install ruff
+        run: python -m pip install 'ruff==0.15.13'
+
+      - name: Ruff check
+        run: ruff check .
+
+      - name: Ruff format check
+        run: ruff format --check .
+
+  test:
+    name: Python scripts test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        # The device-builder maintenance helper depends on importlib.metadata
+        # behavior and filesystem semantics that differ by OS (the #190 loop
+        # manifested on Windows), so exercise every platform we ship. We bundle
+        # CPython 3.13, so that is the only version worth testing.
+        os: [ubuntu-22.04, macos-15, windows-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13"
+
+      # Pin to a major so a breaking/yanked pytest release can't fail this gate
+      # on unrelated PRs (same reasoning the repo pins the Rust toolchain).
       - name: Install pytest
-        run: python3 -m pip install 'pytest~=8.0'
+        run: python -m pip install 'pytest~=8.0'
 
       - name: Run script tests
-        run: python3 -m pytest tests/ -v
+        run: python -m pytest tests/ -v

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,14 @@ repos:
       - id: check-json
       - id: mixed-line-ending
         args: [--fix=lf]
+  # Lint and format first-party Python (release tooling + the embedded
+  # device-builder maintenance helper). Pinned to match the Scripts Test CI job.
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.13
+    hooks:
+      - id: ruff-check
+      - id: ruff-format
+        args: [--check]
   - repo: local
     hooks:
       - id: forbid-nul-bytes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,12 +28,15 @@ locally, match that pinned version (see `toolchain:` in `lint-test.yml`).
 
 ## Running the Python script tests locally
 
-The release tooling under `.github/scripts/` (notably the `latest.json`
-generator that drives in-app self-updates) is gated by the `Scripts Test`
-workflow. The tests use `pytest`:
+The first-party Python (the release tooling under `.github/scripts/` and the
+runtime helpers under `src-tauri/scripts/` that the Rust binary embeds) is gated
+by the `Scripts Test` workflow, which lints with `ruff` and runs the `pytest`
+suite across macOS, Windows, and Linux on the CPython 3.13 line we bundle:
 
 ```bash
-python3 -m pip install pytest   # one-time
+python3 -m pip install pytest ruff   # one-time
+ruff check .
+ruff format --check .
 python3 -m pytest tests/ -v
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+# Tooling config for the repo's first-party Python (release scripts under
+# .github/scripts, the runtime helpers under src-tauri/scripts, and their tests).
+# The bundled CPython and site-packages trees are vendored third-party code and
+# are excluded from linting.
+
+[tool.ruff]
+line-length = 88
+extend-exclude = [
+    "src-tauri/python",
+    "esphome-desktop",
+    "build",
+    "**/*.dist-info",
+]
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/src-tauri/scripts/device_builder_maintenance.py
+++ b/src-tauri/scripts/device_builder_maintenance.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Maintenance for the bundled esphome-device-builder install (#190).
+
+Two modes, selected by argv:
+  detect  -> print the highest installed version (empty if undeterminable)
+  dedupe  -> remove orphaned duplicate *.dist-info dirs; print the count removed
+
+The bundled Python accumulates duplicate dist-info dirs (orphaned by the
+``--ignore-installed`` missing-RECORD recovery), which makes importlib.metadata
+return None or the wrong version and loops the updater forever. The version
+ranking is self-contained so this does not depend on the third-party
+``packaging`` library being importable in the bundled interpreter.
+
+Embedded into the Rust binary via ``include_str!`` and run with the bundled
+interpreter as ``python -c <this file> <mode>``; also imported directly by the
+pytest suite, which is why the functions take an injectable distributions
+iterable instead of always reading the live environment.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import sys
+from collections.abc import Iterable
+from importlib.metadata import Distribution, distributions
+from pathlib import Path
+
+# Only the builder packages: the device-builder updater resolves its version via
+# importlib.metadata, which the duplicate dist-info pileup breaks (#190). Plain
+# esphome is read with `python -m esphome version` (runtime import resolution),
+# so its own --ignore-installed orphans never trigger this loop and are left
+# alone here.
+TARGETS = {"esphome-device-builder", "esphome-device-builder-frontend"}
+
+# Pre-release precedence (PEP 440 order): dev < a < b < rc < release. A release
+# segment with no pre-release tag sorts above any pre-release of the same
+# version, so it gets the high sentinel 9.
+_ORDER = {
+    None: 9,
+    "dev": 0,
+    "a": 1,
+    "alpha": 1,
+    "b": 2,
+    "beta": 2,
+    "c": 3,
+    "rc": 3,
+    "pre": 3,
+    "preview": 3,
+}
+# Order the tag alternation longest-first so a spelled-out tag is matched whole
+# (e.g. "alpha2" -> tag "alpha", serial 2) instead of the leading "a" winning and
+# dropping the serial.
+_VER_RE = re.compile(
+    r"^\s*v?(\d+(?:\.\d+)*)"
+    r"(?:[-_.]?(alpha|beta|preview|rc|pre|dev|a|b|c)\.?(\d*))?"
+)
+
+
+# Sort key returned for any version we cannot parse; sorts below every real
+# version so an unparseable entry never wins a "highest version" comparison.
+_UNRANKED: tuple[tuple[int, ...], int, int] = ((), 0, 0)
+
+
+def vkey(version: str | None) -> tuple[tuple[int, ...], int, int]:
+    """Return a PEP 440-ish sort key; unparseable/None sorts lowest."""
+    # None, "", "None" and any other non-version string all fail to match
+    # (no leading digits) and fall through to the lowest key.
+    match = _VER_RE.match(str(version or "").lower())
+    if not match:
+        return _UNRANKED
+    release = tuple(int(x) for x in match.group(1).split("."))
+    return (release, _ORDER.get(match.group(2), 4), int(match.group(3) or 0))
+
+
+def _norm(name: str | None) -> str:
+    return (name or "").lower().replace("_", "-")
+
+
+def detect_version(dists: Iterable[Distribution]) -> str | None:
+    """Return the highest version among all esphome-device-builder dists.
+
+    Enumerating every matching distribution and taking the max is robust to the
+    duplicate dist-info pileup that makes ``version('esphome-device-builder')``
+    return None or an arbitrary older version.
+    """
+    versions: list[str] = []
+    for dist in dists:
+        try:
+            # Use .get() rather than mapping access: a missing header returns
+            # None instead of emitting the implicit-None DeprecationWarning that
+            # becomes a KeyError in future Python.
+            meta = dist.metadata
+            if _norm(meta.get("Name")) == "esphome-device-builder":
+                version = meta.get("Version")
+                if version and version != "None":
+                    versions.append(version)
+        except Exception as err:
+            # Don't let one unreadable distribution abort detection, but log it:
+            # silently dropping the real target would reintroduce the #190 loop
+            # with no trace.
+            path = getattr(dist, "_path", "?")
+            print(
+                f"detect: skipping unreadable distribution {path}: {err}",
+                file=sys.stderr,
+            )
+    return max(versions, key=vkey) if versions else None
+
+
+def dedupe_dist_info(dists: Iterable[Distribution]) -> int:
+    """Keep the highest-version dist-info per target package; remove the rest.
+
+    The newest version is the code installed last by ``pip install --upgrade``,
+    so its metadata is the one to keep. Returns the number of stale dist-info
+    directories removed.
+    """
+    groups: dict[str, list[tuple[str | None, Path]]] = {}
+    for dist in dists:
+        try:
+            # .get() avoids the implicit-None DeprecationWarning (future
+            # KeyError) on missing headers, and reading Version here keeps a
+            # broken target's metadata from crashing the whole prune.
+            meta = dist.metadata
+            name = _norm(meta.get("Name"))
+            version = meta.get("Version")
+        except Exception as err:
+            # Log rather than silently skip: an unreadable target dist-info that
+            # is never considered for dedup leaves the pileup in place (#190).
+            path = getattr(dist, "_path", "?")
+            print(
+                f"dedupe: skipping unreadable distribution {path}: {err}",
+                file=sys.stderr,
+            )
+            continue
+        if name not in TARGETS:
+            continue
+        # ``_path`` is private; guard it so a future importlib change degrades to
+        # a no-op rather than deleting the wrong directory.
+        path = getattr(dist, "_path", None)
+        if (
+            not isinstance(path, Path)
+            or path.suffix != ".dist-info"
+            or not path.is_dir()
+        ):
+            continue
+        groups.setdefault(name, []).append((version, path))
+
+    removed = 0
+    for items in groups.values():
+        if len(items) < 2:
+            continue  # a single healthy install is left untouched
+        items.sort(key=lambda item: vkey(item[0]))
+        keep_version, keep_path = items[-1]
+        if vkey(keep_version) == _UNRANKED:
+            # No entry in the group has a parseable version, so we can't tell
+            # which is the real install. Leave the whole group rather than risk
+            # a wrong rmtree; detect_version still tolerates the duplicates.
+            print(
+                f"dedupe: keeping ambiguous group, no parseable version "
+                f"near {keep_path}",
+                file=sys.stderr,
+            )
+            continue
+        for version, path in items[:-1]:
+            if vkey(version) == _UNRANKED:
+                # An unparseable version might itself be the real install, so
+                # never delete it on the strength of the lowest-sort sentinel.
+                print(f"dedupe: keeping unrankable {path}", file=sys.stderr)
+                continue
+            try:
+                shutil.rmtree(path)
+                removed += 1
+            except OSError as err:
+                print(f"skip {path}: {err}", file=sys.stderr)
+    return removed
+
+
+def main(argv: list[str]) -> int:
+    mode = argv[0] if argv else ""
+    if mode == "detect":
+        version = detect_version(distributions())
+        if version:
+            print(version)
+        return 0
+    if mode == "dedupe":
+        print(dedupe_dist_info(distributions()))
+        return 0
+    print(f"unknown mode: {mode!r}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/src-tauri/src/update/mod.rs
+++ b/src-tauri/src/update/mod.rs
@@ -388,7 +388,7 @@ impl UpdateChecker {
         // with --ignore-installed, which skips the uninstall but orphans stale
         // files — so we limit that trade-off to the broken-RECORD case.
         let pp = python_path.clone();
-        install_with_record_retry(
+        let result = install_with_record_retry(
             move |ignore| {
                 let pp = pp.clone();
                 async move { run_device_builder_install(&pp, backend, ignore).await }
@@ -397,7 +397,16 @@ impl UpdateChecker {
             "esphome-device-builder upgrade hit missing RECORD file; retrying with --ignore-installed",
             "pip install esphome-device-builder failed",
         )
-        .await
+        .await;
+
+        // On success, prune any `.dist-info` dirs the --ignore-installed retry
+        // may have orphaned, so the next version check resolves a single, real
+        // version instead of looping on "None" (#190). Best-effort.
+        if result.is_ok() {
+            let _ = dedupe_device_builder_dist_info(app_handle);
+        }
+
+        result
     }
 
     /// Query PyPI for the latest available `esphome-device-builder` version.
@@ -444,7 +453,7 @@ impl UpdateChecker {
             return;
         }
 
-        let installed = match get_installed_device_builder_version(app_handle) {
+        let installed = match detect_device_builder_version_with_heal(app_handle) {
             Ok(Some(v)) => v,
             Ok(None) => {
                 debug!("esphome-device-builder is not installed; skipping update check");
@@ -503,7 +512,7 @@ impl UpdateChecker {
             return None;
         }
 
-        let installed = match get_installed_device_builder_version(app_handle) {
+        let installed = match detect_device_builder_version_with_heal(app_handle) {
             Ok(Some(v)) => v,
             Ok(None) => {
                 warn!("esphome-device-builder is not installed");
@@ -705,44 +714,126 @@ fn find_latest_any(releases: &HashMap<String, Vec<PyPIRelease>>) -> Option<Strin
     best
 }
 
+/// Maintenance helper run with the bundled interpreter as `python -c <src>
+/// <mode>`. `detect` prints the highest installed device-builder version (empty
+/// if undeterminable); `dedupe` removes orphaned duplicate `.dist-info` dirs and
+/// prints how many it removed. Embedded so it ships with the binary and stays in
+/// sync with its pytest suite (`tests/test_device_builder_maintenance.py`).
+const DEVICE_BUILDER_MAINT_PY: &str = include_str!("../../scripts/device_builder_maintenance.py");
+
 /// Get the installed `esphome-device-builder` package version.
 ///
 /// - `Ok(Some(v))` — package is installed, returns the version string.
-/// - `Ok(None)` — Python ran successfully but the version is not determinable:
-///   the package is not installed (importlib.metadata raised
-///   `PackageNotFoundError`), or the lookup returned an empty/`"None"` result
-///   because duplicate dist-info dirs confused it (#190).
-/// - `Err(e)` — detection itself failed (bundled Python missing, spawn
-///   error, etc.); the caller should surface this rather than treat it as
-///   "not installed".
+/// - `Ok(None)` — `detect` ran successfully (exit 0) but printed no version: the
+///   package is not installed, or duplicate dist-info dirs left it
+///   undeterminable (#190).
+/// - `Err(e)` — detection itself failed: the bundled Python is missing, the
+///   spawn failed, or the helper exited non-zero (a broken interpreter / import
+///   error). The caller should surface this rather than treat it as "not
+///   installed".
 pub fn get_installed_device_builder_version(app_handle: &AppHandle) -> Result<Option<String>> {
     let python_path = platform::get_python_path(app_handle)?;
 
     let mut cmd = std::process::Command::new(&python_path);
-    cmd.args([
-        "-c",
-        "from importlib.metadata import version; print(version('esphome-device-builder'))",
-    ]);
+    // Enumerate all device-builder distributions and take the highest version,
+    // which is robust to the duplicate dist-info pileup that makes a plain
+    // `importlib.metadata.version(...)` return None or an older version (#190).
+    // `-I` (isolated) keeps user site-packages, PYTHONPATH and sitecustomize off
+    // sys.path so detection only ever sees the managed bundled install.
+    cmd.args(["-I", "-c", DEVICE_BUILDER_MAINT_PY, "detect"]);
     platform::configure_no_window_command(&mut cmd);
 
     let output = cmd.output().context("Failed to run python")?;
 
     if output.status.success() {
+        // `detect` logs skipped/unreadable distributions to stderr; surface it so
+        // the reason a version came back undeterminable isn't lost.
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stderr = stderr.trim();
+        if !stderr.is_empty() {
+            warn!("device-builder version detection: {stderr}");
+        }
         let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        // An empty result, or the literal "None" that `importlib.metadata` prints
-        // when duplicate dist-info dirs confuse the lookup, means we could not
-        // determine the version. Treat it as "not determinable" rather than a
-        // real version, so the updater does not offer an endless update (#190).
+        // `detect` prints nothing when it cannot determine a version (no install
+        // or an unresolvable pileup); the "None" guard is belt-and-suspenders.
+        // Treat either as "not determinable" so the updater does not offer an
+        // endless update (#190).
         if version.is_empty() || version == "None" {
             return Ok(None);
         }
         Ok(Some(version))
     } else {
-        // Non-zero exit means importlib.metadata raised PackageNotFoundError —
-        // the package isn't installed. That's a distinct state from a
-        // detection failure (which would have errored out above).
-        Ok(None)
+        // `detect` exits 0 even when the package is absent (it prints nothing),
+        // so a non-zero exit is a real execution failure (broken bundled
+        // interpreter, import error, etc.). Surface it rather than silently
+        // misclassifying it as "not installed" and skipping the update check.
+        anyhow::bail!(
+            "device-builder version detection failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )
     }
+}
+
+/// Remove orphaned duplicate `.dist-info` directories for the device-builder
+/// package and its frontend, keeping the highest version's metadata.
+///
+/// The `--ignore-installed` install fallback (#155/#183) skips the uninstall and
+/// leaves the previous version's `.dist-info` behind; once several pile up,
+/// `importlib.metadata` can no longer resolve a single version and the updater
+/// loops forever offering "version None" (#190). This heals that state. It is
+/// best-effort: a failure is logged and swallowed so it can never block an
+/// install or an update check.
+pub fn dedupe_device_builder_dist_info(app_handle: &AppHandle) -> Result<()> {
+    let python_path = platform::get_python_path(app_handle)?;
+
+    let mut cmd = std::process::Command::new(&python_path);
+    // `-I` (isolated) keeps user site-packages, PYTHONPATH and sitecustomize off
+    // sys.path so this destructive prune can only ever touch the managed bundled
+    // install, never a user-site or externally-injected tree.
+    cmd.args(["-I", "-c", DEVICE_BUILDER_MAINT_PY, "dedupe"]);
+    platform::configure_no_window_command(&mut cmd);
+
+    let output = cmd.output().context("Failed to run dist-info dedup")?;
+
+    if output.status.success() {
+        // The helper logs dist-info it couldn't read or remove to stderr;
+        // surface it so a partial prune isn't silently lost.
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stderr = stderr.trim();
+        if !stderr.is_empty() {
+            warn!("device-builder dist-info dedup: {stderr}");
+        }
+        let removed = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if !removed.is_empty() && removed != "0" {
+            info!("Removed {removed} stale device-builder dist-info dir(s)");
+        }
+    } else {
+        warn!(
+            "device-builder dist-info dedup failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(())
+}
+
+/// Detect the installed device-builder version, healing a duplicate dist-info
+/// pileup once if the first lookup cannot determine a version.
+///
+/// A `None` result is the exact symptom of the pileup (#190), so prune the
+/// duplicates and re-query before giving up. A genuinely-absent package stays
+/// `None` (dedup finds nothing to remove), at the cost of one extra Python spawn
+/// only on the already-unusual not-determinable path.
+fn detect_device_builder_version_with_heal(app_handle: &AppHandle) -> Result<Option<String>> {
+    let installed = get_installed_device_builder_version(app_handle)?;
+    if installed.is_some() {
+        return Ok(installed);
+    }
+    if let Err(e) = dedupe_device_builder_dist_info(app_handle) {
+        // The heal is best-effort, but a failed attempt shouldn't be invisible:
+        // the re-query below will just return the same undeterminable result.
+        warn!("device-builder dist-info heal failed: {e}");
+    }
+    get_installed_device_builder_version(app_handle)
 }
 
 /// Build the `pip` argument list for installing/upgrading
@@ -1042,6 +1133,17 @@ mod tests {
         assert!(!is_newer_version("2026.5.0-dev", "2026.5.0"));
         // A newer base version dev is still newer than an older stable
         assert!(is_newer_version("2026.5.0-dev", "2026.4.0"));
+    }
+
+    #[test]
+    fn test_device_builder_maint_py_well_formed() {
+        // Behavior is covered in depth by tests/test_device_builder_maintenance.py;
+        // here we only pin the argv-mode contract this module invokes it with, so
+        // a rename of the modes (not the internal functions) can't pass silently.
+        // Match the bare mode words so the check is tolerant of quote style.
+        assert!(DEVICE_BUILDER_MAINT_PY.contains("detect"));
+        assert!(DEVICE_BUILDER_MAINT_PY.contains("dedupe"));
+        assert!(DEVICE_BUILDER_MAINT_PY.contains("esphome-device-builder-frontend"));
     }
 
     #[test]

--- a/tests/test_device_builder_maintenance.py
+++ b/tests/test_device_builder_maintenance.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Tests for src-tauri/scripts/device_builder_maintenance.py.
+
+The bundled Python can accumulate duplicate esphome-device-builder dist-info
+dirs, which makes importlib.metadata return None or the wrong version and loops
+the in-app updater forever (#190). This suite pins the version ranking, the
+robust detection, and the dedup so a regression cannot reintroduce the loop or,
+worse, delete the wrong dist-info directory.
+
+The detection and dedup helpers are exercised against real importlib.metadata
+Distribution objects: fixtures fabricate dist-info dirs in a tmp path and load
+them with ``distributions(path=[...])``, so the tests cover the same code paths
+the bundled interpreter runs.
+
+pytest suite (maintainer-requested framework, fully typed, no classes).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from importlib.metadata import Distribution, distributions
+from pathlib import Path
+from types import ModuleType
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT_PATH = REPO_ROOT / "src-tauri" / "scripts" / "device_builder_maintenance.py"
+
+
+def _load_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "device_builder_maintenance", SCRIPT_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+maint = _load_module()
+
+
+def _make_dist_info(
+    site: Path, package: str, version: str | None, *, with_version: bool = True
+) -> Path:
+    """Create a *.dist-info dir for ``package`` and return its path."""
+    dist_info = site / f"{package.replace('-', '_')}-{version}.dist-info"
+    dist_info.mkdir(parents=True)
+    lines = ["Metadata-Version: 2.1", f"Name: {package}"]
+    if with_version and version is not None:
+        lines.append(f"Version: {version}")
+    (dist_info / "METADATA").write_text("\n".join(lines) + "\n")
+    return dist_info
+
+
+def _dists(site: Path) -> list[Distribution]:
+    return list(distributions(path=[str(site)]))
+
+
+# --------------------------------------------------------------------------- #
+# vkey: self-contained version ranking (no packaging dependency).
+# --------------------------------------------------------------------------- #
+
+
+def test_vkey_release_outranks_prerelease() -> None:
+    assert maint.vkey("1.0.10") > maint.vkey("1.0.10b1")
+    assert maint.vkey("1.0.10") > maint.vkey("1.0.9")
+    assert maint.vkey("1.0.10b1") > maint.vkey("1.0.1")
+
+
+def test_vkey_prerelease_precedence() -> None:
+    # dev < a < b < rc < release
+    assert maint.vkey("1.0.0dev1") < maint.vkey("1.0.0a1")
+    assert maint.vkey("1.0.0a1") < maint.vkey("1.0.0b1")
+    assert maint.vkey("1.0.0b1") < maint.vkey("1.0.0rc1")
+    assert maint.vkey("1.0.0rc1") < maint.vkey("1.0.0")
+
+
+def test_vkey_spelled_out_tag_keeps_serial() -> None:
+    # Longest-first alternation: "alpha2" must keep its serial, not collapse to
+    # the leading "a" and drop the "2".
+    assert maint.vkey("1.0.0alpha2") > maint.vkey("1.0.0alpha1")
+    assert maint.vkey("1.0.0beta2") > maint.vkey("1.0.0beta1")
+    assert maint.vkey("1.0.0preview2") > maint.vkey("1.0.0preview1")
+    # Spelled-out and short forms rank equally by tag.
+    assert maint.vkey("1.0.0alpha1") == maint.vkey("1.0.0a1")
+
+
+def test_vkey_unparseable_sorts_lowest() -> None:
+    lowest = ((), 0, 0)
+    assert maint.vkey(None) == lowest
+    assert maint.vkey("") == lowest
+    assert maint.vkey("None") == lowest
+    assert maint.vkey("garbage") == lowest
+    assert maint.vkey("1.0.0") > maint.vkey("None")
+
+
+# --------------------------------------------------------------------------- #
+# detect_version: robust to the duplicate dist-info pileup.
+# --------------------------------------------------------------------------- #
+
+
+def test_detect_version_picks_highest_among_duplicates(tmp_path: Path) -> None:
+    for version in ("1.0.1", "1.0.9", "1.0.10", "1.0.10b1"):
+        _make_dist_info(tmp_path, "esphome-device-builder", version)
+    assert maint.detect_version(_dists(tmp_path)) == "1.0.10"
+
+
+def test_detect_version_ignores_duplicate_without_version(tmp_path: Path) -> None:
+    # A duplicate whose METADATA lost its Version header (the orphaned None case)
+    # must not mask the real highest version.
+    _make_dist_info(tmp_path, "esphome-device-builder", "1.0.10")
+    _make_dist_info(tmp_path, "esphome-device-builder", "1.0.9", with_version=False)
+    assert maint.detect_version(_dists(tmp_path)) == "1.0.10"
+
+
+def test_detect_version_returns_none_when_absent(tmp_path: Path) -> None:
+    _make_dist_info(tmp_path, "some-other-package", "1.2.3")
+    assert maint.detect_version(_dists(tmp_path)) is None
+
+
+# --------------------------------------------------------------------------- #
+# dedupe_dist_info: heal the pileup, keep the right one.
+# --------------------------------------------------------------------------- #
+
+
+def test_dedupe_keeps_highest_and_removes_rest(tmp_path: Path) -> None:
+    paths = {
+        version: _make_dist_info(tmp_path, "esphome-device-builder", version)
+        for version in ("1.0.1", "1.0.9", "1.0.10", "1.0.10b1")
+    }
+    assert maint.dedupe_dist_info(_dists(tmp_path)) == 3
+    assert paths["1.0.10"].is_dir()
+    for version in ("1.0.1", "1.0.9", "1.0.10b1"):
+        assert not paths[version].exists()
+    # importlib now resolves a single, correct version.
+    assert maint.detect_version(_dists(tmp_path)) == "1.0.10"
+
+
+def test_dedupe_never_deletes_an_unparseable_duplicate(tmp_path: Path) -> None:
+    # A dist-info whose version can't be parsed might itself be the real install,
+    # so the destructive prune must keep it rather than trust the lowest-sort
+    # sentinel. detect_version still reports the real version regardless.
+    keep = _make_dist_info(tmp_path, "esphome-device-builder", "1.0.10")
+    broken = _make_dist_info(
+        tmp_path, "esphome-device-builder", "1.0.9", with_version=False
+    )
+    assert maint.dedupe_dist_info(_dists(tmp_path)) == 0
+    assert keep.is_dir()
+    assert broken.is_dir()
+    assert maint.detect_version(_dists(tmp_path)) == "1.0.10"
+
+
+def test_dedupe_prunes_parseable_but_spares_unparseable_sibling(tmp_path: Path) -> None:
+    # A parseable lower version is still pruned even when an unparseable sibling
+    # is present; only the unrankable entry is spared.
+    keep = _make_dist_info(tmp_path, "esphome-device-builder", "1.0.10")
+    stale = _make_dist_info(tmp_path, "esphome-device-builder", "1.0.9")
+    broken = _make_dist_info(
+        tmp_path, "esphome-device-builder", "1.0.8", with_version=False
+    )
+    assert maint.dedupe_dist_info(_dists(tmp_path)) == 1
+    assert keep.is_dir()
+    assert not stale.exists()
+    assert broken.is_dir()
+
+
+def test_dedupe_skips_group_with_no_parseable_version(tmp_path: Path) -> None:
+    # If nothing in the group parses, we can't pick a winner; leave it all alone.
+    a = _make_dist_info(tmp_path, "esphome-device-builder", "1.0.9", with_version=False)
+    b = _make_dist_info(
+        tmp_path, "esphome-device-builder", "1.0.10", with_version=False
+    )
+    assert maint.dedupe_dist_info(_dists(tmp_path)) == 0
+    assert a.is_dir()
+    assert b.is_dir()
+
+
+def test_dedupe_leaves_single_install_untouched(tmp_path: Path) -> None:
+    only = _make_dist_info(tmp_path, "esphome-device-builder", "1.0.10")
+    assert maint.dedupe_dist_info(_dists(tmp_path)) == 0
+    assert only.is_dir()
+
+
+def test_dedupe_groups_frontend_independently(tmp_path: Path) -> None:
+    main_keep = _make_dist_info(tmp_path, "esphome-device-builder", "1.0.10")
+    _make_dist_info(tmp_path, "esphome-device-builder", "1.0.9")
+    fe_keep = _make_dist_info(tmp_path, "esphome-device-builder-frontend", "0.1.170")
+    _make_dist_info(tmp_path, "esphome-device-builder-frontend", "0.1.158")
+    assert maint.dedupe_dist_info(_dists(tmp_path)) == 2
+    assert main_keep.is_dir()
+    assert fe_keep.is_dir()


### PR DESCRIPTION
# What does this implement/fix?

This is the root cause half of the device builder update loop fix. The bundled Python accumulates duplicate esphome-device-builder dist-info dirs, orphaned by the --ignore-installed install fallback (#155, #183); once several pile up, importlib.metadata can no longer resolve a single version and the updater loops forever offering "version None".

A new helper, device_builder_maintenance.py, is embedded into the binary via include_str! and run with the bundled interpreter. Version detection now enumerates every device-builder distribution and takes the highest, so the pileup no longer reads as None; a dedupe step removes the orphaned dist-info dirs, keeping the newest. Dedupe runs after a successful install, and once on a not-determinable check so installs already broken in the field heal themselves.

The helper ships with a pytest suite driven by real importlib.metadata objects, plus ruff lint and format config, a pre-commit hook, and a Scripts Test matrix across macOS, Windows, and Linux on the bundled CPython 3.13, since the loop is OS dependent.

Stacked on #191 (the Rust safety net); the pre-existing Scripts Test failure is fixed separately in #192.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes #190

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).
