### PR TITLE
Name the Pages artifact per run attempt so deploy re-runs work

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -75,11 +75,18 @@ jobs:
       - name: Configure Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
+      # The artifact name includes the run attempt so re-running the job
+      # after a transient Pages failure works; artifacts persist across
+      # attempts, and deploy-pages refuses to deploy when two artifacts
+      # share the default "github-pages" name.
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: _site
+          name: github-pages-${{ github.run_attempt }}
 
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+        with:
+          artifact_name: github-pages-${{ github.run_attempt }}


### PR DESCRIPTION
# What does this implement/fix?

The v0.12.2 Pages deploy failed with a transient "Deployment failed, try again later" from GitHub, and the re-run then failed with "Multiple artifacts named github-pages were unexpectedly found for this workflow run" because the artifact from the first attempt persists across re-runs. This names the Pages artifact per run attempt, so each attempt uploads and deploys its own artifact and re-running the job works; see https://github.com/esphome/esphome-desktop/actions/runs/28694179225 for both failures.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- none, failed release deploy linked above

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).
