### PR TITLE
Patch quick-sharun to stop the AppImage build hanging in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -204,6 +204,18 @@ jobs:
         env:
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
 
+      # The Tauri AppImage fork downloads quick-sharun.sh from upstream main and
+      # runs it during the build. Its strace step backgrounds each traced binary
+      # and kills it via `set -m` job control, which silently no-ops on tty-less
+      # CI runners, so webkit2gtk's MiniBrowser never dies and the build hangs
+      # until timeout (pkgforge-dev/Anylinux-AppImages regression, late June).
+      # Pre-stage a copy pinned to a known commit, patched to bound each trace
+      # with `timeout` instead, so the bundler reuses ours (it only downloads
+      # when the file is absent).
+      - name: Stage patched quick-sharun (AppImage strace hang fix)
+        if: contains(matrix.bundles, 'appimage')
+        run: ./build-scripts/stage_quick_sharun.sh
+
       # Build step - Linux with special env var
       - name: Build (Linux CI)
         if: matrix.platform == 'linux' && github.event_name != 'workflow_run'

--- a/build-scripts/stage_quick_sharun.sh
+++ b/build-scripts/stage_quick_sharun.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Stage a patched quick-sharun.sh for the Tauri AppImage build.
+#
+# The Tauri AppImage fork downloads quick-sharun.sh from upstream main and runs
+# it during `cargo tauri build`. Its strace step (which discovers dlopen'd
+# libraries) backgrounds each traced binary and stops it with `set -m` job
+# control plus a process group kill. On tty-less CI runners `set -m` silently
+# no-ops, so the kill never reaches webkit2gtk's MiniBrowser and the build hangs
+# until the job timeout (pkgforge-dev/Anylinux-AppImages regression, late June).
+#
+# Pre-stage a copy pinned to a known upstream commit, patched to bound each
+# trace with `timeout` instead. The bundler only downloads quick-sharun.sh when
+# the file is absent, so staging ours here makes it reuse our copy. strace lib
+# detection is preserved.
+
+set -euo pipefail
+
+SHARUN_REV="867c0b1543321149a133565c41cf19d81dc74533"
+SHARUN_SHA256="bcf0496dc2a374734750bcc6f74ce14793cb8539cbeefdecf40bd818fad36a82"
+
+CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/tauri"
+DEST="$CACHE_DIR/quick-sharun.sh"
+mkdir -p "$CACHE_DIR"
+
+curl -fL --retry 3 --retry-delay 2 -o "$DEST" \
+  "https://raw.githubusercontent.com/pkgforge-dev/Anylinux-AppImages/${SHARUN_REV}/useful-tools/quick-sharun.sh"
+echo "${SHARUN_SHA256}  ${DEST}" | sha256sum -c -
+
+# Replace the strace kill block. A pinned SHA256 plus the exact-match assert
+# below fail loudly if the upstream file drifts, prompting a re-pin rather than
+# a silent regression.
+python3 - "$DEST" <<'PY'
+import sys
+
+p = sys.argv[1]
+src = open(p).read()
+old = (
+    '\t\t_echo "STRACE: [$b] ..."\n'
+    '\t\tset -m\n'
+    '\t\tif [ -n "$XVFB_CMD" ]; then\n'
+    '\t\t\t$XVFB_CMD env LD_DEBUG=libs "$b" $flags >/dev/null 2>"$dlopened" &\n'
+    '\t\telse\n'
+    '\t\t\tLD_DEBUG=libs "$b" $flags >/dev/null 2>"$dlopened" &\n'
+    '\t\tfi\n'
+    '\t\tpid=$!\n'
+    '\t\tset +m\n'
+    '\n'
+    '\t\tsleep "$STRACE_TIME"\n'
+    '\t\tkill -TERM -$pid 2>/dev/null || :\n'
+    '\t\tsleep 1\n'
+    '\t\tkill -KILL -$pid 2>/dev/null || :\n'
+    '\t\twait $pid 2>/dev/null || :\n'
+)
+new = (
+    '\t\t_echo "STRACE: [$b] ..."\n'
+    '\t\t# set -m no-ops on tty-less CI; bound each trace with timeout.\n'
+    '\t\tif [ -n "$XVFB_CMD" ]; then\n'
+    '\t\t\ttimeout -k 1 "$STRACE_TIME" $XVFB_CMD env LD_DEBUG=libs "$b" $flags >/dev/null 2>"$dlopened" || :\n'
+    '\t\telse\n'
+    '\t\t\ttimeout -k 1 "$STRACE_TIME" env LD_DEBUG=libs "$b" $flags >/dev/null 2>"$dlopened" || :\n'
+    '\t\tfi\n'
+)
+if src.count(old) != 1:
+    sys.exit("quick-sharun.sh strace block not found exactly once; "
+             "upstream shape changed, re-pin SHARUN_REV/SHA256")
+open(p, "w").write(src.replace(old, new))
+PY
+
+chmod +x "$DEST"
+echo "Staged patched quick-sharun at $DEST"


### PR DESCRIPTION
# What does this implement/fix?

Every PR is currently failing the Linux AppImage build, which hangs until the 360 minute job timeout. Nothing in this repo changed; it is an upstream regression in a script we do not pin.

The Tauri AppImage fork downloads `quick-sharun.sh` from `pkgforge-dev/Anylinux-AppImages` `main` and runs it during `cargo tauri build`. Its strace step (which discovers dlopen'd libraries) backgrounds each traced binary and stops it with `set -m` job control plus a process group kill. On tty-less CI runners `set -m` silently no-ops (the log shows `set: can't access tty; job control turned off`), so the kill never reaches webkit2gtk's `MiniBrowser`; the trace blocks forever and the build runs out the clock.

This stages our own `quick-sharun.sh` at the path the bundler reuses, pinned to a known upstream commit and patched to bound each trace with `timeout` instead of the broken job control; strace lib detection is preserved. A pinned sha256 and an exact match assert fail the build loudly if the upstream file drifts.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes <link to issue>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).
