### PR TITLE
Keep mDNS working after a desktop update on macOS

### DIFF
--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -4,5 +4,27 @@
 <dict>
     <key>LSUIElement</key>
     <true/>
+    <!--
+      Local Network privacy (macOS 15+, enforced for all apps on macOS 26):
+      the bundled Python backend uses mDNS/zeroconf (raw multicast on UDP 5353).
+      That child process's Local Network access is attributed to this app bundle,
+      so the usage string must live here. Declaring it binds a durable grant to
+      the app identity; without it the implicit grant is lost when the updater
+      replaces the .app in place, breaking discovery until a full relaunch.
+
+      NSBonjourServices lists every service type the backend browses or
+      advertises: _esphomelib._tcp (ESPHome devices it discovers and the device
+      state monitor), _esphomebuilder._tcp (the dashboard's own advertised
+      service, also browsed for cross-subnet remote-build pairing), and
+      _http._tcp (browsed alongside _esphomelib by the device state monitor).
+    -->
+    <key>NSLocalNetworkUsageDescription</key>
+    <string>ESPHome Builder discovers ESPHome devices on your local network.</string>
+    <key>NSBonjourServices</key>
+    <array>
+        <string>_esphomelib._tcp</string>
+        <string>_esphomebuilder._tcp</string>
+        <string>_http._tcp</string>
+    </array>
 </dict>
 </plist>

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -19,7 +19,7 @@
       _http._tcp (browsed alongside _esphomelib by the device state monitor).
     -->
     <key>NSLocalNetworkUsageDescription</key>
-    <string>ESPHome Builder discovers ESPHome devices on your local network.</string>
+    <string>ESPHome Device Builder discovers ESPHome devices on your local network.</string>
     <key>NSBonjourServices</key>
     <array>
         <string>_esphomelib._tcp</string>

--- a/src-tauri/src/app_update/mod.rs
+++ b/src-tauri/src/app_update/mod.rs
@@ -14,7 +14,7 @@
 use std::time::Duration;
 
 use tauri::{AppHandle, Manager};
-use tauri_plugin_dialog::{DialogExt, MessageDialogKind};
+use tauri_plugin_dialog::MessageDialogKind;
 use tauri_plugin_notification::NotificationExt;
 use tauri_plugin_updater::UpdaterExt;
 use tracing::{debug, error, info, warn};
@@ -83,16 +83,13 @@ pub async fn check_for_user(app_handle: &AppHandle, show_no_update_dialog: bool)
             let current = app_handle.package_info().version.to_string();
             info!("Desktop app is up to date ({})", current);
             if show_no_update_dialog {
-                let dialog_app = app_handle.clone();
                 let msg = format!("ESPHome Device Builder {} is the latest version.", current);
-                let _ = tokio::task::spawn_blocking(move || {
-                    dialog_app
-                        .dialog()
-                        .message(msg)
-                        .kind(MessageDialogKind::Info)
-                        .title("No Updates Available")
-                        .blocking_show();
-                })
+                crate::dialog::notice(
+                    app_handle,
+                    "No Updates Available",
+                    msg,
+                    MessageDialogKind::Info,
+                )
                 .await;
             }
             NextStep::Continue
@@ -228,16 +225,8 @@ async fn apply_update(app_handle: &AppHandle, update: tauri_plugin_updater::Upda
                 "ESPHome Device Builder {} has been installed.\n\nESPHome Builder will now restart to apply the update.",
                 new_version
             );
-            let notice_app = app_handle.clone();
-            let _ = tokio::task::spawn_blocking(move || {
-                notice_app
-                    .dialog()
-                    .message(msg)
-                    .kind(MessageDialogKind::Info)
-                    .title("Update Installed")
-                    .blocking_show()
-            })
-            .await;
+            crate::dialog::notice(app_handle, "Update Installed", msg, MessageDialogKind::Info)
+                .await;
 
             info!("Restarting to apply desktop update");
             app_handle.restart();
@@ -267,15 +256,12 @@ async fn restore_backend(app_handle: &AppHandle) {
 }
 
 async fn show_error(app_handle: &AppHandle, msg: String) {
-    let dialog_app = app_handle.clone();
-    let _ = tokio::task::spawn_blocking(move || {
-        dialog_app
-            .dialog()
-            .message(msg)
-            .kind(MessageDialogKind::Error)
-            .title("Update Check Failed")
-            .blocking_show();
-    })
+    crate::dialog::notice(
+        app_handle,
+        "Update Check Failed",
+        msg,
+        MessageDialogKind::Error,
+    )
     .await;
 }
 

