### PR TITLE
Cap the build job timeout at 30 minutes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,6 +74,9 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     name: Build ${{ matrix.target }}
+    # The slowest job (macOS) runs ~13 min; cap well above that so a hung step
+    # fails fast instead of running out the 360 minute default.
+    timeout-minutes: 30
 
     steps:
       - name: Checkout


### PR DESCRIPTION
# What does this implement/fix?

The build job had no `timeout-minutes`, so when a step hangs it runs out the full 360 minute GitHub default before failing; a recent AppImage build hang sat for 6 hours before it was cancelled. The slowest job (macOS) takes about 13 minutes, so a 30 minute cap leaves comfortable headroom while a hung step now fails fast.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue (if applicable):**

- fixes <link to issue>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).
