### PR TITLE
fix(windows): bundle GNU patch so micro-opus configs build

### DIFF
--- a/.github/scripts/bump_bundle_versions.py
+++ b/.github/scripts/bump_bundle_versions.py
@@ -60,6 +60,11 @@ GFW_REPO = "git-for-windows/git"
 # rebuilds like MinGit-2.53.0.3-64-bit.zip still do.
 MINGIT_ASSET_RE = re.compile(r"MinGit-(?P<ver>[\d.]+)-64-bit\.zip")
 
+# The 64-bit PortableGit self-extracting archive from the same release. We harvest
+# a GNU patch.exe from it (issue #189); pinning it to the same release as MinGit
+# keeps patch.exe ABI-matched to MinGit's msys-2.0.dll.
+PORTABLEGIT_ASSET_RE = re.compile(r"PortableGit-(?P<ver>[\d.]+)-64-bit\.7z\.exe")
+
 # Per-request network timeout. A stalled connection otherwise blocks the nightly
 # job until the workflow's multi-hour default timeout fires; failing fast lets
 # the run fail promptly (after retries) and surface a clear error.
@@ -157,8 +162,10 @@ def current_python_minor(text: str) -> str:
 
 
 def _version_tuple(version: str) -> tuple[int, ...]:
-    """Parse a dotted numeric version (e.g. "3.13.13") into an int tuple so
-    versions order numerically rather than lexically ("3.13.9" < "3.13.10")."""
+    """Parse a dotted numeric version into an int tuple so versions order
+    numerically rather than lexically ("3.13.9" < "3.13.10"). Shared by the
+    CPython downgrade guard and the MinGit downgrade guard; both pin dotted
+    versions (e.g. "3.13.13", "2.54.0", or a rebuild "2.53.0.3")."""
     return tuple(int(part) for part in version.split("."))
 
 
@@ -294,22 +301,32 @@ def _asset_sha256(asset: dict[str, Any]) -> str:
     return _download_sha256(url)
 
 
-def resolve_latest_mingit() -> tuple[str, str, str]:
-    """Return `(version, url, sha256)` for the latest 64-bit MinGit zip.
-
-    Picks the plain x86-64 MinGit asset from the latest git-for-windows release
-    and reads its checksum, so the literal download URL and digest land in
-    prepare_bundle.sh even for `.windows.N` rebuilds whose filename carries the
-    build number.
-    """
-    release = _api_get(f"https://api.github.com/repos/{GFW_REPO}/releases/latest")
+def _find_asset(
+    release: dict[str, Any], pattern: re.Pattern[str], label: str
+) -> tuple[str, str, str]:
+    """Return `(version, url, sha256)` for the asset matching `pattern`."""
     for asset in release.get("assets", []):
-        m = MINGIT_ASSET_RE.fullmatch(asset.get("name", ""))
+        m = pattern.fullmatch(asset.get("name", ""))
         if m is not None:
             return m.group("ver"), asset["browser_download_url"], _asset_sha256(asset)
     raise ResolutionError(
-        f"no 64-bit MinGit asset in {GFW_REPO} release {release.get('tag_name')!r}"
+        f"no {label} asset in {GFW_REPO} release {release.get('tag_name')!r}"
     )
+
+
+def resolve_latest_mingit() -> tuple[str, str, str, str, str]:
+    """Resolve the MinGit and PortableGit assets from the latest GfW release.
+
+    Returns `(version, mingit_url, mingit_sha256, portablegit_url,
+    portablegit_sha256)`. Both assets come from the same `releases/latest`
+    response (one request), so the harvested patch.exe stays ABI-matched to
+    MinGit's msys-2.0.dll. The literal URLs and digests land in prepare_bundle.sh
+    even for `.windows.N` rebuilds whose filenames carry the build number.
+    """
+    release = _api_get(f"https://api.github.com/repos/{GFW_REPO}/releases/latest")
+    version, mingit_url, mingit_sha = _find_asset(release, MINGIT_ASSET_RE, "MinGit")
+    _, pg_url, pg_sha = _find_asset(release, PORTABLEGIT_ASSET_RE, "PortableGit")
+    return version, mingit_url, mingit_sha, pg_url, pg_sha
 
 
 # --------------------------------------------------------------------------- #
