### PR TITLE
Track bundled ccache in the nightly bump job

### DIFF
--- a/.github/scripts/bump_bundle_versions.py
+++ b/.github/scripts/bump_bundle_versions.py
@@ -2,9 +2,9 @@
 """Bump pinned bundled dependencies in build-scripts/prepare_bundle.sh.
 
 Run nightly by .github/workflows/bump-bundle-versions.yml, once per target
-(`--target python` and `--target mingit`). Each resolves the latest upstream
-release, rewrites the pinned values in prepare_bundle.sh, and emits GitHub
-Actions outputs that the workflow turns into its own pull request.
+(`--target python`, `--target mingit` and `--target ccache`). Each resolves the
+latest upstream release, rewrites the pinned values in prepare_bundle.sh, and
+emits GitHub Actions outputs that the workflow turns into its own pull request.
 
 Python policy: PBS_VERSION (the build-date tag) always moves to the latest
 release; PYTHON_VERSION only takes a newer *patch* within the currently pinned
@@ -14,6 +14,10 @@ ESPHome/PlatformIO. A deliberate minor bump stays a manual change.
 MinGit policy: always track the latest git-for-windows release. Git is invoked
 as a subprocess, so a new minor or major won't break ESPHome/PlatformIO the way
 a Python minor could, and Git for Windows only maintains the newest line.
+
+ccache policy: always track the latest ccache release. Like git it's invoked as
+a subprocess (a compiler cache), so a new version can't break ESPHome the way a
+Python minor could.
 
 The script fails loudly (non-zero exit) if the expected variables aren't found
 in prepare_bundle.sh, or if the latest upstream release can't be resolved —
@@ -30,6 +34,7 @@ Usage (GITHUB_TOKEN keeps the API calls off the anonymous rate limit):
 
     GITHUB_TOKEN=... python3 .github/scripts/bump_bundle_versions.py --target python
     GITHUB_TOKEN=... python3 .github/scripts/bump_bundle_versions.py --target mingit
+    GITHUB_TOKEN=... python3 .github/scripts/bump_bundle_versions.py --target ccache
 """
 
 from __future__ import annotations
@@ -64,6 +69,12 @@ MINGIT_ASSET_RE = re.compile(r"MinGit-(?P<ver>[\d.]+)-64-bit\.zip")
 # a GNU patch.exe from it (issue #189); pinning it to the same release as MinGit
 # keeps patch.exe ABI-matched to MinGit's msys-2.0.dll.
 PORTABLEGIT_ASSET_RE = re.compile(r"PortableGit-(?P<ver>[\d.]+)-64-bit\.7z\.exe")
+
+CCACHE_REPO = "ccache/ccache"
+
+# The x86_64 Windows ccache zip. The version token is digits/dots only, so the
+# aarch64 sibling and the `.zip.minisig` signature can't match.
+CCACHE_ASSET_RE = re.compile(r"ccache-(?P<ver>[\d.]+)-windows-x86_64\.zip")
 
 # Per-request network timeout. A stalled connection otherwise blocks the nightly
 # job until the workflow's multi-hour default timeout fires; failing fast lets
@@ -302,7 +313,10 @@ def _asset_sha256(asset: dict[str, Any]) -> str:
 
 
 def _find_asset(
-    release: dict[str, Any], pattern: re.Pattern[str], label: str
+    release: dict[str, Any],
+    pattern: re.Pattern[str],
+    label: str,
+    repo: str = GFW_REPO,
 ) -> tuple[str, str, str]:
     """Return `(version, url, sha256)` for the asset matching `pattern`."""
     for asset in release.get("assets", []):
