### PR TITLE
Remove the classic dashboard backend and force the device builder for classic users

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Right-click (or left-click on some platforms) the tray icon to access:
 - **Open Dashboard** - Open the dashboard in your browser
 - **Status** - Shows if the daemon is running
 - **Port** - Shows the configured port
-- **Backend** - Choose the classic ESPHome dashboard or the ESPHome Device Builder backend
+- **Backend** - Choose the ESPHome Device Builder channel (stable or beta)
 - **Release Channel** - Choose the update channel (Stable, Beta, Dev)
 - **Startup** - Choose whether the app launches automatically at login (on by default; see [Running as a remote builder](#running-as-a-remote-builder))
 - **Check for Updates** - Check for a new ESPHome Device Builder desktop release, then new ESPHome (Python) and device-builder versions

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ESPHome Device Builder
 
-A cross-platform desktop application that bundles ESPHome with Python and runs the dashboard as a background daemon with system tray integration.
+A cross-platform desktop application that bundles ESPHome with Python and runs the ESPHome Device Builder as a background daemon with system tray integration.
 
 ## Features
 
@@ -29,7 +29,7 @@ Download the latest release for your platform from [desktop.esphome.io](https://
 
 On first launch, ESPHome Device Builder will:
 1. Install ESPHome and its dependencies
-2. Start the dashboard
+2. Start the ESPHome Device Builder
 3. Open your browser to `http://localhost:6052`
 
 This initial setup may take a few minutes depending on your internet connection.
@@ -39,9 +39,9 @@ This initial setup may take a few minutes depending on your internet connection.
 ### Starting the App
 
 Simply launch ESPHome Device Builder. It will:
-- Start the ESPHome dashboard in the background
+- Start the ESPHome Device Builder in the background
 - Show a system tray icon
-- Open your browser to the dashboard
+- Open your browser to the Device Builder
 
 ### Tray Menu
 

--- a/src-tauri/src/daemon/mod.rs
+++ b/src-tauri/src/daemon/mod.rs
@@ -32,6 +32,9 @@ type PidInt = u32;
 #[cfg(unix)]
 type PidInt = i32;
 
+/// Human-readable name of the backend process, for log messages.
+const BACKEND_NAME: &str = "ESPHome device builder";
+
 /// Manages the ESPHome dashboard process
 pub struct DaemonManager {
     /// The running process, if any
@@ -54,8 +57,6 @@ pub struct DaemonManager {
     /// group without locking the tokio mutex. Zero when no child is
     /// running.
     dashboard_pid: Arc<AtomicPid>,
-    /// Use `esphome-device-builder` instead of `esphome dashboard`
-    use_device_builder: Arc<AtomicBool>,
     /// AppHandle for emitting notifications / updating the tray when the
     /// child process exits independently of an explicit `stop()`. Also used
     /// to read the desktop app version (forwarded to the backend via
@@ -91,26 +92,11 @@ impl DaemonManager {
             port: settings.port,
             running: Arc::new(AtomicBool::new(false)),
             dashboard_pid: Arc::new(AtomicPid::new(0)),
-            use_device_builder: Arc::new(AtomicBool::new(settings.backend.is_builder())),
             app_handle: app_handle.clone(),
         })
     }
 
-    /// Update the device-builder flag. Takes effect on the next daemon start.
-    pub fn set_use_device_builder(&self, value: bool) {
-        self.use_device_builder.store(value, Ordering::SeqCst);
-    }
-
-    /// Human-readable name of the current backend, for log messages.
-    fn backend_name(&self) -> &'static str {
-        if self.use_device_builder.load(Ordering::SeqCst) {
-            "ESPHome device builder"
-        } else {
-            "ESPHome dashboard"
-        }
-    }
-
-    /// Start the ESPHome dashboard
+    /// Start the ESPHome device builder
     pub async fn start(&self) -> Result<()> {
         // Hold the process lock for the entire start sequence (check ->
         // spawn -> store) so two concurrent start() calls can't both pass
@@ -133,8 +119,7 @@ impl DaemonManager {
             return Ok(());
         }
 
-        let use_device_builder = self.use_device_builder.load(Ordering::SeqCst);
-        let backend_name = self.backend_name();
+        let backend_name = BACKEND_NAME;
         info!("Starting {} on port {}", backend_name, self.port);
         debug!("Python path: {:?}", self.python_path);
         debug!("Python bin: {:?}", self.python_bin_dir);
@@ -160,28 +145,15 @@ impl DaemonManager {
 
         // Build the command
         let mut cmd = Command::new(&self.python_path);
-        if use_device_builder {
-            cmd.args([
-                "-m",
-                "esphome_device_builder",
-                config_arg,
-                "--host",
-                "127.0.0.1",
-                "--port",
-                &port_arg,
-            ]);
-        } else {
-            cmd.args([
-                "-m",
-                "esphome",
-                "dashboard",
-                config_arg,
-                "--address",
-                "127.0.0.1",
-                "--port",
-                &port_arg,
-            ]);
-        }
+        cmd.args([
+            "-m",
+            "esphome_device_builder",
+            config_arg,
+            "--host",
+            "127.0.0.1",
+            "--port",
+            &port_arg,
+        ]);
         cmd
             // Set working directory to config dir (required for PlatformIO)
             .current_dir(&self.config_dir)
@@ -234,8 +206,7 @@ impl DaemonManager {
         // Set environment variables
         cmd.env("ESPHOME_DASHBOARD", "1");
         // Surface the desktop app version to the backend so it can be shown
-        // in the frontend (e.g. an "About" page). Set unconditionally — both
-        // backends get it; classic dashboard can ignore it.
+        // in the frontend (e.g. an "About" page).
         cmd.env(
             "ESPHOME_DESKTOP_VERSION",
             self.app_handle.package_info().version.to_string(),
@@ -397,7 +368,7 @@ impl DaemonManager {
             return Ok(());
         }
 
-        let backend_name = self.backend_name();
+        let backend_name = BACKEND_NAME;
         info!("Stopping {}", backend_name);
 
         self.running.store(false, Ordering::SeqCst);

--- a/src-tauri/src/daemon/mod.rs
+++ b/src-tauri/src/daemon/mod.rs
@@ -51,7 +51,7 @@ pub struct DaemonManager {
     port: u16,
     /// Whether the daemon is running
     running: Arc<AtomicBool>,
-    /// PID of the dashboard child, mirrored as an atomic so synchronous
+    /// PID of the device builder child, mirrored as an atomic so synchronous
     /// exit paths (e.g. macOS Dock-Quit, which fires `RunEvent::Exit`
     /// without going through `ExitRequested`) can SIGTERM the process
     /// group without locking the tokio mutex. Zero when no child is

--- a/src-tauri/src/daemon/mod.rs
+++ b/src-tauri/src/daemon/mod.rs
@@ -35,7 +35,7 @@ type PidInt = i32;
 /// Human-readable name of the backend process, for log messages.
 const BACKEND_NAME: &str = "ESPHome device builder";
 
-/// Manages the ESPHome dashboard process
+/// Manages the ESPHome Device Builder process
 pub struct DaemonManager {
     /// The running process, if any
     process: Arc<Mutex<Option<Child>>>,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -49,9 +49,9 @@ pub struct Cli {
     #[arg(long = "no-open-dashboard")]
     pub no_open_dashboard: bool,
 
-    /// Switch to the ESPHome Device Builder backend instead of the classic
-    /// dashboard. Persists to settings — useful as a fallback when the tray
-    /// menu is unavailable.
+    /// Apply the `--builder-channel` selection (stable or beta) to the device
+    /// builder. Persists to settings — useful as a fallback when the tray menu
+    /// is unavailable.
     #[arg(long = "use-builder")]
     pub use_builder: bool,
 
@@ -231,9 +231,16 @@ pub fn run(cli: Cli) {
         .setup(move |app| {
             info!("Setting up ESPHome Device Builder");
 
+            // Users migrating off the removed classic dashboard backend should
+            // land on the fresh bundled device builder, not a stale pip-pinned
+            // copy. Detect the classic selection from the persisted settings
+            // before the bundled-Python refresh so the refresh can skip
+            // preserving an old `esphome-device-builder` version.
+            let force_device_builder = settings::persisted_backend_was_classic(app.handle());
+
             // Ensure user Python exists (copy from bundled on first run for non-Windows)
             // This must happen before AppState::new() so paths are correct
-            if let Err(e) = platform::ensure_user_python(app.handle()) {
+            if let Err(e) = platform::ensure_user_python(app.handle(), force_device_builder) {
                 error!("Failed to set up user Python: {}", e);
                 // Continue anyway - might work with bundled Python
             }
@@ -259,6 +266,16 @@ pub fn run(cli: Cli) {
             let state = Arc::new(AppState::new(app.handle())?);
             app.manage(state.clone());
 
+            // If we just migrated a classic-backend user, persist the migrated
+            // settings (loaded as the default device builder) so the legacy
+            // value is cleared from disk and a later app update won't re-force.
+            if force_device_builder {
+                let settings = async_runtime::block_on(state.settings.read());
+                if let Err(e) = settings.save(app.handle()) {
+                    warn!("Failed to persist backend migration: {}", e);
+                }
+            }
+
             // Apply CLI backend override (persists to settings).
             // This runs before the daemon starts so the new backend takes
             // effect immediately, and before the tray menu is built so the
@@ -274,10 +291,8 @@ pub fn run(cli: Cli) {
                     if let Err(e) = settings.save(app.handle()) {
                         warn!("Failed to save settings after CLI override: {}", e);
                     }
-                    state
-                        .daemon
-                        .set_use_device_builder(new_backend.is_builder());
-                    new_backend.is_builder()
+                    // Changing the channel needs a (re)install of the package.
+                    true
                 } else {
                     false
                 }
@@ -457,16 +472,10 @@ pub fn run(cli: Cli) {
                         .update_checker
                         .check_and_notify(&update_app, channel, update_tray_available)
                         .await;
-                    if backend.is_builder() {
-                        update_state
-                            .update_checker
-                            .check_and_notify_device_builder(
-                                &update_app,
-                                backend,
-                                update_tray_available,
-                            )
-                            .await;
-                    }
+                    update_state
+                        .update_checker
+                        .check_and_notify_device_builder(&update_app, backend, update_tray_available)
+                        .await;
                 }
             });
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -474,7 +474,11 @@ pub fn run(cli: Cli) {
                         .await;
                     update_state
                         .update_checker
-                        .check_and_notify_device_builder(&update_app, backend, update_tray_available)
+                        .check_and_notify_device_builder(
+                            &update_app,
+                            backend,
+                            update_tray_available,
+                        )
                         .await;
                 }
             });

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -293,9 +293,10 @@ const MAX_REFRESH_DEFERS: u32 = 3;
 /// current desktop-app version, the directory is wiped and re-copied so that
 /// updated app releases ship a fresh Python tree (e.g. new ESPHome version,
 /// changed dependencies). Without this, the first-run copy persisted forever.
-pub fn ensure_user_python(app_handle: &AppHandle) -> Result<()> {
+pub fn ensure_user_python(app_handle: &AppHandle, force_device_builder: bool) -> Result<()> {
     #[cfg(target_os = "windows")]
     {
+        let _ = force_device_builder;
         let resource_dir = get_bundled_resource_dir(app_handle)?;
         let bundled_python = resource_dir.join("python").join("python.exe");
 
@@ -335,13 +336,18 @@ pub fn ensure_user_python(app_handle: &AppHandle) -> Result<()> {
             // Without this, a user who pip-bumped ESPHome past the bundled
             // version would silently get downgraded by every app self-update.
             //
+            // When `force_device_builder` is set (a user migrating off the
+            // removed classic dashboard), `esphome-device-builder` is left out
+            // of the snapshot so the freshly bundled copy always wins and the
+            // user lands on the current device builder.
+            //
             // If the probe FAILS (as opposed to the package being absent), we
             // cannot tell whether the user pinned a newer version, so wiping
             // the tree now would silently discard it — exactly the downgrade
             // this snapshot exists to prevent. In that case defer the refresh:
             // keep the working tree, log a warning, and retry next launch.
             let preserved = if python_check.exists() {
-                match snapshot_preserved_versions(&python_check) {
+                match snapshot_preserved_versions(&python_check, force_device_builder) {
                     Ok(p) => p,
                     Err(e) => {
                         // A probe error means we can't trust a snapshot — but
@@ -449,11 +455,23 @@ struct PreservedVersions {
 /// [`read_package_version`] means the package is genuinely absent, which is a
 /// successful snapshot). The caller must not wipe a tree it could not read, or
 /// it would silently downgrade a version the user deliberately pinned.
+///
+/// With `force_device_builder`, `esphome-device-builder` is excluded from the
+/// snapshot so the freshly bundled copy is kept as-is on restore (and a probe
+/// failure for it can't trigger a refresh defer either). Used to move a user
+/// off the removed classic dashboard onto the current device builder.
 #[cfg(not(target_os = "windows"))]
-fn snapshot_preserved_versions(python_bin: &Path) -> Result<PreservedVersions> {
+fn snapshot_preserved_versions(
+    python_bin: &Path,
+    force_device_builder: bool,
+) -> Result<PreservedVersions> {
     Ok(PreservedVersions {
         esphome: read_package_version(python_bin, "esphome")?,
-        esphome_device_builder: read_package_version(python_bin, "esphome-device-builder")?,
+        esphome_device_builder: if force_device_builder {
+            None
+        } else {
+            read_package_version(python_bin, "esphome-device-builder")?
+        },
     })
 }
 

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -366,7 +366,13 @@ pub fn ensure_user_python(app_handle: &AppHandle, force_device_builder: bool) ->
                         // MAX_REFRESH_DEFERS consecutive defers we proceed with
                         // the wipe to re-copy a clean bundle. The counter lives
                         // inside the tree, so it resets the moment we wipe.
-                        if interpreter_is_usable(&python_check) {
+                        //
+                        // Never defer while forcing the device builder (classic
+                        // migration): the daemon now always launches
+                        // `esphome_device_builder`, and an old classic tree may
+                        // not have it, so we must refresh to the bundle that
+                        // does rather than keep the old tree another launch.
+                        if !force_device_builder && interpreter_is_usable(&python_check) {
                             let defer_marker = user_python.join(PYTHON_REFRESH_DEFER_MARKER);
                             let defers = read_refresh_defer_count(&defer_marker);
                             if defers < MAX_REFRESH_DEFERS
@@ -390,6 +396,12 @@ pub fn ensure_user_python(app_handle: &AppHandle, force_device_builder: bool) ->
                                  package metadata appears persistently broken (or the defer \
                                  counter is unwritable). Wiping and re-copying the bundled tree \
                                  to recover."
+                            );
+                            PreservedVersions::default()
+                        } else if force_device_builder {
+                            warn!(
+                                "Could not read existing Python package versions ({e:#}) while \
+                                 migrating off the classic backend; refreshing to the bundled tree."
                             );
                             PreservedVersions::default()
                         } else {

--- a/src-tauri/src/settings/mod.rs
+++ b/src-tauri/src/settings/mod.rs
@@ -69,10 +69,13 @@ fn deserialize_backend<'de, D>(deserializer: D) -> Result<Backend, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
-    let raw = String::deserialize(deserializer)?;
+    // Deserialize into a generic value so a non-string `backend` (null, number,
+    // bool from a hand-edited or future file) falls back to the default too,
+    // rather than failing the whole parse and discarding every other preference.
+    let raw = serde_json::Value::deserialize(deserializer)?;
     Ok(match raw.as_str() {
-        "builder_stable" => Backend::BuilderStable,
-        "builder_beta" => Backend::BuilderBeta,
+        Some("builder_stable") => Backend::BuilderStable,
+        Some("builder_beta") => Backend::BuilderBeta,
         _ => Backend::default(),
     })
 }
@@ -374,15 +377,35 @@ mod tests {
     #[test]
     fn legacy_classic_backend_migrates_to_default() {
         // An old settings file selecting the removed classic dashboard backend
-        // must migrate to the default device builder, keep its other fields, and
-        // NOT be treated as corrupt (which would discard every other preference).
+        // must migrate to the default device builder (beta), keep its other
+        // fields, and NOT be treated as corrupt (which would discard every
+        // other preference).
         let dir = unique_temp_dir("classic");
         let path = dir.join("settings.json");
         fs::write(&path, r#"{"port":1234,"backend":"classic"}"#).expect("write settings");
 
         let settings = load_settings_file(&path);
 
-        assert_eq!(settings.backend, Backend::default());
+        assert_eq!(settings.backend, Backend::BuilderBeta);
+        assert_eq!(settings.port, 1234);
+        assert!(path.exists());
+        assert!(!path.with_extension("json.corrupt").exists());
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn non_string_backend_value_falls_back_to_default() {
+        // A malformed (non-string) backend value must fall back to the default
+        // instead of failing the whole parse, which would discard every other
+        // preference via corrupt-file recovery.
+        let dir = unique_temp_dir("bad_backend");
+        let path = dir.join("settings.json");
+        fs::write(&path, r#"{"port":1234,"backend":null}"#).expect("write settings");
+
+        let settings = load_settings_file(&path);
+
+        assert_eq!(settings.backend, Backend::BuilderBeta);
         assert_eq!(settings.port, 1234);
         assert!(path.exists());
         assert!(!path.with_extension("json.corrupt").exists());

--- a/src-tauri/src/settings/mod.rs
+++ b/src-tauri/src/settings/mod.rs
@@ -38,12 +38,12 @@ impl fmt::Display for ReleaseChannel {
     }
 }
 
-/// Which backend the daemon should run.
+/// Which device-builder channel the daemon should run. The classic ESPHome
+/// dashboard backend was removed in line with ESPHome 2026.6.0 retiring the
+/// legacy in-tree dashboard; the daemon now always launches the device builder.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum Backend {
-    /// Classic ESPHome dashboard (`esphome dashboard`)
-    Classic,
     /// ESPHome device builder, stable release from PyPI
     BuilderStable,
     /// ESPHome device builder, beta/pre-release from PyPI
@@ -54,18 +54,47 @@ pub enum Backend {
 impl fmt::Display for Backend {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Classic => write!(f, "Classic ESPHome Dashboard"),
             Self::BuilderStable => write!(f, "ESPHome Device Builder (stable)"),
             Self::BuilderBeta => write!(f, "ESPHome Device Builder (beta)"),
         }
     }
 }
 
-impl Backend {
-    /// True for any of the device-builder variants.
-    pub fn is_builder(self) -> bool {
-        matches!(self, Self::BuilderStable | Self::BuilderBeta)
-    }
+/// Deserialize the backend, tolerating legacy or unknown values by falling back
+/// to the default. An old settings file selecting the removed classic dashboard
+/// (`"backend": "classic"`) must migrate to the default device builder rather
+/// than failing the whole parse, which would discard every other preference via
+/// the corrupt-file recovery path.
+fn deserialize_backend<'de, D>(deserializer: D) -> Result<Backend, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let raw = String::deserialize(deserializer)?;
+    Ok(match raw.as_str() {
+        "builder_stable" => Backend::BuilderStable,
+        "builder_beta" => Backend::BuilderBeta,
+        _ => Backend::default(),
+    })
+}
+
+/// Returns true if the persisted settings file selects the removed classic
+/// dashboard backend. Used at startup to force a fresh bundled device builder
+/// for users migrating off classic. Tolerant of a missing or unreadable file.
+pub fn persisted_backend_was_classic(app_handle: &AppHandle) -> bool {
+    let Ok(path) = Settings::settings_path(app_handle) else {
+        return false;
+    };
+    let Ok(content) = std::fs::read_to_string(&path) else {
+        return false;
+    };
+    serde_json::from_str::<serde_json::Value>(&content)
+        .ok()
+        .and_then(|v| {
+            v.get("backend")
+                .and_then(|b| b.as_str())
+                .map(|b| b == "classic")
+        })
+        .unwrap_or(false)
 }
 
 /// Application settings
@@ -97,8 +126,8 @@ pub struct Settings {
     #[serde(default)]
     pub release_channel: ReleaseChannel,
 
-    /// Active backend (classic dashboard or device builder variant)
-    #[serde(default)]
+    /// Active device-builder channel (stable or beta)
+    #[serde(default, deserialize_with = "deserialize_backend")]
     pub backend: Backend,
 
     /// Installed ESPHome version (detected from venv)
@@ -323,7 +352,7 @@ mod tests {
             port: 1234,
             open_on_start: false,
             release_channel: ReleaseChannel::Beta,
-            backend: Backend::Classic,
+            backend: Backend::BuilderStable,
             ..Default::default()
         };
         let content = serde_json::to_string_pretty(&original).expect("serialize");
@@ -334,8 +363,27 @@ mod tests {
         assert_eq!(loaded.port, 1234);
         assert!(!loaded.open_on_start);
         assert_eq!(loaded.release_channel, ReleaseChannel::Beta);
-        assert_eq!(loaded.backend, Backend::Classic);
+        assert_eq!(loaded.backend, Backend::BuilderStable);
         // A successful parse must not move the file aside.
+        assert!(path.exists());
+        assert!(!path.with_extension("json.corrupt").exists());
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn legacy_classic_backend_migrates_to_default() {
+        // An old settings file selecting the removed classic dashboard backend
+        // must migrate to the default device builder, keep its other fields, and
+        // NOT be treated as corrupt (which would discard every other preference).
+        let dir = unique_temp_dir("classic");
+        let path = dir.join("settings.json");
+        fs::write(&path, r#"{"port":1234,"backend":"classic"}"#).expect("write settings");
+
+        let settings = load_settings_file(&path);
+
+        assert_eq!(settings.backend, Backend::default());
+        assert_eq!(settings.port, 1234);
         assert!(path.exists());
         assert!(!path.with_extension("json.corrupt").exists());
 

--- a/src-tauri/src/tray/mod.rs
+++ b/src-tauri/src/tray/mod.rs
@@ -75,7 +75,6 @@ mod ids {
     pub const CHANNEL_DEV: &str = "channel_dev";
 
     // Backend submenu items
-    pub const BACKEND_CLASSIC: &str = "backend_classic";
     pub const BACKEND_BUILDER_STABLE: &str = "backend_builder_stable";
     pub const BACKEND_BUILDER_BETA: &str = "backend_builder_beta";
 
@@ -168,14 +167,6 @@ pub fn build_tray_menu(app_handle: &AppHandle, state: &Arc<AppState>) -> Result<
 
     // Backend submenu items
     let current_backend = settings.backend;
-    let backend_classic = MenuItemBuilder::with_id(
-        ids::BACKEND_CLASSIC,
-        radio_label(
-            "Classic ESPHome Dashboard",
-            current_backend == Backend::Classic,
-        ),
-    )
-    .build(app_handle)?;
     let backend_builder_stable = MenuItemBuilder::with_id(
         ids::BACKEND_BUILDER_STABLE,
         radio_label(
@@ -194,12 +185,10 @@ pub fn build_tray_menu(app_handle: &AppHandle, state: &Arc<AppState>) -> Result<
     )
     .build(app_handle)?;
 
-    let _ = BACKEND_CLASSIC_ITEM.set(backend_classic.clone());
     let _ = BACKEND_BUILDER_STABLE_ITEM.set(backend_builder_stable.clone());
     let _ = BACKEND_BUILDER_BETA_ITEM.set(backend_builder_beta.clone());
 
     let backend_submenu = SubmenuBuilder::with_id(app_handle, "backend", "Backend")
-        .item(&backend_classic)
         .item(&backend_builder_stable)
         .item(&backend_builder_beta)
         .build()?;
@@ -290,7 +279,6 @@ static CHANNEL_BETA_ITEM: std::sync::OnceLock<MenuItem<tauri::Wry>> = std::sync:
 static CHANNEL_DEV_ITEM: std::sync::OnceLock<MenuItem<tauri::Wry>> = std::sync::OnceLock::new();
 
 /// Backend menu items stored globally for radio-button behavior
-static BACKEND_CLASSIC_ITEM: std::sync::OnceLock<MenuItem<tauri::Wry>> = std::sync::OnceLock::new();
 static BACKEND_BUILDER_STABLE_ITEM: std::sync::OnceLock<MenuItem<tauri::Wry>> =
     std::sync::OnceLock::new();
 static BACKEND_BUILDER_BETA_ITEM: std::sync::OnceLock<MenuItem<tauri::Wry>> =
@@ -351,12 +339,6 @@ fn update_channel_checks(channel: ReleaseChannel) {
 
 /// Update the backend menu item labels to reflect the given backend.
 fn update_backend_checks(backend: Backend) {
-    if let Some(item) = BACKEND_CLASSIC_ITEM.get() {
-        let _ = item.set_text(radio_label(
-            "Classic ESPHome Dashboard",
-            backend == Backend::Classic,
-        ));
-    }
     if let Some(item) = BACKEND_BUILDER_STABLE_ITEM.get() {
         let _ = item.set_text(radio_label(
             "ESPHome Device Builder (stable)",
@@ -597,108 +579,107 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>, _a
                     }
                 }
 
-                // Also check `esphome-device-builder` when it's the active
-                // backend. This is independent of the ESPHome release channel.
-                if backend.is_builder() {
-                    if let Some(builder_version) = state
-                        .update_checker
-                        .check_device_builder_for_user(&app, backend)
-                        .await
-                    {
-                        info!(
-                            "User requested device-builder update to version {}",
-                            builder_version
-                        );
+                // Also check `esphome-device-builder`, independent of the
+                // ESPHome release channel.
+                let Some(builder_version) = state
+                    .update_checker
+                    .check_device_builder_for_user(&app, backend)
+                    .await
+                else {
+                    return;
+                };
+                info!(
+                    "User requested device-builder update to version {}",
+                    builder_version
+                );
 
-                        update_status(&app, false);
-                        if let Err(e) = state.daemon.stop().await {
-                            error!("Failed to stop backend for device-builder update: {}", e);
+                update_status(&app, false);
+                if let Err(e) = state.daemon.stop().await {
+                    error!("Failed to stop backend for device-builder update: {}", e);
+                    let dialog_app = app.clone();
+                    let msg = format!("Failed to stop backend: {}", e);
+                    let _ = tokio::task::spawn_blocking(move || {
+                        dialog_app
+                            .dialog()
+                            .message(msg)
+                            .kind(MessageDialogKind::Error)
+                            .title("Update Failed")
+                            .blocking_show();
+                    })
+                    .await;
+                    return;
+                }
+
+                match state
+                    .update_checker
+                    .install_device_builder(&app, backend)
+                    .await
+                {
+                    Ok(()) => {
+                        info!("Device builder updated successfully to {}", builder_version);
+
+                        // Refresh the device-builder version display in the tray menu
+                        refresh_builder_version_display(&app).await;
+
+                        if let Err(e) = state.daemon.start().await {
+                            error!(
+                                "Failed to restart backend after device-builder update: {}",
+                                e
+                            );
                             let dialog_app = app.clone();
-                            let msg = format!("Failed to stop backend: {}", e);
+                            let msg = format!(
+                                "Device builder updated to {}, but failed to restart backend: {}",
+                                builder_version, e
+                            );
                             let _ = tokio::task::spawn_blocking(move || {
                                 dialog_app
                                     .dialog()
                                     .message(msg)
-                                    .kind(MessageDialogKind::Error)
-                                    .title("Update Failed")
+                                    .kind(MessageDialogKind::Warning)
+                                    .title("Update Partially Complete")
                                     .blocking_show();
                             })
                             .await;
-                            return;
+                        } else {
+                            update_status(&app, true);
+                            let dialog_app = app.clone();
+                            let msg = format!(
+                                "ESPHome Device Builder has been updated to version {}.",
+                                builder_version
+                            );
+                            let _ = tokio::task::spawn_blocking(move || {
+                                dialog_app
+                                    .dialog()
+                                    .message(msg)
+                                    .kind(MessageDialogKind::Info)
+                                    .title("Update Complete")
+                                    .blocking_show();
+                            })
+                            .await;
                         }
+                    }
+                    Err(e) => {
+                        error!("Device-builder update failed: {}", e);
+                        let dialog_app = app.clone();
+                        let msg = format!("Failed to update ESPHome Device Builder: {}", e);
+                        let _ = tokio::task::spawn_blocking(move || {
+                            dialog_app
+                                .dialog()
+                                .message(msg)
+                                .kind(MessageDialogKind::Error)
+                                .title("Update Failed")
+                                .blocking_show();
+                        })
+                        .await;
 
-                        match state
-                            .update_checker
-                            .install_device_builder(&app, backend)
-                            .await
-                        {
-                            Ok(()) => {
-                                info!("Device builder updated successfully to {}", builder_version);
-
-                                // Refresh the device-builder version display in the tray menu
-                                refresh_builder_version_display(&app).await;
-
-                                if let Err(e) = state.daemon.start().await {
-                                    error!(
-                                        "Failed to restart backend after device-builder update: {}",
-                                        e
-                                    );
-                                    let dialog_app = app.clone();
-                                    let msg = format!(
-                                        "Device builder updated to {}, but failed to restart backend: {}",
-                                        builder_version, e
-                                    );
-                                    let _ = tokio::task::spawn_blocking(move || {
-                                        dialog_app
-                                            .dialog()
-                                            .message(msg)
-                                            .kind(MessageDialogKind::Warning)
-                                            .title("Update Partially Complete")
-                                            .blocking_show();
-                                    })
-                                    .await;
-                                } else {
-                                    update_status(&app, true);
-                                    let dialog_app = app.clone();
-                                    let msg = format!(
-                                        "ESPHome Device Builder has been updated to version {}.",
-                                        builder_version
-                                    );
-                                    let _ = tokio::task::spawn_blocking(move || {
-                                        dialog_app
-                                            .dialog()
-                                            .message(msg)
-                                            .kind(MessageDialogKind::Info)
-                                            .title("Update Complete")
-                                            .blocking_show();
-                                    })
-                                    .await;
-                                }
-                            }
-                            Err(e) => {
-                                error!("Device-builder update failed: {}", e);
-                                let dialog_app = app.clone();
-                                let msg = format!("Failed to update ESPHome Device Builder: {}", e);
-                                let _ = tokio::task::spawn_blocking(move || {
-                                    dialog_app
-                                        .dialog()
-                                        .message(msg)
-                                        .kind(MessageDialogKind::Error)
-                                        .title("Update Failed")
-                                        .blocking_show();
-                                })
-                                .await;
-
-                                // Try to restart backend anyway
-                                if let Err(restart_err) = state.daemon.start().await {
-                                    error!(
-                                        "Failed to restart backend after failed device-builder update: {}",
-                                        restart_err
-                                    );
-                                } else {
-                                    update_status(&app, true);
-                                }
-                            }
+                        // Try to restart backend anyway
+                        if let Err(restart_err) = state.daemon.start().await {
+                            error!(
+                                "Failed to restart backend after failed device-builder update: {}",
+                                restart_err
+                            );
+                        } else {
+                            update_status(&app, true);
                         }
                     }
                 }
@@ -854,9 +835,8 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>, _a
                 }
             });
         }
-        ids::BACKEND_CLASSIC | ids::BACKEND_BUILDER_STABLE | ids::BACKEND_BUILDER_BETA => {
+        ids::BACKEND_BUILDER_STABLE | ids::BACKEND_BUILDER_BETA => {
             let new_backend = match id {
-                ids::BACKEND_CLASSIC => Backend::Classic,
                 ids::BACKEND_BUILDER_STABLE => Backend::BuilderStable,
                 ids::BACKEND_BUILDER_BETA => Backend::BuilderBeta,
                 _ => unreachable!(),
@@ -876,18 +856,12 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>, _a
                 }
 
                 // Confirm the switch with the user.
-                let msg = if new_backend.is_builder() {
-                    format!(
-                        "Switch to {}?\n\n\
-                         This will install the `esphome-device-builder` Python package, \
-                         stop the current backend, and restart with the new one.",
-                        new_backend
-                    )
-                } else {
-                    "Switch back to the classic ESPHome dashboard?\n\n\
-                     This will stop the device builder and restart with the dashboard."
-                        .to_string()
-                };
+                let msg = format!(
+                    "Switch to {}?\n\n\
+                     This will install the `esphome-device-builder` Python package, \
+                     stop the current backend, and restart with the new one.",
+                    new_backend
+                );
                 let confirmed =
                     crate::dialog::confirm(&app, "Switch Backend", msg, "Switch", "Cancel").await;
 
@@ -918,45 +892,40 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>, _a
                     return;
                 }
 
-                // When switching to a builder variant, install/upgrade the package first.
-                if new_backend.is_builder() {
-                    if let Err(e) = state
-                        .update_checker
-                        .install_device_builder(&app, new_backend)
-                        .await
-                    {
-                        error!("Failed to install esphome-device-builder: {}", e);
-                        let dialog_app = app.clone();
-                        let msg = format!("Failed to install esphome-device-builder: {}", e);
-                        let _ = tokio::task::spawn_blocking(move || {
-                            dialog_app
-                                .dialog()
-                                .message(msg)
-                                .kind(MessageDialogKind::Error)
-                                .title("Backend Switch Failed")
-                                .blocking_show();
-                        })
-                        .await;
-                        update_backend_checks(old_backend);
-                        // Try to restart the original backend.
-                        if let Err(restart_err) = state.daemon.start().await {
-                            error!(
-                                "Failed to restart backend after failed switch: {}",
-                                restart_err
-                            );
-                        } else {
-                            update_status(&app, true);
-                        }
-                        return;
+                // Install/upgrade the package for the selected channel first.
+                if let Err(e) = state
+                    .update_checker
+                    .install_device_builder(&app, new_backend)
+                    .await
+                {
+                    error!("Failed to install esphome-device-builder: {}", e);
+                    let dialog_app = app.clone();
+                    let msg = format!("Failed to install esphome-device-builder: {}", e);
+                    let _ = tokio::task::spawn_blocking(move || {
+                        dialog_app
+                            .dialog()
+                            .message(msg)
+                            .kind(MessageDialogKind::Error)
+                            .title("Backend Switch Failed")
+                            .blocking_show();
+                    })
+                    .await;
+                    update_backend_checks(old_backend);
+                    // Try to restart the original backend.
+                    if let Err(restart_err) = state.daemon.start().await {
+                        error!(
+                            "Failed to restart backend after failed switch: {}",
+                            restart_err
+                        );
+                    } else {
+                        update_status(&app, true);
                     }
-                    // Install succeeded — refresh the tray version display.
-                    refresh_builder_version_display(&app).await;
+                    return;
                 }
+                // Install succeeded — refresh the tray version display.
+                refresh_builder_version_display(&app).await;
 
-                // Apply the new backend to the daemon and persist it.
-                state
-                    .daemon
-                    .set_use_device_builder(new_backend.is_builder());
+                // Persist the new backend channel.
                 {
                     let mut settings = state.settings.write().await;
                     settings.backend = new_backend;

--- a/src-tauri/src/update/mod.rs
+++ b/src-tauri/src/update/mod.rs
@@ -369,16 +369,12 @@ impl UpdateChecker {
 
     /// Install or upgrade the `esphome-device-builder` package from PyPI.
     /// Pass `Backend::BuilderBeta` to allow pre-releases (`pip install --pre`),
-    /// `Backend::BuilderStable` for stable-only. Calling with `Backend::Classic`
-    /// is a no-op.
+    /// `Backend::BuilderStable` for stable-only.
     pub async fn install_device_builder(
         &self,
         app_handle: &AppHandle,
         backend: Backend,
     ) -> Result<()> {
-        if !backend.is_builder() {
-            return Ok(());
-        }
         let python_path = platform::get_python_path(app_handle)?;
 
         info!("Installing/upgrading esphome-device-builder ({})", backend);
@@ -411,12 +407,8 @@ impl UpdateChecker {
 
     /// Query PyPI for the latest available `esphome-device-builder` version.
     /// `Backend::BuilderStable` returns the latest final release; `BuilderBeta`
-    /// returns the latest version including pre-releases. Returns `Ok(None)`
-    /// if the backend is not a builder variant.
-    pub async fn check_device_builder(&self, backend: Backend) -> Result<Option<String>> {
-        if !backend.is_builder() {
-            return Ok(None);
-        }
+    /// returns the latest version including pre-releases.
+    pub async fn check_device_builder(&self, backend: Backend) -> Result<String> {
         let response: PyPIResponse = self
             .client
             .get("https://pypi.org/pypi/esphome-device-builder/json")
@@ -437,22 +429,17 @@ impl UpdateChecker {
             "Latest esphome-device-builder version on PyPI ({}): {}",
             backend, latest
         );
-        Ok(Some(latest))
+        Ok(latest)
     }
 
     /// Background check for esphome-device-builder updates. Emits a
-    /// notification if a newer version is available. No-op for non-builder
-    /// backends.
+    /// notification if a newer version is available.
     pub async fn check_and_notify_device_builder(
         &self,
         app_handle: &AppHandle,
         backend: Backend,
         tray_available: bool,
     ) {
-        if !backend.is_builder() {
-            return;
-        }
-
         let installed = match detect_device_builder_version_with_heal(app_handle) {
             Ok(Some(v)) => v,
             Ok(None) => {
@@ -466,8 +453,7 @@ impl UpdateChecker {
         };
 
         let latest = match self.check_device_builder(backend).await {
-            Ok(Some(v)) => v,
-            Ok(None) => return,
+            Ok(v) => v,
             Err(e) => {
                 warn!("Device-builder update check failed: {}", e);
                 return;
@@ -508,10 +494,6 @@ impl UpdateChecker {
         app_handle: &AppHandle,
         backend: Backend,
     ) -> Option<String> {
-        if !backend.is_builder() {
-            return None;
-        }
-
         let installed = match detect_device_builder_version_with_heal(app_handle) {
             Ok(Some(v)) => v,
             Ok(None) => {
@@ -528,8 +510,7 @@ impl UpdateChecker {
         };
 
         let latest = match self.check_device_builder(backend).await {
-            Ok(Some(v)) => v,
-            Ok(None) => return None,
+            Ok(v) => v,
             Err(e) => {
                 warn!("Device-builder update check failed: {}", e);
                 return None;


### PR DESCRIPTION
# What does this implement/fix?

ESPHome 2026.6.0 retired the legacy in-tree dashboard and replaced it with the ESPHome Device Builder, so this drops the classic dashboard backend here too. The daemon now always launches the device builder; the tray Backend submenu keeps the device builder stable/beta picker, and the `esphome dashboard` launch path is gone. A settings file that still selects `classic` migrates to the default device builder on load, keeping the rest of the preferences.

It also forces the freshly bundled device builder for users coming off classic; on the app update that removes classic their device builder is taken from the bundle instead of preserving a stale pip copy, so they land on the current version. ESPHome itself is still preserved across updates, so a user pinned to a newer ESPHome is not downgraded.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).