@@ -388,15 +405,10 @@ def resolve_python_bump(text: str) -> tuple[BumpResult, str]:
     return result, title
 
 
-def _version_tuple(version: str) -> tuple[int, ...]:
-    """Parse a dotted MinGit version (e.g. "2.54.0" or rebuild "2.53.0.3")."""
-    return tuple(int(part) for part in version.split("."))
-
-
 def resolve_mingit_bump(text: str) -> tuple[BumpResult, str]:
-    """Resolve the latest MinGit and compute the bump over `text`."""
+    """Resolve the latest MinGit + PortableGit and compute the bump over `text`."""
     current = read_assignment(text, "MINGIT_VERSION")
-    version, url, sha256 = resolve_latest_mingit()
+    version, url, sha256, pg_url, pg_sha256 = resolve_latest_mingit()
     # Git for Windows releases move forward, so a resolved version older than the
     # current pin means upstream republished an old tag as `latest` or unpublished
     # a release. That's a broken assumption, not a routine skip: fail loudly
@@ -407,9 +419,17 @@ def resolve_mingit_bump(text: str) -> tuple[BumpResult, str]:
             f"latest MinGit {version} is older than the pinned {current}; "
             "refusing to downgrade"
         )
+    # MinGit and the PortableGit we harvest patch.exe from are bumped together so
+    # patch.exe stays ABI-matched to MinGit's msys-2.0.dll.
     result = apply_bumps(
         text,
-        {"MINGIT_VERSION": version, "MINGIT_URL": url, "MINGIT_SHA256": sha256},
+        {
+            "MINGIT_VERSION": version,
+            "MINGIT_URL": url,
+            "MINGIT_SHA256": sha256,
+            "PORTABLEGIT_URL": pg_url,
+            "PORTABLEGIT_SHA256": pg_sha256,
+        },
     )
     return result, f"Bump bundled MinGit to {version}"
 
@@ -427,7 +447,13 @@ TARGETS: dict[str, tuple[tuple[str, ...], _Resolver, str]] = {
         "Python interpreter",
     ),
     "mingit": (
-        ("MINGIT_VERSION", "MINGIT_URL", "MINGIT_SHA256"),
+        (
+            "MINGIT_VERSION",
+            "MINGIT_URL",
+            "MINGIT_SHA256",
+            "PORTABLEGIT_URL",
+            "PORTABLEGIT_SHA256",
+        ),
         resolve_mingit_bump,
         "MinGit (Git for Windows)",
     ),

--- a/build-scripts/prepare_bundle.sh
+++ b/build-scripts/prepare_bundle.sh
@@ -35,6 +35,16 @@ MINGIT_VERSION="2.54.0"
 MINGIT_URL="https://github.com/git-for-windows/git/releases/download/v2.54.0.windows.1/MinGit-2.54.0-64-bit.zip"
 MINGIT_SHA256="04f937e1f0918b17b9be6f2294cb2bb66e96e1d9832d1c298e2de088a1d0e668"
 
