### PR TITLE
fix(update): stop the backend before installing a desktop self-update

### DIFF
--- a/src-tauri/src/app_update/mod.rs
+++ b/src-tauri/src/app_update/mod.rs
@@ -205,10 +205,15 @@ async fn apply_update(app_handle: &AppHandle, update: tauri_plugin_updater::Upda
     }
 
     // `install` is synchronous and writes files, so run it off the async
-    // executor like the dialogs above.
+    // executor like the dialogs above. Flatten the join error and the install
+    // error so success and failure each have a single arm.
     info!("Installing desktop update…");
-    match tokio::task::spawn_blocking(move || update.install(bytes)).await {
-        Ok(Ok(())) => {
+    let result = match tokio::task::spawn_blocking(move || update.install(bytes)).await {
+        Ok(install) => install.map_err(|e| e.to_string()),
+        Err(join) => Err(format!("install task panicked: {}", join)),
+    };
+    match result {
+        Ok(()) => {
             info!("Desktop update {} installed", new_version);
             let msg = format!(
                 "ESPHome Device Builder {} has been installed.\n\nRestart now to use the new version?",
@@ -227,13 +232,8 @@ async fn apply_update(app_handle: &AppHandle, update: tauri_plugin_updater::Upda
                 restore_backend(app_handle).await;
             }
         }
-        Ok(Err(e)) => {
-            error!("Desktop update install failed: {}", e);
-            restore_backend(app_handle).await;
-            show_error(app_handle, format!("Failed to install update: {}", e)).await;
-        }
         Err(e) => {
-            error!("Desktop update install task failed: {}", e);
+            error!("Desktop update install failed: {}", e);
             restore_backend(app_handle).await;
             show_error(app_handle, format!("Failed to install update: {}", e)).await;
         }

--- a/src-tauri/src/app_update/mod.rs
+++ b/src-tauri/src/app_update/mod.rs
@@ -210,7 +210,7 @@ async fn apply_update(app_handle: &AppHandle, update: tauri_plugin_updater::Upda
     info!("Installing desktop update…");
     let result = match tokio::task::spawn_blocking(move || update.install(bytes)).await {
         Ok(install) => install.map_err(|e| e.to_string()),
-        Err(join) => Err(format!("install task panicked: {}", join)),
+        Err(join) => Err(format!("install task failed: {}", join)),
     };
     match result {
         Ok(()) => {

--- a/src-tauri/src/app_update/mod.rs
+++ b/src-tauri/src/app_update/mod.rs
@@ -13,7 +13,7 @@
 
 use std::time::Duration;
 
-use tauri::AppHandle;
+use tauri::{AppHandle, Manager};
 use tauri_plugin_dialog::{DialogExt, MessageDialogKind};
 use tauri_plugin_notification::NotificationExt;
 use tauri_plugin_updater::UpdaterExt;
@@ -157,8 +157,11 @@ async fn apply_update(app_handle: &AppHandle, update: tauri_plugin_updater::Upda
 
     let mut downloaded: u64 = 0;
     let mut last_logged = std::time::Instant::now();
-    let result = update
-        .download_and_install(
+    // Download first, with the backend still running. A failed download must
+    // not disrupt the running dashboard, so we only stop it once we have the
+    // bytes in hand and are about to write files.
+    let bytes = match update
+        .download(
             move |chunk, total| {
                 downloaded = downloaded.saturating_add(chunk as u64);
                 // Throttle progress logs to once per second.
@@ -171,12 +174,37 @@ async fn apply_update(app_handle: &AppHandle, update: tauri_plugin_updater::Upda
                     last_logged = std::time::Instant::now();
                 }
             },
-            || info!("Desktop update download complete; installing…"),
+            || info!("Desktop update download complete"),
         )
-        .await;
+        .await
+    {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            error!("Desktop update download failed: {}", e);
+            show_error(app_handle, format!("Failed to download update: {}", e)).await;
+            return;
+        }
+    };
 
-    match result {
-        Ok(()) => {
+    // Stop the backend before installing: the install overwrites the bundled
+    // `python/` directory, and on Windows the live `python.exe` keeps those
+    // files open (WinError 5) and holds port 6052, so the write fails and the
+    // next launch can't bind. Reuses the same graceful `DaemonManager::stop()`
+    // the ESPHome package-update path uses; best-effort, so proceed on error.
+    if let Some(state) = app_handle.try_state::<std::sync::Arc<crate::AppState>>() {
+        info!("Stopping ESPHome backend before installing desktop update");
+        if let Err(e) = state.daemon.stop().await {
+            warn!("Error stopping backend before update: {}", e);
+        }
+    } else {
+        warn!("App state unavailable; installing update without stopping backend");
+    }
+
+    // `install` is synchronous and writes files, so run it off the async
+    // executor like the dialogs above.
+    info!("Installing desktop update…");
+    match tokio::task::spawn_blocking(move || update.install(bytes)).await {
+        Ok(Ok(())) => {
             info!("Desktop update {} installed", new_version);
             let msg = format!(
                 "ESPHome Device Builder {} has been installed.\n\nRestart now to use the new version?",
@@ -191,8 +219,12 @@ async fn apply_update(app_handle: &AppHandle, update: tauri_plugin_updater::Upda
                 app_handle.restart();
             }
         }
-        Err(e) => {
+        Ok(Err(e)) => {
             error!("Desktop update install failed: {}", e);
+            show_error(app_handle, format!("Failed to install update: {}", e)).await;
+        }
+        Err(e) => {
+            error!("Desktop update install task failed: {}", e);
             show_error(app_handle, format!("Failed to install update: {}", e)).await;
         }
     }

--- a/src-tauri/src/app_update/mod.rs
+++ b/src-tauri/src/app_update/mod.rs
@@ -193,6 +193,10 @@ async fn apply_update(app_handle: &AppHandle, update: tauri_plugin_updater::Upda
     // the ESPHome package-update path uses; best-effort, so proceed on error.
     if let Some(state) = app_handle.try_state::<std::sync::Arc<crate::AppState>>() {
         info!("Stopping ESPHome backend before installing desktop update");
+        // Reflect the stop in the tray immediately; `stop()` only flips the
+        // daemon's internal flag, so the tray would otherwise stay on
+        // "Running" (matches the package-update path in `tray`).
+        crate::tray::update_status(app_handle, false);
         if let Err(e) = state.daemon.stop().await {
             warn!("Error stopping backend before update: {}", e);
         }
@@ -221,11 +225,26 @@ async fn apply_update(app_handle: &AppHandle, update: tauri_plugin_updater::Upda
         }
         Ok(Err(e)) => {
             error!("Desktop update install failed: {}", e);
+            restart_backend_after_failed_install(app_handle).await;
             show_error(app_handle, format!("Failed to install update: {}", e)).await;
         }
         Err(e) => {
             error!("Desktop update install task failed: {}", e);
+            restart_backend_after_failed_install(app_handle).await;
             show_error(app_handle, format!("Failed to install update: {}", e)).await;
+        }
+    }
+}
+
+/// Bring the backend back up after a failed self-update install. We stop it
+/// before installing, so a failed install would otherwise leave the running
+/// app with no dashboard; restart it best-effort and restore the tray status.
+async fn restart_backend_after_failed_install(app_handle: &AppHandle) {
+    if let Some(state) = app_handle.try_state::<std::sync::Arc<crate::AppState>>() {
+        info!("Restarting ESPHome backend after failed desktop update");
+        match state.daemon.start().await {
+            Ok(()) => crate::tray::update_status(app_handle, true),
+            Err(e) => warn!("Failed to restart backend after failed update: {}", e),
         }
     }
 }

--- a/src-tauri/src/app_update/mod.rs
+++ b/src-tauri/src/app_update/mod.rs
@@ -221,30 +221,35 @@ async fn apply_update(app_handle: &AppHandle, update: tauri_plugin_updater::Upda
             if restart {
                 info!("Restarting to apply desktop update");
                 app_handle.restart();
+            } else {
+                // User deferred the restart; bring the backend back so the
+                // freshly installed dashboard is usable until they relaunch.
+                restore_backend(app_handle).await;
             }
         }
         Ok(Err(e)) => {
             error!("Desktop update install failed: {}", e);
-            restart_backend_after_failed_install(app_handle).await;
+            restore_backend(app_handle).await;
             show_error(app_handle, format!("Failed to install update: {}", e)).await;
         }
         Err(e) => {
             error!("Desktop update install task failed: {}", e);
-            restart_backend_after_failed_install(app_handle).await;
+            restore_backend(app_handle).await;
             show_error(app_handle, format!("Failed to install update: {}", e)).await;
         }
     }
 }
 
-/// Bring the backend back up after a failed self-update install. We stop it
-/// before installing, so a failed install would otherwise leave the running
-/// app with no dashboard; restart it best-effort and restore the tray status.
-async fn restart_backend_after_failed_install(app_handle: &AppHandle) {
+/// Bring the backend back up when we're not restarting the whole app. We stop
+/// it before installing, so without this a failed install (or a user who defers
+/// the post-install restart) would leave the running app with no dashboard.
+/// Best-effort: restart it and restore the tray status.
+async fn restore_backend(app_handle: &AppHandle) {
     if let Some(state) = app_handle.try_state::<std::sync::Arc<crate::AppState>>() {
-        info!("Restarting ESPHome backend after failed desktop update");
+        info!("Restarting ESPHome backend after desktop update");
         match state.daemon.start().await {
             Ok(()) => crate::tray::update_status(app_handle, true),
-            Err(e) => warn!("Failed to restart backend after failed update: {}", e),
+            Err(e) => warn!("Failed to restart backend after update: {}", e),
         }
     }
 }


### PR DESCRIPTION
# What does this implement/fix?

Updating the desktop app on Windows failed because the self-updater never stopped the Python backend before installing; the live python.exe kept the bundled python/ files open (WinError 5) and held port 6052, so the install could not overwrite them and the next launch could not bind the dashboard port.

This splits the download and install steps so the backend stays up during the download, then stops it right before writing files using the same graceful DaemonManager::stop the ESPHome package update path already uses. The synchronous install now runs off the async executor, matching how the dialogs are handled.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes https://github.com/esphome/esphome-desktop/issues/195

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).