### PR TITLE
refactor(dialog): extract a shared confirm() helper

### DIFF
--- a/src-tauri/src/app_update/mod.rs
+++ b/src-tauri/src/app_update/mod.rs
@@ -58,9 +58,14 @@ pub async fn check_for_user(app_handle: &AppHandle, show_no_update_dialog: bool)
             let notes = update.body.clone().unwrap_or_default();
 
             let msg = format_update_prompt(&current_version, &new_version, &notes);
-            let confirmed =
-                crate::dialog::confirm(app_handle, "Desktop Update Available", msg, "Update Now", "Later")
-                    .await;
+            let confirmed = crate::dialog::confirm(
+                app_handle,
+                "Desktop Update Available",
+                msg,
+                "Update Now",
+                "Later",
+            )
+            .await;
 
             if !confirmed {
                 // User saw the dialog and declined — fall through to ESPHome check.

--- a/src-tauri/src/app_update/mod.rs
+++ b/src-tauri/src/app_update/mod.rs
@@ -57,21 +57,10 @@ pub async fn check_for_user(app_handle: &AppHandle, show_no_update_dialog: bool)
             let current_version = update.current_version.clone();
             let notes = update.body.clone().unwrap_or_default();
 
-            let dialog_app = app_handle.clone();
             let msg = format_update_prompt(&current_version, &new_version, &notes);
-            let confirmed = tokio::task::spawn_blocking(move || {
-                dialog_app
-                    .dialog()
-                    .message(msg)
-                    .title("Desktop Update Available")
-                    .buttons(tauri_plugin_dialog::MessageDialogButtons::OkCancelCustom(
-                        "Update Now".to_string(),
-                        "Later".to_string(),
-                    ))
-                    .blocking_show()
-            })
-            .await
-            .unwrap_or(false);
+            let confirmed =
+                crate::dialog::confirm(app_handle, "Desktop Update Available", msg, "Update Now", "Later")
+                    .await;
 
             if !confirmed {
                 // User saw the dialog and declined — fall through to ESPHome check.
@@ -184,24 +173,13 @@ async fn apply_update(app_handle: &AppHandle, update: tauri_plugin_updater::Upda
     match result {
         Ok(()) => {
             info!("Desktop update {} installed", new_version);
-            let dialog_app = app_handle.clone();
             let msg = format!(
                 "ESPHome Device Builder {} has been installed.\n\nRestart now to use the new version?",
                 new_version
             );
-            let restart = tokio::task::spawn_blocking(move || {
-                dialog_app
-                    .dialog()
-                    .message(msg)
-                    .title("Update Installed")
-                    .buttons(tauri_plugin_dialog::MessageDialogButtons::OkCancelCustom(
-                        "Restart Now".to_string(),
-                        "Later".to_string(),
-                    ))
-                    .blocking_show()
-            })
-            .await
-            .unwrap_or(false);
+            let restart =
+                crate::dialog::confirm(app_handle, "Update Installed", msg, "Restart Now", "Later")
+                    .await;
 
             if restart {
                 info!("Restarting to apply desktop update");

--- a/src-tauri/src/dialog.rs
+++ b/src-tauri/src/dialog.rs
@@ -1,0 +1,34 @@
+//! Small helpers around `tauri-plugin-dialog`.
+
+use tauri::AppHandle;
+use tauri_plugin_dialog::{DialogExt, MessageDialogButtons};
+
+/// Show a modal two-button confirmation dialog and wait for the user's choice.
+///
+/// `blocking_show` is synchronous, so it runs on a blocking thread to keep the
+/// async executor free. Returns `true` only when the user picks the confirm
+/// button; a cancel, a closed dialog, or a join error all map to `false`.
+pub(crate) async fn confirm(
+    app_handle: &AppHandle,
+    title: &str,
+    message: String,
+    confirm_label: &str,
+    cancel_label: &str,
+) -> bool {
+    let app = app_handle.clone();
+    let title = title.to_string();
+    let confirm_label = confirm_label.to_string();
+    let cancel_label = cancel_label.to_string();
+    tokio::task::spawn_blocking(move || {
+        app.dialog()
+            .message(message)
+            .title(title)
+            .buttons(MessageDialogButtons::OkCancelCustom(
+                confirm_label,
+                cancel_label,
+            ))
+            .blocking_show()
+    })
+    .await
+    .unwrap_or(false)
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@
 
 mod app_update;
 mod daemon;
+mod dialog;
 mod git_check;
 mod platform;
 mod settings;

--- a/src-tauri/src/tray/mod.rs
+++ b/src-tauri/src/tray/mod.rs
@@ -735,24 +735,13 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>, _a
                     ""
                 };
 
-                let dialog_app = app.clone();
                 let msg = format!(
                     "{}Switch ESPHome from {} to {} channel?\n\nThis will stop the dashboard, install the appropriate version, and restart.",
                     warning, old_channel, new_channel
                 );
-                let confirmed = tokio::task::spawn_blocking(move || {
-                    dialog_app
-                        .dialog()
-                        .message(msg)
-                        .title("Switch Release Channel")
-                        .buttons(tauri_plugin_dialog::MessageDialogButtons::OkCancelCustom(
-                            "Switch".to_string(),
-                            "Cancel".to_string(),
-                        ))
-                        .blocking_show()
-                })
-                .await
-                .unwrap_or(false);
+                let confirmed =
+                    crate::dialog::confirm(&app, "Switch Release Channel", msg, "Switch", "Cancel")
+                        .await;
 
                 if !confirmed {
                     // Revert the check marks
@@ -887,7 +876,6 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>, _a
                 }
 
                 // Confirm the switch with the user.
-                let dialog_app = app.clone();
                 let msg = if new_backend.is_builder() {
                     format!(
                         "Switch to {}?\n\n\
@@ -900,19 +888,8 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>, _a
                      This will stop the device builder and restart with the dashboard."
                         .to_string()
                 };
-                let confirmed = tokio::task::spawn_blocking(move || {
-                    dialog_app
-                        .dialog()
-                        .message(msg)
-                        .title("Switch Backend")
-                        .buttons(tauri_plugin_dialog::MessageDialogButtons::OkCancelCustom(
-                            "Switch".to_string(),
-                            "Cancel".to_string(),
-                        ))
-                        .blocking_show()
-                })
-                .await
-                .unwrap_or(false);
+                let confirmed =
+                    crate::dialog::confirm(&app, "Switch Backend", msg, "Switch", "Cancel").await;
 
                 if !confirmed {
                     update_backend_checks(old_backend);


### PR DESCRIPTION
# What does this implement/fix?

Four call sites hand built the same OkCancelCustom dialog on a blocking thread and mapped the result to a bool; the desktop update prompt, the ESPHome update restart prompt, the release channel switch, and the backend switch. This collapses them into a single crate::dialog::confirm helper, so each call site only specifies the title and the two button labels. No behavior change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes <link to issue>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).