@@ -310,7 +324,7 @@ def _find_asset(
         if m is not None:
             return m.group("ver"), asset["browser_download_url"], _asset_sha256(asset)
     raise ResolutionError(
-        f"no {label} asset in {GFW_REPO} release {release.get('tag_name')!r}"
+        f"no {label} asset in {repo} release {release.get('tag_name')!r}"
     )
 
 
@@ -327,6 +341,18 @@ def resolve_latest_mingit() -> tuple[str, str, str, str, str]:
     version, mingit_url, mingit_sha = _find_asset(release, MINGIT_ASSET_RE, "MinGit")
     _, pg_url, pg_sha = _find_asset(release, PORTABLEGIT_ASSET_RE, "PortableGit")
     return version, mingit_url, mingit_sha, pg_url, pg_sha
+
+
+def resolve_latest_ccache() -> tuple[str, str, str]:
+    """Resolve the x86_64 Windows ccache asset from the latest ccache release.
+
+    Returns `(version, url, sha256)`. ccache publishes no SHA256SUMS file (only
+    a per-asset `.minisig`), so the digest comes from the asset metadata when
+    GitHub reports it and is otherwise computed by streaming the zip — either
+    way prepare_bundle.sh re-verifies it at build time.
+    """
+    release = _api_get(f"https://api.github.com/repos/{CCACHE_REPO}/releases/latest")
+    return _find_asset(release, CCACHE_ASSET_RE, "ccache", repo=CCACHE_REPO)
 
 
 # --------------------------------------------------------------------------- #
@@ -434,6 +460,30 @@ def resolve_mingit_bump(text: str) -> tuple[BumpResult, str]:
     return result, f"Bump bundled MinGit to {version}"
 
 
+def resolve_ccache_bump(text: str) -> tuple[BumpResult, str]:
+    """Resolve the latest ccache and compute the bump over `text`."""
+    current = read_assignment(text, "CCACHE_VERSION")
+    version, url, sha256 = resolve_latest_ccache()
+    # ccache releases move forward, so a resolved version older than the current
+    # pin means upstream republished an old tag as `latest` or unpublished a
+    # release. Fail loudly rather than open a PR moving bundled ccache backwards
+    # (the sha would verify fine against a genuine older release).
+    if _version_tuple(version) < _version_tuple(current):
+        raise ResolutionError(
+            f"latest ccache {version} is older than the pinned {current}; "
+            "refusing to downgrade"
+        )
+    result = apply_bumps(
+        text,
+        {
+            "CCACHE_VERSION": version,
+            "CCACHE_URL": url,
+            "CCACHE_SHA256": sha256,
+        },
+    )
+    return result, f"Bump bundled ccache to {version}"
+
+
 # Resolves the latest upstream release and computes the bump over the file text.
 _Resolver = Callable[[str], tuple[BumpResult, str]]
 
@@ -456,6 +506,11 @@ TARGETS: dict[str, tuple[tuple[str, ...], _Resolver, str]] = {
         ),
         resolve_mingit_bump,
         "MinGit (Git for Windows)",
+    ),
+    "ccache": (
+        ("CCACHE_VERSION", "CCACHE_URL", "CCACHE_SHA256"),
+        resolve_ccache_bump,
+        "ccache",
     ),
 }
 

--- a/.github/workflows/bump-bundle-versions.yml
+++ b/.github/workflows/bump-bundle-versions.yml
@@ -3,9 +3,9 @@ name: Bump bundle versions
 # Nightly check for newer pinned bundled dependencies in
 # build-scripts/prepare_bundle.sh, one PR per target when an update is
 # available. Python (python-build-standalone) stays on its current minor and
-# only takes newer patches; MinGit (Git for Windows) tracks the latest release.
-# The PR (not a direct push) runs the full Build + lint/test CI so a human
-# merges only after the platforms are green.
+# only takes newer patches; MinGit (Git for Windows) and ccache track the latest
+# release. The PR (not a direct push) runs the full Build + lint/test CI so a
+# human merges only after the platforms are green.
 
 on:
   schedule:
@@ -38,7 +38,7 @@ jobs:
       # cancel the other's bump.
       fail-fast: false
       matrix:
-        target: [python, mingit]
+        target: [python, mingit, ccache]
 
     steps:
       - name: Generate a token

--- a/build-scripts/prepare_bundle.sh
+++ b/build-scripts/prepare_bundle.sh
@@ -54,8 +54,8 @@ PORTABLEGIT_SHA256="bea006a6cc69673f27b1647e84ab3a68e912fbc175ab6320c5987e012897
 # `ccache.exe` (no DLLs) under a versioned dir; we extract just that exe.
 # CCACHE_VERSION is display-only; CCACHE_URL is the literal asset URL. There is
 # no upstream checksum file (only minisig), so CCACHE_SHA256 is computed from the
