### PR TITLE
Relaunch through LaunchServices after a macOS update

### DIFF
--- a/src-tauri/src/app_update/mod.rs
+++ b/src-tauri/src/app_update/mod.rs
@@ -213,13 +213,11 @@ async fn apply_update(app_handle: &AppHandle, update: tauri_plugin_updater::Upda
         Ok(()) => {
             info!("Desktop update {} installed", new_version);
             // Always relaunch after a successful install rather than offering to
-            // defer. The install replaced the .app bundle under the still-running
-            // process; on macOS that orphans the app's Local Network (mDNS) grant,
-            // and since the bundled backend's multicast discovery is attributed to
-            // this parent process, merely restarting the backend can't recover it
-            // (see Info.plist `NSLocalNetworkUsageDescription`). A full relaunch is
-            // the only way to put the user on a process that matches the freshly
-            // installed bundle, so we make it unconditional. The dialog is now
+            // defer: the install replaced the .app bundle, and the running
+            // process must be replaced by a fresh instance of it. On macOS the
+            // relaunch must go through LaunchServices so the new process (and the
+            // backend child it spawns) keeps the Local Network grant mDNS
+            // discovery needs — see `platform::relaunch_for_update`. The dialog is
             // informational (single OK) just to explain the restart.
             let msg = format!(
                 "ESPHome Device Builder {} has been installed.\n\nIt will now restart to apply the update.",
@@ -228,8 +226,8 @@ async fn apply_update(app_handle: &AppHandle, update: tauri_plugin_updater::Upda
             crate::dialog::notice(app_handle, "Update Installed", msg, MessageDialogKind::Info)
                 .await;
 
-            info!("Restarting to apply desktop update");
-            app_handle.restart();
+            info!("Relaunching to apply desktop update");
+            crate::platform::relaunch_for_update(app_handle);
         }
         Err(e) => {
             error!("Desktop update install failed: {}", e);

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -1232,21 +1232,20 @@ mod macos {
             tracing::warn!("Could not resolve .app bundle path; falling back to direct restart");
             return false;
         };
-        let Some(bundle_str) = bundle.to_str() else {
-            tracing::warn!("Bundle path is not valid UTF-8; falling back to direct restart");
-            return false;
-        };
         let pid = std::process::id();
         // Poll our PID; once it's gone, LaunchServices-launch a fresh instance so
-        // it (and its backend child) is the TCC-responsible process again.
-        let script = format!(
-            "while kill -0 {pid} 2>/dev/null; do sleep 0.2; done; exec /usr/bin/open \"{bundle_str}\""
-        );
-        // Own process group so it outlives us cleanly and isn't caught by any
-        // signal aimed at our group during shutdown.
+        // it (and its backend child) is the TCC-responsible process again. Pass
+        // the PID and bundle path as argv positionals ($1/$2) rather than
+        // interpolating them into the script, so the shell never parses the path
+        // — a `.app` path with spaces or shell metacharacters can't break the
+        // relaunch or inject a command. Own process group so the watcher outlives
+        // us cleanly and isn't caught by any signal aimed at our group.
         match Command::new("/bin/sh")
             .arg("-c")
-            .arg(script)
+            .arg(r#"while kill -0 "$1" 2>/dev/null; do sleep 0.2; done; exec /usr/bin/open "$2""#)
+            .arg("sh") // $0
+            .arg(pid.to_string()) // $1
+            .arg(&bundle) // $2, passed as an OsStr — no UTF-8 requirement
             .process_group(0)
             .spawn()
         {

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -1170,8 +1170,34 @@ pub fn init(app_handle: &AppHandle) {
     linux::init();
 }
 
+/// Relaunch the app after a desktop update.
+///
+/// On macOS this goes through LaunchServices (`open`) instead of Tauri's
+/// [`tauri::AppHandle::restart`], which respawns the inner Mach-O directly. A
+/// directly respawned instance is not the LaunchServices-launched, TCC
+/// "responsible" process, so the bundled Python backend it spawns is not covered
+/// by the app's Local Network grant: its mDNS multicast then fails with
+/// `EHOSTUNREACH` ("No route to host") until the user manually relaunches.
+/// Reopening via LaunchServices gives the new instance the correct
+/// responsibility, so device discovery works immediately after an update. Other
+/// platforms keep `restart()` (Local Network privacy is macOS-only).
+pub fn relaunch_for_update(app_handle: &AppHandle) {
+    #[cfg(target_os = "macos")]
+    if macos::spawn_launchservices_relaunch() {
+        // The watcher reopens us once we're gone; exit cleanly so it can.
+        app_handle.exit(0);
+        return;
+    }
+    // Non-macOS, or the LaunchServices path couldn't be set up: fall back to
+    // Tauri's direct relaunch (diverges).
+    app_handle.restart();
+}
+
 #[cfg(target_os = "macos")]
 mod macos {
+    use std::os::unix::process::CommandExt;
+    use std::path::PathBuf;
+    use std::process::Command;
     use tauri::{ActivationPolicy, AppHandle};
 
     pub fn init(app_handle: &AppHandle) {
@@ -1179,6 +1205,56 @@ mod macos {
         // doesn't appear in the Dock or the Cmd+Tab switcher.
         if let Err(e) = app_handle.set_activation_policy(ActivationPolicy::Accessory) {
             tracing::warn!("Failed to set macOS activation policy to Accessory: {e}");
+        }
+    }
+
+    /// Resolve the `.app` bundle directory from the running executable
+    /// (`<name>.app/Contents/MacOS/<bin>` -> `<name>.app`).
+    fn app_bundle_path() -> Option<PathBuf> {
+        let exe = std::env::current_exe().ok()?;
+        // ancestors(): <bin>, MacOS, Contents, <name>.app
+        let bundle = exe.ancestors().nth(3)?;
+        if bundle.extension().and_then(|e| e.to_str()) == Some("app") {
+            Some(bundle.to_path_buf())
+        } else {
+            None
+        }
+    }
+
+    /// Spawn a detached watcher that waits for this process to exit, then
+    /// relaunches the app through LaunchServices (`open`). We wait first because
+    /// `tauri-plugin-single-instance` would make a second instance started while
+    /// we're still quitting forward-and-exit instead of taking over. Returns
+    /// `false` (so the caller falls back to `restart()`) when the bundle path
+    /// can't be resolved or the watcher can't be spawned.
+    pub fn spawn_launchservices_relaunch() -> bool {
+        let Some(bundle) = app_bundle_path() else {
+            tracing::warn!("Could not resolve .app bundle path; falling back to direct restart");
+            return false;
+        };
+        let Some(bundle_str) = bundle.to_str() else {
+            tracing::warn!("Bundle path is not valid UTF-8; falling back to direct restart");
+            return false;
+        };
+        let pid = std::process::id();
+        // Poll our PID; once it's gone, LaunchServices-launch a fresh instance so
+        // it (and its backend child) is the TCC-responsible process again.
+        let script = format!(
+            "while kill -0 {pid} 2>/dev/null; do sleep 0.2; done; exec /usr/bin/open \"{bundle_str}\""
+        );
+        // Own process group so it outlives us cleanly and isn't caught by any
+        // signal aimed at our group during shutdown.
+        match Command::new("/bin/sh")
+            .arg("-c")
+            .arg(script)
+            .process_group(0)
+            .spawn()
+        {
+            Ok(_) => true,
+            Err(e) => {
+                tracing::warn!("Failed to spawn LaunchServices relaunch watcher: {e}");
+                false
+            }
         }
     }
 }

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -1195,7 +1195,6 @@ pub fn relaunch_for_update(app_handle: &AppHandle) {
 
 #[cfg(target_os = "macos")]
 mod macos {
-    use std::os::fd::IntoRawFd;
     use std::os::unix::process::CommandExt;
     use std::path::PathBuf;
     use std::process::{Command, Stdio};
@@ -1245,7 +1244,7 @@ mod macos {
             .arg("-c")
             .arg(r#"cat >/dev/null; exec /usr/bin/open "$1""#)
             .arg("sh") // $0
-            .arg(&bundle) // $1, passed as an OsStr — no UTF-8 requirement
+            .arg(&bundle) // $1, a positional the shell never parses (also fine if non-UTF-8)
             .stdin(Stdio::piped())
             .process_group(0)
             .spawn()
@@ -1261,7 +1260,7 @@ mod macos {
         // dropped it here the watcher would fire immediately, racing our own
         // still-running instance against single-instance.
         if let Some(stdin) = child.stdin.take() {
-            let _ = stdin.into_raw_fd();
+            std::mem::forget(stdin);
         }
         true
     }

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -1195,9 +1195,10 @@ pub fn relaunch_for_update(app_handle: &AppHandle) {
 
 #[cfg(target_os = "macos")]
 mod macos {
+    use std::os::fd::IntoRawFd;
     use std::os::unix::process::CommandExt;
     use std::path::PathBuf;
-    use std::process::Command;
+    use std::process::{Command, Stdio};
     use tauri::{ActivationPolicy, AppHandle};
 
     pub fn init(app_handle: &AppHandle) {
@@ -1232,29 +1233,37 @@ mod macos {
             tracing::warn!("Could not resolve .app bundle path; falling back to direct restart");
             return false;
         };
-        let pid = std::process::id();
-        // Poll our PID; once it's gone, LaunchServices-launch a fresh instance so
-        // it (and its backend child) is the TCC-responsible process again. Pass
-        // the PID and bundle path as argv positionals ($1/$2) rather than
-        // interpolating them into the script, so the shell never parses the path
-        // — a `.app` path with spaces or shell metacharacters can't break the
-        // relaunch or inject a command. Own process group so the watcher outlives
-        // us cleanly and isn't caught by any signal aimed at our group.
-        match Command::new("/bin/sh")
+        // The watcher blocks reading its stdin, which is the read end of a pipe
+        // whose write end this process holds. When we exit, the kernel closes
+        // that write end, `cat` sees EOF, and the watcher relaunches — so it
+        // unblocks exactly when we terminate, with no PID-reuse race and no poll
+        // latency. The bundle path is an argv positional ($1) so the shell never
+        // parses it (spaces/metacharacters can't break the relaunch or inject a
+        // command). Own process group so the watcher outlives us cleanly and
+        // isn't caught by any signal aimed at our group.
+        let mut child = match Command::new("/bin/sh")
             .arg("-c")
-            .arg(r#"while kill -0 "$1" 2>/dev/null; do sleep 0.2; done; exec /usr/bin/open "$2""#)
+            .arg(r#"cat >/dev/null; exec /usr/bin/open "$1""#)
             .arg("sh") // $0
-            .arg(pid.to_string()) // $1
-            .arg(&bundle) // $2, passed as an OsStr — no UTF-8 requirement
+            .arg(&bundle) // $1, passed as an OsStr — no UTF-8 requirement
+            .stdin(Stdio::piped())
             .process_group(0)
             .spawn()
         {
-            Ok(_) => true,
+            Ok(child) => child,
             Err(e) => {
                 tracing::warn!("Failed to spawn LaunchServices relaunch watcher: {e}");
-                false
+                return false;
             }
+        };
+        // Intentionally leak the pipe's write end so it stays open until this
+        // process actually exits; that EOF is what releases the watcher. If we
+        // dropped it here the watcher would fire immediately, racing our own
+        // still-running instance against single-instance.
+        if let Some(stdin) = child.stdin.take() {
+            let _ = stdin.into_raw_fd();
         }
+        true
     }
 }
 


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #230, which did not fix the macOS "device builder mDNS stops working after an update" bug. The real cause is that Tauri's app_handle.restart() respawns the inner Mach-O directly and never goes through LaunchServices, so the relaunched instance is not the TCC responsible process; the bundled Python backend it spawns then falls outside the app's Local Network grant and its mDNS multicast fails with EHOSTUNREACH ("No route to host") until a manual relaunch. The log confirmed it (No route to host on en0, the primary interface, which does not change during an update), and a manual quit and relaunch through LaunchServices always fixed it.

This relaunches via `open` after a successful update so launchd owns the fresh instance and the grant applies. A detached watcher waits for the current process to exit first, then opens the bundle, so tauri-plugin-single-instance does not make the new instance forward and exit while we are still quitting. Other platforms keep restart(). #230's Info.plist declaration and the always-relaunch behavior are kept.

Needs a signed, notarized build to verify end to end, since Local Network privacy only applies to the granted signed app.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- N/A

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).
