### PR TITLE
Add workflow to lock closed issues and PRs

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,17 @@
+---
+name: Lock closed issues and PRs
+
+on:
+  schedule:
+    - cron: "30 0 * * *"  # Run daily at 00:30 UTC
+  workflow_dispatch:
+
+# Deny by default; the lock job opts in to exactly what the reusable workflow needs.
+permissions: {}
+
+jobs:
+  lock:
+    permissions:
+      issues: write         # issues.lock on closed issues
+      pull-requests: write  # issues.lock on closed pull requests
+    uses: esphome/workflows/.github/workflows/lock.yml@025a1e6255610c498ed590403b7e510b69e474df  # 2026.4.1


### PR DESCRIPTION
# What does this implement/fix?

Closed issues and PRs here are starting to collect comment spam as we near 1.0; this adds the same lock workflow already merged in device-builder and device-builder-frontend so old threads get locked automatically. It calls the org shared reusable workflow `esphome/workflows/.github/workflows/lock.yml`, pinned to the same revision as the sibling repos so all three stay in lockstep; runs nightly at 00:30 UTC and on demand via workflow_dispatch.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue (if applicable):**

- fixes <link to issue>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).