+# PortableGit is downloaded (Windows only) solely to harvest a GNU `patch.exe`:
+# MinGit doesn't ship one, but the esphome micro-opus component's ESP-IDF build
+# needs `patch` on PATH to patch the Opus source (issue #189). We extract only
+# patch.exe plus the MSYS runtime DLLs it links into a dedicated `git/patch/`
+# dir rather than bundling the ~300MB PortableGit tree. Pinned to the same
+# git-for-windows release as MinGit so patch.exe and msys-2.0.dll match, and
+# rewritten alongside MINGIT_* by the nightly `bump_bundle_versions.py` job.
+PORTABLEGIT_URL="https://github.com/git-for-windows/git/releases/download/v2.54.0.windows.1/PortableGit-2.54.0-64-bit.7z.exe"
+PORTABLEGIT_SHA256="bea006a6cc69673f27b1647e84ab3a68e912fbc175ab6320c5987e012897f311"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 BUILD_DIR="$PROJECT_DIR/build"
@@ -224,6 +234,81 @@ prepare_git_for_platform() {
         exit 1
     fi
     "$python_exe" -m zipfile -e "$temp_file" "$GIT_BUNDLE_DIR"
+
+    prepare_patch_for_windows
+}
+
+# Harvest a GNU `patch.exe` from PortableGit into a dedicated `git/patch/` dir
+# (issue #189). MinGit ships no patch, but the esphome micro-opus ESP-IDF build
+# needs `patch` on PATH. We extract only patch.exe and the MSYS DLLs it links —
+# co-located so Windows resolves them from the exe's own directory — instead of
+# shipping the ~300MB PortableGit tree or exposing all of MinGit's usr/bin
+# (whose sh/find/sort would shadow Windows built-ins in the build).
+prepare_patch_for_windows() {
+    local patch_dir="$GIT_BUNDLE_DIR/patch"
+    local temp_file="$BUILD_DIR/$(basename "$PORTABLEGIT_URL")"
+
+    # PortableGit is a 7-Zip self-extracting archive. 7z is preinstalled on the
+    # windows-latest CI runner; for a local Windows build, install 7-Zip and put
+    # `7z` on PATH. Fail with a clear message rather than a bare "command not
+    # found" from the extract step below.
+    if ! command -v 7z >/dev/null 2>&1; then
+        echo "ERROR: 7z (7-Zip) is required to extract patch.exe from PortableGit." >&2
+        echo "       Install 7-Zip and ensure '7z' is on PATH." >&2
+        exit 1
+    fi
+
+    echo ""
+    echo "=== Downloading PortableGit (for patch.exe) ==="
+    if [[ -f "$temp_file" ]]; then
+        echo "Using cached download: $temp_file"
+        verify_sha256 "$temp_file" "$PORTABLEGIT_SHA256"
+    else
+        curl -fL --retry 3 -o "${temp_file}.partial" "$PORTABLEGIT_URL"
+        verify_sha256 "${temp_file}.partial" "$PORTABLEGIT_SHA256"
+        mv -f "${temp_file}.partial" "$temp_file"
+    fi
+
+    echo ""
+    echo "=== Extracting patch.exe into ${patch_dir} ==="
+    # PortableGit is a 7-Zip self-extracting archive; `7z` is preinstalled on the
+    # windows-latest runner this path runs on. Pull only patch.exe and the MSYS
+    # runtime DLLs it depends on (msys-2.0.dll + gettext/iconv), flattened into
+    # patch_dir so they sit beside the exe.
+    mkdir -p "$patch_dir"
+    7z e "$temp_file" -o"$patch_dir" -y \
+        usr/bin/patch.exe \
+        usr/bin/msys-2.0.dll \
+        usr/bin/msys-intl-8.dll \
+        usr/bin/msys-iconv-2.dll
+
+    if [[ ! -f "$patch_dir/patch.exe" ]]; then
+        echo "ERROR: patch.exe not extracted from PortableGit" >&2
+        exit 1
+    fi
+
+    # We ship only the binaries (not PortableGit's license tree), so accompany
+    # them with the required attribution + corresponding-source pointer for these
+    # GPL/LGPL components.
+    cat > "$patch_dir/THIRD_PARTY_NOTICES.txt" <<EOF
+This directory contains unmodified binaries taken from Git for Windows
+(${PORTABLEGIT_URL}):
+
+  patch.exe         GNU patch          GPLv3
+  msys-2.0.dll      MSYS2 runtime      LGPLv3
+  msys-intl-8.dll   GNU gettext libintl  LGPLv2.1-or-later
+  msys-iconv-2.dll  GNU libiconv         LGPLv2.1-or-later
+
+They are redistributed under their respective licenses and are invoked as a
+separate process (GNU patch) by ESPHome's build. Corresponding source is
+available from the Git for Windows release above and its upstream projects.
+EOF
+
+    # Smoke-test: prove patch runs (and that no DLL dependency is missing). If a
+    # future MSYS patch needs more than the DLLs above, this fails the build here
+    # rather than shipping a patch.exe that won't launch on a user's machine.
+    echo "=== Verifying bundled patch.exe ==="
+    "$patch_dir/patch.exe" --version
 }
 
 # Rewrite pip-generated script shebangs so the bundle is relocatable.

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -173,6 +173,19 @@ pub fn get_bundled_git_dir(app_handle: &AppHandle) -> Result<PathBuf> {
     Ok(resource_dir.join("git").join("cmd"))
 }
 