--- a/src-tauri/src/app_update/mod.rs
+++ b/src-tauri/src/app_update/mod.rs
@@ -222,7 +222,7 @@ async fn apply_update(app_handle: &AppHandle, update: tauri_plugin_updater::Upda
             // installed bundle, so we make it unconditional. The dialog is now
             // informational (single OK) just to explain the restart.
             let msg = format!(
-                "ESPHome Device Builder {} has been installed.\n\nESPHome Builder will now restart to apply the update.",
+                "ESPHome Device Builder {} has been installed.\n\nIt will now restart to apply the update.",
                 new_version
             );
             crate::dialog::notice(app_handle, "Update Installed", msg, MessageDialogKind::Info)

--- a/src-tauri/src/app_update/mod.rs
+++ b/src-tauri/src/app_update/mod.rs
@@ -215,22 +215,32 @@ async fn apply_update(app_handle: &AppHandle, update: tauri_plugin_updater::Upda
     match result {
         Ok(()) => {
             info!("Desktop update {} installed", new_version);
+            // Always relaunch after a successful install rather than offering to
+            // defer. The install replaced the .app bundle under the still-running
+            // process; on macOS that orphans the app's Local Network (mDNS) grant,
+            // and since the bundled backend's multicast discovery is attributed to
+            // this parent process, merely restarting the backend can't recover it
+            // (see Info.plist `NSLocalNetworkUsageDescription`). A full relaunch is
+            // the only way to put the user on a process that matches the freshly
+            // installed bundle, so we make it unconditional. The dialog is now
+            // informational (single OK) just to explain the restart.
             let msg = format!(
-                "ESPHome Device Builder {} has been installed.\n\nRestart now to use the new version?",
+                "ESPHome Device Builder {} has been installed.\n\nESPHome Builder will now restart to apply the update.",
                 new_version
             );
-            let restart =
-                crate::dialog::confirm(app_handle, "Update Installed", msg, "Restart Now", "Later")
-                    .await;
+            let notice_app = app_handle.clone();
+            let _ = tokio::task::spawn_blocking(move || {
+                notice_app
+                    .dialog()
+                    .message(msg)
+                    .kind(MessageDialogKind::Info)
+                    .title("Update Installed")
+                    .blocking_show()
+            })
+            .await;
 
-            if restart {
-                info!("Restarting to apply desktop update");
-                app_handle.restart();
-            } else {
-                // User deferred the restart; bring the backend back so the
-                // freshly installed dashboard is usable until they relaunch.
-                restore_backend(app_handle).await;
-            }
+            info!("Restarting to apply desktop update");
+            app_handle.restart();
         }
         Err(e) => {
             error!("Desktop update install failed: {}", e);
@@ -241,9 +251,11 @@ async fn apply_update(app_handle: &AppHandle, update: tauri_plugin_updater::Upda
 }
 
 /// Bring the backend back up when we're not restarting the whole app. We stop
-/// it before installing, so without this a failed install (or a user who defers
-/// the post-install restart) would leave the running app with no dashboard.
-/// Best-effort: restart it and restore the tray status.
+/// it before installing, so on a failed install — where the bundle was not
+/// replaced and the running process is still valid — without this the running
+/// app would be left with no dashboard. (A successful install always relaunches,
+/// so it never takes this path.) Best-effort: restart it and restore the tray
+/// status.
 async fn restore_backend(app_handle: &AppHandle) {
     if let Some(state) = app_handle.try_state::<std::sync::Arc<crate::AppState>>() {
         info!("Restarting ESPHome backend after desktop update");

--- a/src-tauri/src/dialog.rs
+++ b/src-tauri/src/dialog.rs
@@ -1,7 +1,7 @@
 //! Small helpers around `tauri-plugin-dialog`.
 
 use tauri::AppHandle;
-use tauri_plugin_dialog::{DialogExt, MessageDialogButtons};
+use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
 
 /// Show a modal two-button confirmation dialog and wait for the user's choice.
 ///
@@ -31,4 +31,27 @@ pub(crate) async fn confirm(
     })
     .await
     .unwrap_or(false)
+}
+
+/// Show a modal single-button notice (informational or error) and wait for the
+/// user to dismiss it. Like [`confirm`], `blocking_show` is synchronous so it
+/// runs on a blocking thread; the result is discarded since a notice has nothing
+/// to report back. A join error just means the dialog never showed, which is
+/// fine for a best-effort notice.
+pub(crate) async fn notice(
+    app_handle: &AppHandle,
+    title: &str,
+    message: String,
+    kind: MessageDialogKind,
+) {
+    let app = app_handle.clone();
+    let title = title.to_string();
+    let _ = tokio::task::spawn_blocking(move || {
+        app.dialog()
+            .message(message)
+            .title(title)
+            .kind(kind)
+            .blocking_show()
+    })
+    .await;
 }


### PR DESCRIPTION
# What does this implement/fix?

After a desktop update on macOS the device builder mDNS stops finding devices until a full quit and relaunch. The backend does mDNS over raw multicast, which needs the macOS Local Network grant, and that grant is attributed to this app bundle; Info.plist never declared NSLocalNetworkUsageDescription, so the grant was only implicit and got orphaned when the updater replaced the .app under the running process. This declares the usage string and lists the browsed and advertised service types (_esphomelib._tcp, _esphomebuilder._tcp, _http._tcp) so the grant binds durably to the app identity. It also always relaunches after a successful update instead of restoring only the backend, since the in place restore cannot recover the orphaned grant; restore_backend now runs only on the install failure path.

Not yet verified on a signed build; the persisted grant path only shows up with a notarized update, so the checklist below stays unchecked until tested on a real macOS install.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- N/A

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).
