### PR TITLE
Print CLI help instead of launching when run bare in a terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ esphome-desktop quit             # quit the running app
 Unlike the tray's confirmation dialogs, the CLI applies changes immediately;
 running the command is the consent. `logs` and `status` also work when the app
 is not running, and `status` prints the config and log directory paths.
+Running `esphome-desktop` with no arguments in a terminal prints this command
+list instead of launching another app instance; use `open` to start the app.
 
 On Linux the deb/rpm/AUR packages put `esphome-desktop` on your `PATH`. On
 macOS the app installs the command on launch, as a small launcher in

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -131,6 +131,10 @@ pub enum CliCommand {
 #[derive(Parser, Debug, Clone)]
 #[command(name = "esphome-desktop")]
 #[command(about = "ESPHome Device Builder", long_about = None)]
+#[command(
+    after_help = "Run 'esphome-desktop open' to start the app and open the dashboard; \
+                  launching with no subcommand starts the app when run outside a terminal."
+)]
 pub struct Cli {
     /// Control an already-running app instead of launching one.
     #[command(subcommand)]
@@ -156,6 +160,21 @@ pub struct Cli {
 /// code. No Tauri, no logging init — this path must stay quiet and quick.
 pub fn run_cli(command: CliCommand) -> std::process::ExitCode {
     control::client::run(command)
+}
+
+/// Whether this is a bare `esphome-desktop` typed in a terminal, which should
+/// print help rather than launch another app instance. Explicit launch flags
+/// keep launching (a terminal launch with `--no-open-dashboard` or
+/// `--use-builder` is deliberate), and launches without a terminal — Finder,
+/// the applications menu, a `.desktop` file, autostart, `open`'s detached
+/// spawn — are the normal app-start path.
+pub fn bare_terminal_invocation(cli: &Cli) -> bool {
+    use std::io::IsTerminal;
+
+    cli.command.is_none()
+        && !cli.no_open_dashboard
+        && !cli.use_builder
+        && (std::io::stdin().is_terminal() || std::io::stdout().is_terminal())
 }
 
 /// Attach to the parent process's console so terminal output is visible:

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -162,32 +162,32 @@ pub fn run_cli(command: CliCommand) -> std::process::ExitCode {
     control::client::run(command)
 }
 
-/// Whether this is a bare `esphome-desktop` typed in a terminal, which should
-/// print help rather than launch another app instance. Explicit launch flags
-/// keep launching (a terminal launch with `--no-open-dashboard` or
-/// `--use-builder` is deliberate), and launches without a terminal — Finder,
-/// the applications menu, a `.desktop` file, autostart, `open`'s detached
-/// spawn — are the normal app-start path.
-pub fn bare_terminal_invocation(cli: &Cli) -> bool {
-    use std::io::IsTerminal;
-
-    cli.command.is_none()
-        && !cli.no_open_dashboard
-        && !cli.use_builder
-        && (std::io::stdin().is_terminal() || std::io::stdout().is_terminal())
+/// Whether this is a bare `esphome-desktop` run from a terminal, which should
+/// print help rather than launch another app instance. `from_terminal` is the
+/// platform's "started from a console" signal (a real TTY on Unix, a
+/// successful parent-console attach on Windows — see [`attach_parent_console`]).
+/// Explicit launch flags keep launching (a terminal launch with
+/// `--no-open-dashboard` or `--use-builder` is deliberate), and non-terminal
+/// launches — Finder, the applications menu, a `.desktop` file, autostart,
+/// `open`'s detached spawn — take the normal app-start path.
+pub fn bare_terminal_invocation(cli: &Cli, from_terminal: bool) -> bool {
+    cli.command.is_none() && !cli.no_open_dashboard && !cli.use_builder && from_terminal
 }
 
-/// Attach to the parent process's console so terminal output is visible:
-/// release builds use `windows_subsystem = "windows"`, which starts the
-/// process with no console. Must run before clap parses so `--help` and
-/// usage errors are visible too. A no-op when there is no parent console
-/// (normal double-click launches).
+/// Attach to the parent process's console so terminal output is visible, and
+/// report whether one was attached. Release builds use
+/// `windows_subsystem = "windows"`, which starts the process with no console,
+/// so `--help` and usage errors would otherwise print nowhere; this must run
+/// before clap parses. `AttachConsole(ATTACH_PARENT_PROCESS)` succeeds only
+/// when the launcher had a console (cmd/PowerShell) and fails on a GUI /
+/// Start-menu / autostart launch, so its result is also the reliable "started
+/// from a terminal" signal — more robust than reading the std handles with
+/// `is_terminal()` afterward, which is not guaranteed to observe the
+/// just-attached console.
 #[cfg(windows)]
-pub fn attach_parent_console() {
+pub fn attach_parent_console() -> bool {
     use ::windows::Win32::System::Console::{AttachConsole, ATTACH_PARENT_PROCESS};
-    unsafe {
-        let _ = AttachConsole(ATTACH_PARENT_PROCESS);
-    }
+    unsafe { AttachConsole(ATTACH_PARENT_PROCESS).is_ok() }
 }
 
 /// Application state shared across the app
@@ -786,8 +786,43 @@ pub fn run(cli: Cli) {
 
 #[cfg(test)]
 mod tests {
+    use super::bare_terminal_invocation;
     use super::dashboard_ready_url;
     use super::updates_menu_hint;
+    use super::Cli;
+    use clap::Parser;
+
+    fn parse(args: &[&str]) -> Cli {
+        Cli::try_parse_from(std::iter::once("esphome-desktop").chain(args.iter().copied()))
+            .expect("parse")
+    }
+
+    #[test]
+    fn bare_run_in_a_terminal_shows_help() {
+        assert!(bare_terminal_invocation(&parse(&[]), true));
+    }
+
+    #[test]
+    fn bare_run_without_a_terminal_launches() {
+        // Finder / autostart / detached spawn: no terminal, so start the app.
+        assert!(!bare_terminal_invocation(&parse(&[]), false));
+    }
+
+    #[test]
+    fn a_subcommand_is_never_a_launch() {
+        // Subcommands are dispatched before this check, but guard anyway.
+        assert!(!bare_terminal_invocation(&parse(&["status"]), true));
+    }
+
+    #[test]
+    fn explicit_launch_flags_launch_even_in_a_terminal() {
+        // A terminal launch with a launch flag is a deliberate start.
+        assert!(!bare_terminal_invocation(
+            &parse(&["--no-open-dashboard"]),
+            true
+        ));
+        assert!(!bare_terminal_invocation(&parse(&["--use-builder"]), true));
+    }
 
     #[test]
     fn dashboard_ready_url_targets_ipv4_loopback() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -162,16 +162,21 @@ pub fn run_cli(command: CliCommand) -> std::process::ExitCode {
     control::client::run(command)
 }
 
-/// Whether this is a bare `esphome-desktop` run from a terminal, which should
-/// print help rather than launch another app instance. `from_terminal` is the
-/// platform's "started from a console" signal (a real TTY on Unix, a
-/// successful parent-console attach on Windows — see [`attach_parent_console`]).
-/// Explicit launch flags keep launching (a terminal launch with
-/// `--no-open-dashboard` or `--use-builder` is deliberate), and non-terminal
-/// launches — Finder, the applications menu, a `.desktop` file, autostart,
-/// `open`'s detached spawn — take the normal app-start path.
-pub fn bare_terminal_invocation(cli: &Cli, from_terminal: bool) -> bool {
-    cli.command.is_none() && !cli.no_open_dashboard && !cli.use_builder && from_terminal
+/// Whether this is a bare `esphome-desktop` run from a terminal — no
+/// subcommand and no flags at all, just the program name — which should print
+/// the command list instead of launching another app instance. Any explicit
+/// argument is a deliberate invocation and launches as before: a launch flag
+/// like `--no-open-dashboard`, or even the no-op `--builder-channel`, so the
+/// rule needs no per-flag list and stays correct as flags are added.
+/// Non-terminal launches (Finder, the applications menu, a `.desktop` file,
+/// autostart, `open`'s detached spawn) also take the normal app-start path.
+///
+/// `from_terminal` is the platform's "started from a console" signal (a real
+/// TTY on Unix, a successful parent-console attach on Windows — see
+/// [`attach_parent_console`]). `arg_count` is `std::env::args_os().count()`,
+/// so the bare case is a count of 1 (just the program name).
+pub fn is_bare_terminal_launch(from_terminal: bool, arg_count: usize) -> bool {
+    from_terminal && arg_count <= 1
 }
 
 /// Attach to the parent process's console so terminal output is visible, and
@@ -786,42 +791,28 @@ pub fn run(cli: Cli) {
 
 #[cfg(test)]
 mod tests {
-    use super::bare_terminal_invocation;
     use super::dashboard_ready_url;
+    use super::is_bare_terminal_launch;
     use super::updates_menu_hint;
-    use super::Cli;
-    use clap::Parser;
-
-    fn parse(args: &[&str]) -> Cli {
-        Cli::try_parse_from(std::iter::once("esphome-desktop").chain(args.iter().copied()))
-            .expect("parse")
-    }
 
     #[test]
     fn bare_run_in_a_terminal_shows_help() {
-        assert!(bare_terminal_invocation(&parse(&[]), true));
+        // Just the program name (arg_count 1), attached to a terminal.
+        assert!(is_bare_terminal_launch(true, 1));
     }
 
     #[test]
     fn bare_run_without_a_terminal_launches() {
         // Finder / autostart / detached spawn: no terminal, so start the app.
-        assert!(!bare_terminal_invocation(&parse(&[]), false));
+        assert!(!is_bare_terminal_launch(false, 1));
     }
 
     #[test]
-    fn a_subcommand_is_never_a_launch() {
-        // Subcommands are dispatched before this check, but guard anyway.
-        assert!(!bare_terminal_invocation(&parse(&["status"]), true));
-    }
-
-    #[test]
-    fn explicit_launch_flags_launch_even_in_a_terminal() {
-        // A terminal launch with a launch flag is a deliberate start.
-        assert!(!bare_terminal_invocation(
-            &parse(&["--no-open-dashboard"]),
-            true
-        ));
-        assert!(!bare_terminal_invocation(&parse(&["--use-builder"]), true));
+    fn any_argument_launches_even_in_a_terminal() {
+        // A launch flag, a subcommand, or even the no-op `--builder-channel`
+        // is a deliberate invocation: arg_count > 1, so never bare.
+        assert!(!is_bare_terminal_launch(true, 2)); // e.g. --no-open-dashboard
+        assert!(!is_bare_terminal_launch(true, 3)); // e.g. --builder-channel stable
     }
 
     #[test]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -9,14 +9,21 @@ fn main() -> std::process::ExitCode {
     // On Windows this must go through AttachConsole (release builds start
     // with no console), which both makes --help/usage output visible and,
     // via its success, tells us the launcher had a console. On Unix we check
-    // the std handles directly.
+    // the std handles directly, including stderr so a `cmd >out 2>&1`-style
+    // launch with stdin/stdout redirected but stderr on the tty still counts.
     #[cfg(windows)]
     let from_terminal = esphome_desktop_lib::attach_parent_console();
     #[cfg(not(windows))]
     let from_terminal = {
         use std::io::IsTerminal;
-        std::io::stdin().is_terminal() || std::io::stdout().is_terminal()
+        std::io::stdin().is_terminal()
+            || std::io::stdout().is_terminal()
+            || std::io::stderr().is_terminal()
     };
+
+    // Count args before clap consumes them; a bare invocation is just the
+    // program name (count 1).
+    let arg_count = std::env::args_os().count();
 
     let cli = Cli::parse();
     // A subcommand means "control the running app": run the short-lived CLI
@@ -27,10 +34,12 @@ fn main() -> std::process::ExitCode {
     // A bare `esphome-desktop` typed in a terminal is someone exploring the
     // CLI, not a request to launch another app instance (a second launch is
     // heavyweight: it runs a full startup before single-instance forwards
-    // it). Desktop launches — Finder, the applications menu, autostart —
-    // are not from a terminal and fall through to a normal launch, as does
-    // any explicit launch flag.
-    if esphome_desktop_lib::bare_terminal_invocation(&cli, from_terminal) {
+    // it). Any explicit flag, or a launch from outside a terminal (Finder,
+    // the applications menu, autostart), falls through to a normal launch.
+    if esphome_desktop_lib::is_bare_terminal_launch(from_terminal, arg_count) {
+        // Best-effort: a write failure here is almost always a broken pipe
+        // (`esphome-desktop | head`), which is not worth reporting; clap's
+        // help already ends with a newline.
         let _ = Cli::command().print_help();
         return std::process::ExitCode::SUCCESS;
     }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -5,11 +5,18 @@ use clap::{CommandFactory, Parser};
 use esphome_desktop_lib::Cli;
 
 fn main() -> std::process::ExitCode {
-    // Attach to the invoking console before clap parses: release builds use
-    // `windows_subsystem = "windows"`, so without this, --help/--version and
-    // usage errors for mistyped subcommands print nothing.
+    // Decide whether we were started from a terminal before clap parses.
+    // On Windows this must go through AttachConsole (release builds start
+    // with no console), which both makes --help/usage output visible and,
+    // via its success, tells us the launcher had a console. On Unix we check
+    // the std handles directly.
     #[cfg(windows)]
-    esphome_desktop_lib::attach_parent_console();
+    let from_terminal = esphome_desktop_lib::attach_parent_console();
+    #[cfg(not(windows))]
+    let from_terminal = {
+        use std::io::IsTerminal;
+        std::io::stdin().is_terminal() || std::io::stdout().is_terminal()
+    };
 
     let cli = Cli::parse();
     // A subcommand means "control the running app": run the short-lived CLI
@@ -21,9 +28,9 @@ fn main() -> std::process::ExitCode {
     // CLI, not a request to launch another app instance (a second launch is
     // heavyweight: it runs a full startup before single-instance forwards
     // it). Desktop launches — Finder, the applications menu, autostart —
-    // have no controlling terminal and fall through to a normal launch, as
-    // does any explicit launch flag.
-    if esphome_desktop_lib::bare_terminal_invocation(&cli) {
+    // are not from a terminal and fall through to a normal launch, as does
+    // any explicit launch flag.
+    if esphome_desktop_lib::bare_terminal_invocation(&cli, from_terminal) {
         let _ = Cli::command().print_help();
         return std::process::ExitCode::SUCCESS;
     }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,7 +1,7 @@
 // Prevents additional console window on Windows in release
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-use clap::Parser;
+use clap::{CommandFactory, Parser};
 use esphome_desktop_lib::Cli;
 
 fn main() -> std::process::ExitCode {
@@ -16,6 +16,16 @@ fn main() -> std::process::ExitCode {
     // client and exit without ever starting Tauri.
     if let Some(command) = cli.command.clone() {
         return esphome_desktop_lib::run_cli(command);
+    }
+    // A bare `esphome-desktop` typed in a terminal is someone exploring the
+    // CLI, not a request to launch another app instance (a second launch is
+    // heavyweight: it runs a full startup before single-instance forwards
+    // it). Desktop launches — Finder, the applications menu, autostart —
+    // have no controlling terminal and fall through to a normal launch, as
+    // does any explicit launch flag.
+    if esphome_desktop_lib::bare_terminal_invocation(&cli) {
+        let _ = Cli::command().print_help();
+        return std::process::ExitCode::SUCCESS;
     }
     esphome_desktop_lib::run(cli);
     std::process::ExitCode::SUCCESS


### PR DESCRIPTION
# What does this implement/fix?

Follow up to the CLI control feature in #236. With the `esphome-desktop` shell command now on PATH, typing it with no arguments was far too easy a way to start a second app instance; a second launch runs a full startup before single-instance forwards it. A bare invocation attached to a terminal now prints the command list instead of launching. Desktop launches (Finder, applications menu, autostart, the open fallback's detached spawn) have no controlling terminal and start the app as before, and explicit launch flags like `--no-open-dashboard` still launch.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- follows up on #236

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).