+/// Directory inside the bundled `git` resource that holds a GNU `patch.exe`.
+///
+/// MinGit ships no `patch`, but the esphome micro-opus ESP-IDF build needs one
+/// on `PATH` to patch the Opus source (issue #189). `prepare_bundle.sh` harvests
+/// `patch.exe` (and the MSYS DLLs it links) from PortableGit into `git/patch/`.
+/// We expose only this dir, not MinGit's full `usr/bin`, so the build doesn't
+/// pick up MSYS `sh`/`find`/`sort` that shadow Windows built-ins.
+#[cfg(target_os = "windows")]
+pub fn get_bundled_patch_dir(app_handle: &AppHandle) -> Result<PathBuf> {
+    let resource_dir = get_bundled_resource_dir(app_handle)?;
+    Ok(resource_dir.join("git").join("patch"))
+}
+
 /// Build a `PATH` value with `dir` prepended to `existing`.
 ///
 /// Pure (no environment mutation) so the prepend ordering, separator
@@ -231,7 +244,19 @@ pub fn ensure_git_on_path(app_handle: &AppHandle) -> Result<()> {
         // Prepend the bundled git dir to PATH (see path_with_prepended for why
         // it goes through split/join).
         let existing = std::env::var_os("PATH").unwrap_or_default();
-        let new_path = path_with_prepended(&existing, &git_dir)?;
+        let mut new_path = path_with_prepended(&existing, &git_dir)?;
+
+        // Also expose the bundled GNU patch (issue #189) when present. Only this
+        // dedicated dir goes on PATH, not MinGit's full usr/bin, so the build
+        // doesn't pick up MSYS sh/find/sort that shadow Windows built-ins.
+        let patch_dir = get_bundled_patch_dir(app_handle)?;
+        if patch_dir.join("patch.exe").exists() {
+            new_path = path_with_prepended(&new_path, &patch_dir)?;
+            info!("Using bundled patch at {:?}", patch_dir);
+        } else {
+            warn!("Bundled patch.exe missing at {:?}; micro-opus and other components that need `patch` will fail to build", patch_dir);
+        }
+
         std::env::set_var("PATH", &new_path);
         info!("Using bundled MinGit at {:?}", git_exe);
     }
@@ -1128,6 +1153,24 @@ mod tests {
                 PathBuf::from("/bin"),
             ],
             "bundled git dir must come first so it shadows anything already on PATH"
+        );
+    }
+
+    #[test]
+    fn path_with_prepended_chains_two_bundled_dirs() {
+        // ensure_git_on_path prepends git/cmd then git/patch (#189). Both bundled
+        // dirs must end up ahead of the inherited PATH.
+        let existing = std::env::join_paths(["/usr/bin"]).unwrap();
+        let with_git = path_with_prepended(&existing, Path::new("/opt/git/cmd")).unwrap();
+        let with_patch = path_with_prepended(&with_git, Path::new("/opt/git/patch")).unwrap();
+        let entries: Vec<PathBuf> = std::env::split_paths(&with_patch).collect();
+        assert_eq!(
+            entries,
+            vec![
+                PathBuf::from("/opt/git/patch"),
+                PathBuf::from("/opt/git/cmd"),
+                PathBuf::from("/usr/bin"),
+            ],
         );
     }
 

--- a/tests/test_bump_bundle_versions.py
+++ b/tests/test_bump_bundle_versions.py
@@ -37,6 +37,8 @@ BASE_URL="https://example/${PBS_VERSION}"
 MINGIT_VERSION="2.53.0"
 MINGIT_URL="https://github.com/git-for-windows/git/releases/download/v2.53.0.windows.1/MinGit-2.53.0-64-bit.zip"
 MINGIT_SHA256="0000000000000000000000000000000000000000000000000000000000000000"