-# pinned asset. Bump all three together when adopting a newer ccache (unlike
-# MINGIT_*, these are not yet wired into the nightly bump_bundle_versions.py job).
+# pinned asset. All three are rewritten by the nightly
+# `bump_bundle_versions.py --target ccache` job.
 CCACHE_VERSION="4.13.6"
 CCACHE_URL="https://github.com/ccache/ccache/releases/download/v4.13.6/ccache-4.13.6-windows-x86_64.zip"
 CCACHE_SHA256="3d7cebb05850ad704e197b3f1d3f0f924ab6c9fdfc561578e146184fe9d89380"

--- a/tests/test_bump_bundle_versions.py
+++ b/tests/test_bump_bundle_versions.py
@@ -39,6 +39,10 @@ MINGIT_URL="https://github.com/git-for-windows/git/releases/download/v2.53.0.win
 MINGIT_SHA256="0000000000000000000000000000000000000000000000000000000000000000"
 PORTABLEGIT_URL="https://github.com/git-for-windows/git/releases/download/v2.53.0.windows.1/PortableGit-2.53.0-64-bit.7z.exe"
 PORTABLEGIT_SHA256="1111111111111111111111111111111111111111111111111111111111111111"
+
+CCACHE_VERSION="4.13.5"
+CCACHE_URL="https://github.com/ccache/ccache/releases/download/v4.13.5/ccache-4.13.5-windows-x86_64.zip"
+CCACHE_SHA256="2222222222222222222222222222222222222222222222222222222222222222"
 """
 
 
@@ -305,6 +309,55 @@ def test_resolve_latest_mingit_raises_when_portablegit_missing(
         bump.resolve_latest_mingit()
 
 
+def _ccache_release(tag: str, ver: str) -> dict[str, Any]:
+    """A ccache release shaped like the real API payload.
+
+    The x86_64 Windows zip must be chosen over the aarch64 sibling and the
+    `.zip.minisig` signature (whose names the digits/dots version token and the
+    `.zip` anchor both exclude).
+    """
+    base = f"https://github.com/ccache/ccache/releases/download/{tag}"
+    names = [
+        f"ccache-{ver}-windows-aarch64.zip",
+        f"ccache-{ver}-windows-x86_64.zip.minisig",
+        f"ccache-{ver}-windows-x86_64.zip",
+        f"ccache-{ver}-linux-x86_64.tar.xz",
+    ]
+    return {
+        "tag_name": tag,
+        "assets": [
+            {
+                "name": n,
+                "browser_download_url": f"{base}/{n}",
+                "digest": f"sha256:{'ab' * 32}",
+            }
+            for n in names
+        ],
+    }
+
+
+def test_resolve_latest_ccache_picks_x86_64_zip(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        bump, "_api_get", lambda url: _ccache_release("v4.13.6", "4.13.6")
+    )
+    version, url, sha = bump.resolve_latest_ccache()
+    assert version == "4.13.6"
+    assert url.endswith("/v4.13.6/ccache-4.13.6-windows-x86_64.zip")
+    assert sha == "ab" * 32
+
+
+def test_resolve_latest_ccache_raises_when_no_asset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        bump, "_api_get", lambda url: {"tag_name": "v4.13.6", "assets": []}
+    )
+    with pytest.raises(bump.ResolutionError, match="ccache"):
+        bump.resolve_latest_ccache()
+
+
 def test_asset_sha256_prefers_digest_without_download(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -562,5 +615,94 @@ def test_main_mingit_fails_when_variables_absent(
     monkeypatch.setenv("GITHUB_OUTPUT", str(out))
 
     rc = bump.main(["--target", "mingit", "--file", str(script)])
+    assert rc == 1
+    assert not out.exists() or "changed=true" not in out.read_text()
+
+
+def test_main_ccache_writes_file_and_outputs_on_bump(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    script = tmp_path / "prepare_bundle.sh"
+    script.write_text(SAMPLE_SCRIPT)
+    out = tmp_path / "out"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+    new_url = (
+        "https://github.com/ccache/ccache/releases/download/"
+        "v4.13.6/ccache-4.13.6-windows-x86_64.zip"
+    )
+    monkeypatch.setattr(
+        bump, "resolve_latest_ccache", lambda: ("4.13.6", new_url, "ff" * 32)
+    )
+
+    rc = bump.main(["--target", "ccache", "--file", str(script)])
+    assert rc == 0
+    text = script.read_text()
+    assert 'CCACHE_VERSION="4.13.6"' in text
+    assert f'CCACHE_URL="{new_url}"' in text
+    assert f'CCACHE_SHA256="{"ff" * 32}"' in text
+    # A ccache bump leaves the Python and MinGit pins untouched.
+    assert 'PYTHON_VERSION="3.13.12"' in text
+    assert 'MINGIT_VERSION="2.53.0"' in text
+
+    output = out.read_text()
+    assert "changed=true" in output
+    assert "Bump bundled ccache to 4.13.6" in output
+
+
+def test_main_ccache_no_op_when_already_current(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    script = tmp_path / "prepare_bundle.sh"
+    script.write_text(SAMPLE_SCRIPT)
+    out = tmp_path / "out"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+    current_url = (
+        "https://github.com/ccache/ccache/releases/download/"
+        "v4.13.5/ccache-4.13.5-windows-x86_64.zip"
+    )
+    monkeypatch.setattr(
+        bump, "resolve_latest_ccache", lambda: ("4.13.5", current_url, "2" * 64)
+    )
+
+    rc = bump.main(["--target", "ccache", "--file", str(script)])
+    assert rc == 0
+    assert script.read_text() == SAMPLE_SCRIPT
+    assert "changed=false" in out.read_text()
+
+
+def test_main_ccache_refuses_downgrade(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Current pin is 4.13.5; a resolved older release (upstream republished an
+    # old tag as latest) must fail loudly rather than open a backwards PR.
+    script = tmp_path / "prepare_bundle.sh"
+    script.write_text(SAMPLE_SCRIPT)
+    out = tmp_path / "out"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+    old_url = (
+        "https://github.com/ccache/ccache/releases/download/"
+        "v4.13.4/ccache-4.13.4-windows-x86_64.zip"
+    )
+    monkeypatch.setattr(
+        bump, "resolve_latest_ccache", lambda: ("4.13.4", old_url, "aa" * 32)
+    )
+
+    rc = bump.main(["--target", "ccache", "--file", str(script)])
+    assert rc == 1
+    assert script.read_text() == SAMPLE_SCRIPT
+    assert not out.exists() or "changed=true" not in out.read_text()
+
+
+def test_main_ccache_fails_when_variables_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # No ccache pins present: a real breakage that must fail the job rather than
+    # silently no-op and let the bundled ccache drift.
+    script = tmp_path / "prepare_bundle.sh"
+    script.write_text('PYTHON_VERSION="3.13.12"\nPBS_VERSION="20260203"\n')
+    out = tmp_path / "out"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+
+    rc = bump.main(["--target", "ccache", "--file", str(script)])
     assert rc == 1
     assert not out.exists() or "changed=true" not in out.read_text()


### PR DESCRIPTION
## Why

PR #214 bundles `ccache` on Windows with a manually-pinned `CCACHE_VERSION`/`CCACHE_URL`/`CCACHE_SHA256` in `prepare_bundle.sh`. MinGit and Python are kept current automatically by the nightly `bump-bundle-versions` job; ccache should be too, so it doesn't silently drift to a stale release.

## What

Wire a `ccache` target into the nightly bump tooling, mirroring the MinGit target:

- `bump_bundle_versions.py`: `resolve_latest_ccache` (resolves the `ccache-<ver>-windows-x86_64.zip` asset from the latest `ccache/ccache` release) + `resolve_ccache_bump` (rewrites the three `CCACHE_*` pins) and a `ccache` entry in `TARGETS`. Includes a downgrade guard (refuses an older version than the current pin) like MinGit. `_find_asset` now takes a `repo` arg so the missing-asset error names the right repo.
- `bump-bundle-versions.yml`: add `ccache` to the matrix, so the nightly run opens a `Bump bundled ccache to X` PR when a newer release exists.
- `prepare_bundle.sh`: the `CCACHE_*` comment now points at the nightly job (matching MINGIT_*).
- Tests: ccache resolution + CLI tests mirroring the MinGit coverage (asset selection over the aarch64/minisig siblings, no-op when current, downgrade refusal, missing-var failure). 40 pass.

ccache publishes no SHA256SUMS (only `.minisig`), so the digest comes from the asset metadata when GitHub reports it, else is computed by streaming the zip — and `prepare_bundle.sh` re-verifies it at build time regardless.

## Test

`PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest tests/test_bump_bundle_versions.py` → 40 passed. `--target ccache` is a valid CLI choice; YAML validates; pre-commit (ruff/yaml) clean.