### PR TITLE
Bundle ccache on Windows so ESP-IDF builds enable compiler caching

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -60,13 +60,13 @@ jobs:
           workspaces: src-tauri
           key: lint-test
 
-      # `tauri.conf.json` lists `python` and `git` as bundle resources. Those
-      # directories are gitignored and absent on a fresh checkout (they're
-      # populated by prepare_bundle.sh only for real bundling). A plain
-      # `cargo test`/`clippy` never bundles, but create empty stubs so config
-      # parsing can't trip on the missing paths.
+      # `tauri.conf.json` lists `python`, `git` and `ccache` as bundle
+      # resources. Those directories are gitignored and absent on a fresh
+      # checkout (they're populated by prepare_bundle.sh only for real
+      # bundling). A plain `cargo test`/`clippy` never bundles, but create empty
+      # stubs so config parsing can't trip on the missing paths.
       - name: Stub bundle resource dirs
-        run: mkdir -p src-tauri/python src-tauri/git
+        run: mkdir -p src-tauri/python src-tauri/git src-tauri/ccache
 
       # Required gates. clippy and rustfmt were introduced as advisory in the
       # first iteration of this workflow because they had never run in CI and the
@@ -136,13 +136,14 @@ jobs:
           # (matches build.yml). Harmless on Windows.
           cache-bin: false
 
-      # Stub the gitignored `python` and `git` bundle resources (see the Linux
-      # job). `tauri.conf.json` declares both at the top-level `bundle` block, so
-      # both are resources on macOS/Windows too (git = MinGit on Windows). `bash`
-      # is forced so `mkdir -p` works on the Windows runner too.
+      # Stub the gitignored `python`, `git` and `ccache` bundle resources (see
+      # the Linux job). `tauri.conf.json` declares all three at the top-level
+      # `bundle` block, so they're resources on macOS/Windows too (git = MinGit,
+      # ccache = bundled ccache on Windows). `bash` is forced so `mkdir -p` works
+      # on the Windows runner too.
       - name: Stub bundle resource dirs
         shell: bash
-        run: mkdir -p src-tauri/python src-tauri/git
+        run: mkdir -p src-tauri/python src-tauri/git src-tauri/ccache
 
       # fmt is cfg-agnostic and already green on Linux; advisory here only to
       # guard against a Windows newline quirk on this first run.

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ pnpm-debug.log*
 src-tauri/python/
 # Bundled MinGit on Windows (downloaded by build scripts)
 src-tauri/git/
+# Bundled ccache on Windows (downloaded by build scripts)
+src-tauri/ccache/
 resources/
 
 # Python

--- a/build-scripts/prepare_bundle.sh
+++ b/build-scripts/prepare_bundle.sh
@@ -45,11 +45,27 @@ MINGIT_SHA256="04f937e1f0918b17b9be6f2294cb2bb66e96e1d9832d1c298e2de088a1d0e668"
 PORTABLEGIT_URL="https://github.com/git-for-windows/git/releases/download/v2.54.0.windows.1/PortableGit-2.54.0-64-bit.7z.exe"
 PORTABLEGIT_SHA256="bea006a6cc69673f27b1647e84ab3a68e912fbc175ab6320c5987e012897f311"
 
+# ccache is bundled on Windows only. ESPHome's ESP-IDF builds auto-enable ccache
+# when the `ccache` binary is on PATH, which roughly halves repeat-build times;
+# Windows ships no ccache and users rarely install one, so we bundle the official
+# static Windows build and put it on PATH at runtime. macOS finds a brew-installed
+# ccache via the appended Homebrew PATH, and Linux users install it from their
+# distro, so neither bundles it. The Windows release zip nests a single static
+# `ccache.exe` (no DLLs) under a versioned dir; we extract just that exe.
+# CCACHE_VERSION is display-only; CCACHE_URL is the literal asset URL. There is
+# no upstream checksum file (only minisig), so CCACHE_SHA256 is computed from the
+# pinned asset. Bump all three together when adopting a newer ccache (unlike
+# MINGIT_*, these are not yet wired into the nightly bump_bundle_versions.py job).
+CCACHE_VERSION="4.13.6"
+CCACHE_URL="https://github.com/ccache/ccache/releases/download/v4.13.6/ccache-4.13.6-windows-x86_64.zip"
+CCACHE_SHA256="3d7cebb05850ad704e197b3f1d3f0f924ab6c9fdfc561578e146184fe9d89380"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 BUILD_DIR="$PROJECT_DIR/build"
 BUNDLE_DIR="$PROJECT_DIR/src-tauri/python"
 GIT_BUNDLE_DIR="$PROJECT_DIR/src-tauri/git"