+PORTABLEGIT_URL="https://github.com/git-for-windows/git/releases/download/v2.53.0.windows.1/PortableGit-2.53.0-64-bit.7z.exe"
+PORTABLEGIT_SHA256="1111111111111111111111111111111111111111111111111111111111111111"
 """
 
 
@@ -228,6 +230,8 @@ def _gfw_release(tag: str, mingit_ver: str) -> dict[str, Any]:
         f"MinGit-{mingit_ver}-arm64.zip",
         f"MinGit-{mingit_ver}-busybox-64-bit.zip",
         f"MinGit-{mingit_ver}-64-bit.zip",
+        f"PortableGit-{mingit_ver}-32-bit.7z.exe",
+        f"PortableGit-{mingit_ver}-64-bit.7z.exe",
     ]
     return {
         "tag_name": tag,
@@ -248,10 +252,13 @@ def test_resolve_latest_mingit_picks_plain_64bit_asset(
     monkeypatch.setattr(
         bump, "_api_get", lambda url: _gfw_release("v2.54.0.windows.1", "2.54.0")
     )
-    version, url, sha = bump.resolve_latest_mingit()
+    version, url, sha, pg_url, pg_sha = bump.resolve_latest_mingit()
     assert version == "2.54.0"
     assert url.endswith("/v2.54.0.windows.1/MinGit-2.54.0-64-bit.zip")
     assert sha == "ab" * 32
+    # The PortableGit asset (patch.exe source) is resolved from the same release.
+    assert pg_url.endswith("/v2.54.0.windows.1/PortableGit-2.54.0-64-bit.7z.exe")
+    assert pg_sha == "ab" * 32
 
 
 def test_resolve_latest_mingit_handles_rebuild(
@@ -262,9 +269,10 @@ def test_resolve_latest_mingit_handles_rebuild(
     monkeypatch.setattr(
         bump, "_api_get", lambda url: _gfw_release("v2.53.0.windows.3", "2.53.0.3")
     )
-    version, url, _sha = bump.resolve_latest_mingit()
+    version, url, _sha, pg_url, _pg_sha = bump.resolve_latest_mingit()
     assert version == "2.53.0.3"
     assert url.endswith("/v2.53.0.windows.3/MinGit-2.53.0.3-64-bit.zip")
+    assert pg_url.endswith("/v2.53.0.windows.3/PortableGit-2.53.0.3-64-bit.7z.exe")
 
 
 def test_resolve_latest_mingit_raises_when_no_asset(
@@ -274,6 +282,26 @@ def test_resolve_latest_mingit_raises_when_no_asset(
         bump, "_api_get", lambda url: {"tag_name": "v2.54.0.windows.1", "assets": []}
     )
     with pytest.raises(bump.ResolutionError):
+        bump.resolve_latest_mingit()
+
+
+def test_resolve_latest_mingit_raises_when_portablegit_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # MinGit present but no PortableGit (the patch.exe source) is a broken release
+    # assumption that must fail loudly, not silently ship without patch.
+    release = {
+        "tag_name": "v2.54.0.windows.1",
+        "assets": [
+            {
+                "name": "MinGit-2.54.0-64-bit.zip",
+                "browser_download_url": "https://example/MinGit-2.54.0-64-bit.zip",
+                "digest": f"sha256:{'ab' * 32}",
+            }
+        ],
+    }
+    monkeypatch.setattr(bump, "_api_get", lambda url: release)
+    with pytest.raises(bump.ResolutionError, match="PortableGit"):
         bump.resolve_latest_mingit()
 
 
@@ -433,8 +461,14 @@ def test_main_mingit_writes_file_and_outputs_on_bump(
         "https://github.com/git-for-windows/git/releases/download/"
         "v2.54.0.windows.1/MinGit-2.54.0-64-bit.zip"
     )
+    new_pg_url = (
+        "https://github.com/git-for-windows/git/releases/download/"
+        "v2.54.0.windows.1/PortableGit-2.54.0-64-bit.7z.exe"
+    )
     monkeypatch.setattr(
-        bump, "resolve_latest_mingit", lambda: ("2.54.0", new_url, "ff" * 32)
+        bump,
+        "resolve_latest_mingit",
+        lambda: ("2.54.0", new_url, "ff" * 32, new_pg_url, "ee" * 32),
     )
 
     rc = bump.main(["--target", "mingit", "--file", str(script)])
@@ -443,6 +477,9 @@ def test_main_mingit_writes_file_and_outputs_on_bump(
     assert 'MINGIT_VERSION="2.54.0"' in text
     assert f'MINGIT_URL="{new_url}"' in text
     assert f'MINGIT_SHA256="{"ff" * 32}"' in text
+    # PortableGit (patch.exe source) is bumped in lockstep with MinGit.
+    assert f'PORTABLEGIT_URL="{new_pg_url}"' in text
+    assert f'PORTABLEGIT_SHA256="{"ee" * 32}"' in text
     # The Python pins are untouched by a MinGit bump.
     assert 'PYTHON_VERSION="3.13.12"' in text
 
@@ -462,8 +499,14 @@ def test_main_mingit_no_op_when_already_current(
         "https://github.com/git-for-windows/git/releases/download/"
         "v2.53.0.windows.1/MinGit-2.53.0-64-bit.zip"
     )
+    current_pg_url = (
+        "https://github.com/git-for-windows/git/releases/download/"
+        "v2.53.0.windows.1/PortableGit-2.53.0-64-bit.7z.exe"
+    )
     monkeypatch.setattr(
-        bump, "resolve_latest_mingit", lambda: ("2.53.0", current_url, "0" * 64)
+        bump,
+        "resolve_latest_mingit",
+        lambda: ("2.53.0", current_url, "0" * 64, current_pg_url, "1" * 64),
     )
 
     rc = bump.main(["--target", "mingit", "--file", str(script)])
@@ -485,8 +528,14 @@ def test_main_mingit_refuses_downgrade(
         "https://github.com/git-for-windows/git/releases/download/"
         "v2.52.0.windows.1/MinGit-2.52.0-64-bit.zip"
     )
+    old_pg_url = (
+        "https://github.com/git-for-windows/git/releases/download/"
+        "v2.52.0.windows.1/PortableGit-2.52.0-64-bit.7z.exe"
+    )
     monkeypatch.setattr(
-        bump, "resolve_latest_mingit", lambda: ("2.52.0", old_url, "aa" * 32)
+        bump,
+        "resolve_latest_mingit",
+        lambda: ("2.52.0", old_url, "aa" * 32, old_pg_url, "bb" * 32),
     )
 
     rc = bump.main(["--target", "mingit", "--file", str(script)])


### PR DESCRIPTION
# What does this implement/fix?

On Windows, configs that pull in the esphome micro-opus component (for example Home Assistant Voice PE) fail to build with `Opus: 'patch' command not found`. The micro-opus ESP-IDF build patches the Opus source and needs a `patch` utility on PATH; the bundled MinGit ships git but no patch, so the build dies. It works on Linux and HA because patch is available system-wide there. The `fatal: not a git repository` line in the issue title is a benign CMake probe, not the real failure.

This harvests a GNU patch.exe, plus the MSYS DLLs it links, from PortableGit at build time into a dedicated `git/patch` directory, and puts only that directory on the build PATH. Exposing just patch (not all of MinGit's `usr/bin`) keeps MSYS `sh`/`find`/`sort` off PATH so they can't shadow Windows built-ins during the ESP-IDF/CMake build. PortableGit is pinned to the same git-for-windows release as MinGit and bumped in lockstep by the nightly job, so patch.exe stays ABI matched to MinGit's msys-2.0.dll. The build smoke-tests `patch.exe --version`, and a notice file records the GPLv3/LGPL attribution and source for the harvested binaries.

Footprint stays minimal: ~5 MB added (patch.exe + 3 DLLs) rather than switching the bundle to the ~300 MB full PortableGit tree.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes #189

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).