+CCACHE_BUNDLE_DIR="$PROJECT_DIR/src-tauri/ccache"
 
 detect_platform() {
     local os=$(uname -s)
@@ -311,6 +327,104 @@ EOF
     "$patch_dir/patch.exe" --version
 }
 
+# Stage ccache into $CCACHE_BUNDLE_DIR (src-tauri/ccache), bundled as a Tauri
+# resource. At runtime the app prepends this dir to PATH so ESPHome's ESP-IDF
+# builds discover ccache and turn caching on automatically.
+#
+# Windows: download the pinned ccache zip, verify its SHA-256, and extract just
+# the single static ccache.exe (the zip also carries docs/license we don't ship).
+#
+# Other platforms: leave an empty directory so the "ccache" resource path in
+# tauri.conf.json resolves; ccache is never bundled there (macOS finds a brew
+# ccache via the appended Homebrew PATH, Linux installs it from the distro).
+prepare_ccache_for_platform() {
+    local platform="$1"
+
+    rm -rf "$CCACHE_BUNDLE_DIR"
+    mkdir -p "$CCACHE_BUNDLE_DIR"
+
+    if [[ "$platform" != "windows-x64" ]]; then
+        echo ""
+        echo "=== Skipping ccache bundle (${platform}); empty ccache/ placeholder created ==="
+        return
+    fi
+
+    # Cache under $BUILD_DIR (which we own) rather than world-writable /tmp, same
+    # as the MinGit download.
+    local temp_file="$BUILD_DIR/$(basename "$CCACHE_URL")"
+
+    echo ""
+    echo "=== Downloading ccache ${CCACHE_VERSION} ==="
+    if [[ -f "$temp_file" ]]; then
+        echo "Using cached download: $temp_file"
+        verify_sha256 "$temp_file" "$CCACHE_SHA256"
+    else
+        # `--fail`/`--retry` and the .partial->rename dance mirror the MinGit
+        # download so an interrupted or corrupt fetch never becomes a sticky,
+        # always-failing cache entry.
+        curl -fL --retry 3 -o "${temp_file}.partial" "$CCACHE_URL"
+        verify_sha256 "${temp_file}.partial" "$CCACHE_SHA256"
+        mv -f "${temp_file}.partial" "$temp_file"
+    fi
+
+    echo ""
+    echo "=== Extracting ccache.exe into ${CCACHE_BUNDLE_DIR} ==="
+    # Extract with the standalone Python we just unpacked rather than `unzip`,
+    # which isn't shipped on the Windows runner (same reasoning as MinGit). The
+    # zip nests ccache.exe (plus docs and the license) under a versioned dir, so
+    # extract to a temp dir then copy just the exe and the license into the flat
+    # bundle dir.
+    local python_exe="$BUILD_DIR/python-${platform}/python.exe"
+    if [[ ! -f "$python_exe" ]]; then
+        echo "Bundled Python not found at $python_exe; cannot extract ccache"
+        exit 1
+    fi
+    local extract_dir="$BUILD_DIR/ccache-extract"
+    rm -rf "$extract_dir"
+    "$python_exe" -m zipfile -e "$temp_file" "$extract_dir"
+
+    # Require exactly one ccache.exe so a future zip layout change (extra arch,
+    # helper exe) fails loudly here rather than silently bundling whichever copy
+    # `find` happened to list first.
+    local -a exe_matches=()
+    while IFS= read -r match; do
+        exe_matches+=("$match")
+    done < <(find "$extract_dir" -type f -name ccache.exe)
+    if [[ ${#exe_matches[@]} -ne 1 ]]; then
+        echo "ERROR: expected exactly one ccache.exe in $CCACHE_URL, found ${#exe_matches[@]}" >&2
+        exit 1
+    fi
+    local ccache_src_dir
+    ccache_src_dir=$(dirname "${exe_matches[0]}")
+    cp "${exe_matches[0]}" "$CCACHE_BUNDLE_DIR/ccache.exe"
+
+    # ccache is GPLv3, so ship its full license text (carried in the release zip)
+    # next to the binary, not just a pointer, to satisfy the redistribution
+    # terms. Fail if it's missing rather than ship an unlicensed binary.
+    if [[ ! -f "$ccache_src_dir/LICENSE.md" ]]; then
+        echo "ERROR: LICENSE.md not found beside ccache.exe in $CCACHE_URL" >&2
+        exit 1
+    fi
+    cp "$ccache_src_dir/LICENSE.md" "$CCACHE_BUNDLE_DIR/LICENSE.md"
+
+    cat > "$CCACHE_BUNDLE_DIR/THIRD_PARTY_NOTICES.txt" <<EOF
+This directory contains an unmodified ccache.exe taken from the official ccache
+release (${CCACHE_URL}):
+
+  ccache.exe        ccache             GPLv3
+
+It is redistributed under its license (see the bundled LICENSE.md) and is
+invoked as a separate process (compiler cache) by ESPHome's build. Corresponding
+source is available from the ccache release above and
+https://github.com/ccache/ccache.
+EOF
+
+    # Smoke-test: prove ccache runs, so a broken extract fails the build here
+    # rather than shipping a ccache.exe that won't launch on a user's machine.
+    echo "=== Verifying bundled ccache.exe ==="
+    "$CCACHE_BUNDLE_DIR/ccache.exe" --version
+}
+
 # Rewrite pip-generated script shebangs so the bundle is relocatable.
 # pip bakes the build-time python path into every console-script shebang
 # (`#!$python_dir/bin/python3`), so when the bundle ships to a user's
@@ -454,6 +568,7 @@ mkdir -p "$BUILD_DIR"
 
 prepare_python_for_platform "$PLATFORM"
 prepare_git_for_platform "$PLATFORM"
+prepare_ccache_for_platform "$PLATFORM"
 
 PYTHON_DIR="$BUILD_DIR/python-${PLATFORM}"
 
@@ -473,6 +588,8 @@ echo "Size: $BUNDLE_SIZE"
 if [[ "$PLATFORM" == "windows-x64" ]]; then
     GIT_BUNDLE_SIZE=$(du -sh "$GIT_BUNDLE_DIR" | cut -f1)
     echo "Bundled git: $GIT_BUNDLE_DIR ($GIT_BUNDLE_SIZE)"
+    CCACHE_BUNDLE_SIZE=$(du -sh "$CCACHE_BUNDLE_DIR" | cut -f1)
+    echo "Bundled ccache: $CCACHE_BUNDLE_DIR ($CCACHE_BUNDLE_SIZE)"
 fi
 echo ""
 echo "You can now run 'cargo tauri build' to create the app bundle."

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -301,6 +301,15 @@ pub fn run(cli: Cli) {
                 error!("Failed to add Homebrew to PATH: {}", e);
             }
 
+            // Make the bundled ccache discoverable to the ESPHome backend on
+            // Windows so ESP-IDF builds enable compiler caching automatically.
+            // Prepends to PATH like the git setup above; no-op elsewhere. Runs
+            // before the daemon task spawns so the child inherits it.
+            // Log-and-continue: builds just run without caching on failure.
+            if let Err(e) = platform::ensure_ccache_on_path(app.handle()) {
+                error!("Failed to set up bundled ccache: {}", e);
+            }
+
             // One-shot prompt to remove the pre-rename `/Applications/ESPHome Builder.app`.
             // No-op on non-macOS and after the user has answered once.
             platform::cleanup_legacy_macos_app(app.handle());

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -191,6 +191,17 @@ pub fn get_bundled_patch_dir(app_handle: &AppHandle) -> Result<PathBuf> {
     Ok(resource_dir.join("git").join("patch"))
 }
 
+/// Directory inside the bundled `ccache` resource that holds `ccache.exe`.
+///
+/// `prepare_bundle.sh` extracts a single static `ccache.exe` into `ccache/`.
+/// Putting this dir on `PATH` lets ESPHome's ESP-IDF build discover ccache and
+/// enable compiler caching automatically.
+#[cfg(target_os = "windows")]
+pub fn get_bundled_ccache_dir(app_handle: &AppHandle) -> Result<PathBuf> {
+    let resource_dir = get_bundled_resource_dir(app_handle)?;
+    Ok(resource_dir.join("ccache"))
+}
+
 /// Build a `PATH` value with `dir` prepended to `existing`.
 ///
 /// Pure (no environment mutation) so the prepend ordering, separator
@@ -362,6 +373,51 @@ pub fn ensure_homebrew_on_path(app_handle: &AppHandle) -> Result<()> {
     }
 
     #[cfg(not(target_os = "macos"))]
+    {
+        let _ = app_handle;
+    }
+
+    Ok(())
+}
+
+/// Ensure the bundled `ccache` is on `PATH` for the ESPHome backend we spawn.
+///
+/// ESPHome's ESP-IDF build turns on compiler caching automatically when a
+/// `ccache` binary is found on `PATH`, roughly halving repeat-build times.
+/// Windows ships no ccache and users rarely install one, so we bundle the
+/// official static build (`prepare_bundle.sh`) and prepend its directory here.
+/// The spawned daemon inherits this process's environment (it never sets `PATH`
+/// itself), so this single mutation is enough for the build to see ccache.
+///
+/// No-op on macOS (a brew-installed ccache is reached via the Homebrew dirs
+/// appended in `ensure_homebrew_on_path`) and Linux (ccache is a distro
+/// package). Log-and-continue if the bundled exe is missing: builds just run
+/// without caching, exactly as before.
+pub fn ensure_ccache_on_path(app_handle: &AppHandle) -> Result<()> {
+    #[cfg(target_os = "windows")]
+    {
+        use tracing::{info, warn};
+
+        let ccache_dir = get_bundled_ccache_dir(app_handle)?;
+        let ccache_exe = ccache_dir.join("ccache.exe");
+        if !ccache_exe.exists() {
+            warn!(
+                "Bundled ccache missing at {:?}; ESP-IDF builds will run without \
+                 compiler caching",
+                ccache_exe
+            );
+            return Ok(());
+        }
+
+        // Prepend the bundled ccache dir so it wins over anything already on
+        // PATH. There is no system ccache on Windows to shadow, so prepend vs
+        // append is immaterial; prepend keeps it consistent with the bundled
+        // git/patch handling above.
+        insert_dir_into_path(&ccache_dir, PathInsert::Front)?;
+        info!("Using bundled ccache at {:?}", ccache_exe);
+    }
+
+    #[cfg(not(target_os = "windows"))]
     {
         let _ = app_handle;
     }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -45,7 +45,8 @@
     },
     "resources": [
       "python",
-      "git"
+      "git",
+      "ccache"
     ]
   },
   "plugins": {


### PR DESCRIPTION
> **Stacked on #213.** Base is `macos-homebrew-path`; the shared `insert_dir_into_path` PATH helper is introduced there. This PR's diff is ccache-only. GitHub will retarget it to `main` automatically once #213 merges.

## Why

[esphome/esphome#17163](https://github.com/esphome/esphome/pull/17163) makes ESP-IDF builds auto-enable `ccache` whenever the `ccache` binary is found on `PATH`, roughly halving repeat-build times. In esphome-desktop the build chain is `daemon → python -m esphome_device_builder → ESPHome → PlatformIO → ESP-IDF`, and the daemon inherits the app's process environment verbatim.

Windows ships no `ccache` and users rarely install one, so that speedup never happened there. (macOS is handled by appending Homebrew to PATH in #213; Linux users get ccache from their distro.)

## What

Bundle the official static `ccache.exe` as a Tauri resource and prepend its directory to `PATH` at startup via the shared `insert_dir_into_path` helper, mirroring the bundled-MinGit handling, so the daemon (and the build) discover it.

- `build-scripts/prepare_bundle.sh`: pinned `CCACHE_VERSION`/`CCACHE_URL`/`CCACHE_SHA256` and a `prepare_ccache_for_platform` that (Windows only) downloads the release zip, verifies its SHA-256, extracts just the single static `ccache.exe`, writes a GPLv3 `THIRD_PARTY_NOTICES.txt`, and smoke-tests `ccache.exe --version`. Other platforms get an empty placeholder dir so the resource path resolves.
- `tauri.conf.json`: add `ccache` to `bundle.resources`.
- `.gitignore`: ignore the generated `src-tauri/ccache/`.
- `platform/mod.rs`: `get_bundled_ccache_dir` + `ensure_ccache_on_path` (Windows only; prepends to PATH through `insert_dir_into_path`, log-and-continue if missing). No-op on macOS/Linux.
- `lib.rs`: call `ensure_ccache_on_path` after the git setup, before the daemon spawns.

Inert until the bundled ESPHome includes #17163, then active automatically.

## Notes

- ccache publishes no checksum file (only minisig), so `CCACHE_SHA256` is the computed digest of the pinned asset and is bumped manually. A follow-up could add a `ccache` target to the nightly `bump_bundle_versions.py` job like MinGit has.

## Test

- `cargo test` / `cargo clippy` / `cargo fmt --check` green; the non-Windows no-op path compiles.
- Verified the extraction logic against the real `ccache-4.13.6-windows-x86_64.zip`: it locates `ccache.exe` and copies a valid `PE32+ x86-64` executable. The `--version` smoke test runs on the Windows CI runner.