### PR TITLE
Add a versioned JSON api for device-builder update integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,10 @@ confirmation, so an unattended remote builder always comes back on its own even
 with no one at the keyboard. Trigger it detached (e.g. Python
 `Popen([...], start_new_session=True)`) and poll `check-update`/`status`
 afterward; the update completes in the app even if the caller is torn down when
-the backend restarts.
+the backend restarts. Unlike the human `status --json`, `api` commands other
+than `version` require a running app; when it is down they emit
+`{"type":"err","code":"not_running",...}` and exit 3 rather than an offline
+summary (the backend only calls the API while the app is up).
 
 On Linux the deb/rpm/AUR packages put `esphome-desktop` on your `PATH`. On
 macOS the app installs the command on launch, as a small launcher in

--- a/README.md
+++ b/README.md
@@ -83,6 +83,33 @@ is not running, and `status` prints the config and log directory paths.
 Running `esphome-desktop` with no arguments in a terminal prints this command
 list instead of launching another app instance; use `open` to start the app.
 
+### Device-builder integration API
+
+The ESPHome Device Builder dashboard (the backend the app runs) can show an
+"update available" banner and trigger the update itself through a stable,
+versioned JSON interface, separate from the human commands above so their
+wording can change without breaking the dashboard. The app sets
+`ESPHOME_DESKTOP_BIN` in the backend's environment, pointing at the CLI to call:
+
+```bash
+esphome-desktop api version        # {"schema_version":1} (no running app needed)
+esphome-desktop api check-update   # one JSON line: per-component update availability
+esphome-desktop api update         # trigger the full update; streams JSON, then a terminal line
+esphome-desktop api status         # status as one JSON object
+```
+
+Every `api` command prints newline-delimited JSON only, one object per line,
+valid JSON even on error (`{"type":"err","code":"not_running",...}`). Gate on
+`schema_version` before using the others. `check-update` returns
+`{"any_available":bool,"app":{...},"esphome":{...},"device_builder":{...}}` where
+each component carries `available`, `installed`, `latest`, and `error`. `update`
+is fully non-interactive; it stops and restarts the backend without any
+confirmation, so an unattended remote builder always comes back on its own even
+with no one at the keyboard. Trigger it detached (e.g. Python
+`Popen([...], start_new_session=True)`) and poll `check-update`/`status`
+afterward; the update completes in the app even if the caller is torn down when
+the backend restarts.
+
 On Linux the deb/rpm/AUR packages put `esphome-desktop` on your `PATH`. On
 macOS the app installs the command on launch, as a small launcher in
 `/opt/homebrew/bin` or `/usr/local/bin` when one is writable; it removes

--- a/README.md
+++ b/README.md
@@ -101,8 +101,9 @@ esphome-desktop api status         # status as one JSON object
 Every `api` command prints newline-delimited JSON only, one object per line,
 valid JSON even on error (`{"type":"err","code":"not_running",...}`). Gate on
 `schema_version` before using the others. `check-update` returns
-`{"any_available":bool,"app":{...},"esphome":{...},"device_builder":{...}}` where
-each component carries `available`, `installed`, `latest`, and `error`. `update`
+`{"type":"update_check","any_available":bool,"app":{...},"esphome":{...},"device_builder":{...}}`
+where each component carries `available`, `installed`, `latest`, and `error`;
+route on the `type` field, which every reply line carries. `update`
 is fully non-interactive; it stops and restarts the backend without any
 confirmation, so an unattended remote builder always comes back on its own even
 with no one at the keyboard. Trigger it detached (e.g. Python

--- a/README.md
+++ b/README.md
@@ -103,8 +103,9 @@ valid JSON even on error (`{"type":"err","code":"not_running",...}`). Gate on
 `schema_version` before using the others. `check-update` returns
 `{"type":"update_check","any_available":bool,"app":{...},"esphome":{...},"device_builder":{...}}`
 where each component carries `available`, `installed`, `latest`, and `error`;
-route on the `type` field, which every reply line carries. `update`
-is fully non-interactive; it stops and restarts the backend without any
+route on the `type` field, which every server reply carries (the one exception
+is `version`, a local handshake that prints only `{"schema_version":N}`).
+`update` is fully non-interactive; it stops and restarts the backend without any
 confirmation, so an unattended remote builder always comes back on its own even
 with no one at the keyboard. Trigger it detached (e.g. Python
 `Popen([...], start_new_session=True)`) and poll `check-update`/`status`

--- a/src-tauri/src/control/client.rs
+++ b/src-tauri/src/control/client.rs
@@ -14,6 +14,8 @@ use super::protocol::{
 };
 use crate::{ApiMethod, CliCommand, OnOff};
 
+/// The operation succeeded.
+const EXIT_SUCCESS: u8 = 0;
 /// The operation ran and failed.
 const EXIT_FAILED: u8 = 1;
 /// The app is not running (or the control channel is unreachable).
@@ -560,13 +562,15 @@ fn api(method: ApiMethod) -> ExitCode {
         // without any consent, so an unattended remote builder recovers itself.
         ApiMethod::Update => (Request::Update, UPDATE_TIMEOUT),
     };
-    api_stream(&request, timeout)
+    // The stream helpers work in raw exit codes so they stay unit-testable
+    // (ExitCode is opaque); wrap once here at the boundary.
+    ExitCode::from(api_stream(&request, timeout))
 }
 
 /// Connect, send one request, and echo each server reply line verbatim (already
 /// JSON) until the terminal reply or EOF. The exit code mirrors the terminal
 /// reply for shell callers; the JSON line is authoritative for the dashboard.
-fn api_stream(request: &Request, timeout: Duration) -> ExitCode {
+fn api_stream(request: &Request, timeout: Duration) -> u8 {
     let mut stream = match connect() {
         Ok(stream) => stream,
         Err(ConnectError::NotRunning) => {
@@ -591,7 +595,8 @@ fn api_stream(request: &Request, timeout: Duration) -> ExitCode {
 }
 
 /// Drain reply lines, echoing each raw JSON line, until a terminal reply.
-fn api_read<R: BufRead>(mut reader: R) -> ExitCode {
+/// Returns the exit code the terminal reply maps to.
+fn api_read<R: BufRead>(mut reader: R) -> u8 {
     let mut saw_restart_marker = false;
     let mut line = String::new();
     loop {
@@ -601,7 +606,7 @@ fn api_read<R: BufRead>(mut reader: R) -> ExitCode {
                 // A desktop self-update relaunch tears the connection down right
                 // after its terminal `ok`; the marker tells us that's success.
                 return if saw_restart_marker {
-                    ExitCode::SUCCESS
+                    EXIT_SUCCESS
                 } else {
                     api_err_line(
                         "connection_closed",
@@ -638,12 +643,12 @@ fn api_read<R: BufRead>(mut reader: R) -> ExitCode {
                 }
             }
             Ok(Reply::Ok { .. }) | Ok(Reply::Status(_)) | Ok(Reply::UpdateCheck(_)) => {
-                return ExitCode::SUCCESS
+                return EXIT_SUCCESS
             }
             Ok(Reply::Err { code, .. }) => {
                 return match code {
-                    ErrCode::Busy => ExitCode::from(EXIT_BUSY),
-                    ErrCode::Failed => ExitCode::from(EXIT_FAILED),
+                    ErrCode::Busy => EXIT_BUSY,
+                    ErrCode::Failed => EXIT_FAILED,
                 }
             }
             // A line we can't classify was still echoed; keep reading for the
@@ -656,13 +661,13 @@ fn api_read<R: BufRead>(mut reader: R) -> ExitCode {
 /// Print a synthesized client-side error as one JSON line and return `exit`.
 /// Client-only `code`s (`not_running`, `timeout`, ...) sit alongside the
 /// server's `busy`/`failed`; the dashboard treats `code` as an opaque string.
-fn api_err_line(code: &str, message: &str, exit: u8) -> ExitCode {
+fn api_err_line(code: &str, message: &str, exit: u8) -> u8 {
     print_json(&serde_json::json!({
         "type": "err",
         "code": code,
         "message": message,
     }));
-    ExitCode::from(exit)
+    exit
 }
 
 /// Print a JSON value as one line on stdout.
@@ -873,6 +878,70 @@ mod tests {
     #[test]
     fn garbage_reply_is_a_failure() {
         assert!(matches!(outcome_for("not json\n"), Outcome::Failed(_)));
+    }
+
+    fn api_exit_for(lines: &str) -> u8 {
+        api_read(Cursor::new(lines.as_bytes().to_vec()))
+    }
+
+    #[test]
+    fn api_ok_after_progress_exits_success() {
+        let exit = api_exit_for(
+            "{\"type\":\"progress\",\"step\":\"esphome\",\"detail\":\"installing\"}\n\
+             {\"type\":\"ok\",\"message\":\"done\"}\n",
+        );
+        assert_eq!(exit, EXIT_SUCCESS);
+    }
+
+    #[test]
+    fn api_update_check_reply_exits_success() {
+        let raw = serde_json::to_string(&Reply::UpdateCheck(Box::new(
+            crate::control::protocol::UpdateCheckReply {
+                any_available: false,
+                app: crate::control::protocol::ComponentUpdate::not_installed(),
+                esphome: crate::control::protocol::ComponentUpdate::not_installed(),
+                device_builder: crate::control::protocol::ComponentUpdate::not_installed(),
+            },
+        )))
+        .unwrap();
+        assert_eq!(api_exit_for(&format!("{raw}\n")), EXIT_SUCCESS);
+    }
+
+    #[test]
+    fn api_busy_and_failed_map_to_their_exit_codes() {
+        assert_eq!(
+            api_exit_for("{\"type\":\"err\",\"message\":\"busy\",\"code\":\"busy\"}\n"),
+            EXIT_BUSY
+        );
+        assert_eq!(
+            api_exit_for("{\"type\":\"err\",\"message\":\"boom\",\"code\":\"failed\"}\n"),
+            EXIT_FAILED
+        );
+    }
+
+    #[test]
+    fn api_eof_after_restart_marker_is_success() {
+        // The load-bearing case for unattended builders: the self-update
+        // relaunch closes the connection after the marker, which is success.
+        let exit = api_exit_for(
+            "{\"type\":\"progress\",\"step\":\"app_restarting\",\"detail\":\"restarting\"}\n",
+        );
+        assert_eq!(exit, EXIT_SUCCESS);
+    }
+
+    #[test]
+    fn api_eof_without_terminal_reply_is_a_failure() {
+        let exit =
+            api_exit_for("{\"type\":\"progress\",\"step\":\"stop\",\"detail\":\"stopping\"}\n");
+        assert_eq!(exit, EXIT_FAILED);
+    }
+
+    #[test]
+    fn api_unclassifiable_line_does_not_end_the_stream() {
+        // A line api_read can't parse is echoed, not terminal; the following
+        // ok still decides the exit code.
+        let exit = api_exit_for("not json\n{\"type\":\"ok\",\"message\":\"done\"}\n");
+        assert_eq!(exit, EXIT_SUCCESS);
     }
 
     #[test]

--- a/src-tauri/src/control/client.rs
+++ b/src-tauri/src/control/client.rs
@@ -413,12 +413,8 @@ fn app_launch_command() -> Result<std::process::Command, String> {
     }
 
     #[cfg(target_os = "linux")]
-    {
-        if let Some(appimage) = std::env::var_os("APPIMAGE") {
-            if !appimage.is_empty() {
-                return Ok(std::process::Command::new(appimage));
-            }
-        }
+    if let Some(appimage) = super::appimage_path() {
+        return Ok(std::process::Command::new(appimage));
     }
 
     Ok(std::process::Command::new(exe))
@@ -551,9 +547,10 @@ fn api(method: ApiMethod) -> ExitCode {
         // Pure handshake: answer even while the app is starting (or absent), so
         // the dashboard can gate on the version before making any other call.
         ApiMethod::Version => {
-            print_json(&serde_json::json!({
-                "schema_version": protocol::API_SCHEMA_VERSION,
-            }));
+            println!(
+                "{}",
+                serde_json::json!({ "schema_version": protocol::API_SCHEMA_VERSION })
+            );
             return ExitCode::SUCCESS;
         }
         ApiMethod::Status => (Request::Status, DEFAULT_TIMEOUT),
@@ -662,17 +659,11 @@ fn api_read<R: BufRead>(mut reader: R) -> u8 {
 /// Client-only `code`s (`not_running`, `timeout`, ...) sit alongside the
 /// server's `busy`/`failed`; the dashboard treats `code` as an opaque string.
 fn api_err_line(code: &str, message: &str, exit: u8) -> u8 {
-    print_json(&serde_json::json!({
-        "type": "err",
-        "code": code,
-        "message": message,
-    }));
+    println!(
+        "{}",
+        serde_json::json!({ "type": "err", "code": code, "message": message })
+    );
     exit
-}
-
-/// Print a JSON value as one line on stdout.
-fn print_json(value: &serde_json::Value) {
-    println!("{value}");
 }
 
 /// `logs`: print/tail the dashboard log, or open the logs folder. Fully

--- a/src-tauri/src/control/client.rs
+++ b/src-tauri/src/control/client.rs
@@ -564,9 +564,10 @@ fn api(method: ApiMethod) -> ExitCode {
     ExitCode::from(api_stream(&request, timeout))
 }
 
-/// Connect, send one request, and echo each server reply line verbatim (already
-/// JSON) until the terminal reply or EOF. The exit code mirrors the terminal
-/// reply for shell callers; the JSON line is authoritative for the dashboard.
+/// Connect, send one request, and forward each server reply as a validated JSON
+/// line (trimmed of surrounding whitespace) until the terminal reply or EOF. The
+/// exit code mirrors the terminal reply for shell callers; the JSON line is
+/// authoritative for the dashboard.
 fn api_stream(request: &Request, timeout: Duration) -> u8 {
     let mut stream = match connect() {
         Ok(stream) => stream,
@@ -591,7 +592,7 @@ fn api_stream(request: &Request, timeout: Duration) -> u8 {
     api_read(reply_reader(stream, timeout))
 }
 
-/// Drain reply lines, echoing each raw JSON line, until a terminal reply.
+/// Drain reply lines, forwarding each validated JSON line, until a terminal reply.
 /// Returns the exit code the terminal reply maps to.
 fn api_read<R: BufRead>(mut reader: R) -> u8 {
     let mut saw_restart_marker = false;

--- a/src-tauri/src/control/client.rs
+++ b/src-tauri/src/control/client.rs
@@ -631,28 +631,54 @@ fn api_read<R: BufRead>(mut reader: R) -> u8 {
         if trimmed.is_empty() {
             continue;
         }
-        // Echo the server's JSON exactly so the dashboard sees the real schema.
-        println!("{trimmed}");
+        // Parse before echoing: the `api` contract is NDJSON-only, so a line
+        // that is not valid JSON must never reach stdout (it would break a
+        // dashboard doing `json.loads` per line). A recognized Reply is echoed
+        // and dispatched; a line that is valid JSON but not a known Reply is
+        // still echoed (forward-compatible with a newer server) and we keep
+        // reading; anything else is a protocol violation we surface as a
+        // synthesized JSON error and stop.
         match serde_json::from_str::<Reply>(trimmed) {
             Ok(Reply::Progress { step, .. }) => {
+                echo_json_line(trimmed);
                 if step == STEP_APP_RESTARTING {
                     saw_restart_marker = true;
                 }
             }
             Ok(Reply::Ok { .. }) | Ok(Reply::Status(_)) | Ok(Reply::UpdateCheck(_)) => {
-                return EXIT_SUCCESS
+                echo_json_line(trimmed);
+                return EXIT_SUCCESS;
             }
             Ok(Reply::Err { code, .. }) => {
+                echo_json_line(trimmed);
                 return match code {
                     ErrCode::Busy => EXIT_BUSY,
                     ErrCode::Failed => EXIT_FAILED,
-                }
+                };
             }
-            // A line we can't classify was still echoed; keep reading for the
-            // terminal reply (or let EOF decide).
-            Err(_) => {}
+            Err(_) if serde_json::from_str::<serde_json::Value>(trimmed).is_ok() => {
+                // Valid JSON, just not a Reply we recognize: still NDJSON, so
+                // echo it and keep reading for the terminal reply.
+                echo_json_line(trimmed);
+            }
+            Err(_) => {
+                return api_err_line(
+                    "protocol_error",
+                    "the app sent a line that was not valid JSON",
+                    EXIT_FAILED,
+                )
+            }
         }
     }
+}
+
+/// Print one already-validated JSON line and flush, so a dashboard consuming
+/// this process's stdout as a pipe sees each progress line promptly rather than
+/// only when the OS buffer fills.
+fn echo_json_line(line: &str) {
+    let mut out = std::io::stdout();
+    let _ = writeln!(out, "{line}");
+    let _ = out.flush();
 }
 
 /// Print a synthesized client-side error as one JSON line and return `exit`.
@@ -928,10 +954,20 @@ mod tests {
     }
 
     #[test]
-    fn api_unclassifiable_line_does_not_end_the_stream() {
-        // A line api_read can't parse is echoed, not terminal; the following
-        // ok still decides the exit code.
+    fn api_non_json_line_is_a_protocol_error() {
+        // The `api` contract is NDJSON-only: a line that isn't valid JSON must
+        // not be echoed as-is (it would break a per-line `json.loads`); it ends
+        // the stream with a synthesized JSON error instead.
         let exit = api_exit_for("not json\n{\"type\":\"ok\",\"message\":\"done\"}\n");
+        assert_eq!(exit, EXIT_FAILED);
+    }
+
+    #[test]
+    fn api_unknown_json_variant_is_echoed_and_stream_continues() {
+        // A line that is valid JSON but not a Reply we recognize (e.g. a newer
+        // server variant) is still NDJSON, so it's forwarded and the following
+        // terminal reply still decides the exit code.
+        let exit = api_exit_for("{\"type\":\"future\"}\n{\"type\":\"ok\",\"message\":\"done\"}\n");
         assert_eq!(exit, EXIT_SUCCESS);
     }
 

--- a/src-tauri/src/control/client.rs
+++ b/src-tauri/src/control/client.rs
@@ -10,9 +10,9 @@ use std::process::ExitCode;
 use std::time::Duration;
 
 use super::protocol::{
-    backend_name, channel_name, ErrCode, Reply, Request, StatusReply, STEP_APP_RESTARTING,
+    self, backend_name, channel_name, ErrCode, Reply, Request, StatusReply, STEP_APP_RESTARTING,
 };
-use crate::{CliCommand, OnOff};
+use crate::{ApiMethod, CliCommand, OnOff};
 
 /// The operation ran and failed.
 const EXIT_FAILED: u8 = 1;
@@ -27,6 +27,9 @@ const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
 const RESTART_TIMEOUT: Duration = Duration::from_secs(180);
 /// Switches and updates download and pip-install packages.
 const UPDATE_TIMEOUT: Duration = Duration::from_secs(600);
+/// `check-update` hits GitHub and PyPI and spawns Python for the installed
+/// versions; more headroom than a local request, far less than an install.
+const CHECK_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// Lines shown by the default (non-follow) `logs` tail.
 const TAIL_LINES: usize = 50;
@@ -70,6 +73,7 @@ pub(crate) fn run(command: CliCommand) -> ExitCode {
         CliCommand::Restart => simple(Request::Restart, RESTART_TIMEOUT),
         CliCommand::Quit => simple(Request::Quit, DEFAULT_TIMEOUT),
         CliCommand::Status { json } => status_cmd(json),
+        CliCommand::Api(method) => api(method),
     }
 }
 
@@ -210,6 +214,11 @@ fn read_replies<R: BufRead>(mut reader: R) -> Outcome {
                 }
             }
             Ok(Reply::Status(reply)) => return Outcome::Status(reply),
+            // No human subcommand requests a check; it only arrives via `api`,
+            // which reads replies on its own path.
+            Ok(Reply::UpdateCheck(_)) => {
+                return Outcome::Failed("unexpected update-check reply".to_string())
+            }
             Err(e) => return Outcome::Failed(format!("could not parse server reply: {e}")),
         }
     }
@@ -529,6 +538,136 @@ fn offline_status(json: bool) -> ExitCode {
         }
     }
     ExitCode::from(EXIT_NOT_RUNNING)
+}
+
+/// `api <method>`: the machine-readable contract the device-builder dashboard
+/// codes against. Emits newline-delimited JSON only — one object per line, on
+/// stdout, valid JSON even for errors — so the human CLI's wording stays free
+/// to change. Versioned via [`protocol::API_SCHEMA_VERSION`].
+fn api(method: ApiMethod) -> ExitCode {
+    let (request, timeout) = match method {
+        // Pure handshake: answer even while the app is starting (or absent), so
+        // the dashboard can gate on the version before making any other call.
+        ApiMethod::Version => {
+            print_json(&serde_json::json!({
+                "schema_version": protocol::API_SCHEMA_VERSION,
+            }));
+            return ExitCode::SUCCESS;
+        }
+        ApiMethod::Status => (Request::Status, DEFAULT_TIMEOUT),
+        ApiMethod::CheckUpdate => (Request::CheckUpdate, CHECK_TIMEOUT),
+        // Non-interactive by construction: the server restarts the backend
+        // without any consent, so an unattended remote builder recovers itself.
+        ApiMethod::Update => (Request::Update, UPDATE_TIMEOUT),
+    };
+    api_stream(&request, timeout)
+}
+
+/// Connect, send one request, and echo each server reply line verbatim (already
+/// JSON) until the terminal reply or EOF. The exit code mirrors the terminal
+/// reply for shell callers; the JSON line is authoritative for the dashboard.
+fn api_stream(request: &Request, timeout: Duration) -> ExitCode {
+    let mut stream = match connect() {
+        Ok(stream) => stream,
+        Err(ConnectError::NotRunning) => {
+            return api_err_line("not_running", "the app is not running", EXIT_NOT_RUNNING)
+        }
+        Err(ConnectError::BadPath(message)) => {
+            return api_err_line("bad_path", &message, EXIT_FAILED)
+        }
+    };
+    let mut line = match serde_json::to_string(request) {
+        Ok(line) => line,
+        Err(e) => return api_err_line("encode_failed", &e.to_string(), EXIT_FAILED),
+    };
+    line.push('\n');
+    if let Err(e) = stream
+        .write_all(line.as_bytes())
+        .and_then(|()| stream.flush())
+    {
+        return api_err_line("send_failed", &e.to_string(), EXIT_FAILED);
+    }
+    api_read(reply_reader(stream, timeout))
+}
+
+/// Drain reply lines, echoing each raw JSON line, until a terminal reply.
+fn api_read<R: BufRead>(mut reader: R) -> ExitCode {
+    let mut saw_restart_marker = false;
+    let mut line = String::new();
+    loop {
+        line.clear();
+        match reader.read_line(&mut line) {
+            Ok(0) => {
+                // A desktop self-update relaunch tears the connection down right
+                // after its terminal `ok`; the marker tells us that's success.
+                return if saw_restart_marker {
+                    ExitCode::SUCCESS
+                } else {
+                    api_err_line(
+                        "connection_closed",
+                        "connection closed before the operation finished",
+                        EXIT_FAILED,
+                    )
+                };
+            }
+            Ok(_) => {}
+            Err(e)
+                if matches!(
+                    e.kind(),
+                    std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                ) =>
+            {
+                return api_err_line(
+                    "timeout",
+                    "timed out waiting for the app's reply; the operation may still be running",
+                    EXIT_FAILED,
+                )
+            }
+            Err(e) => return api_err_line("read_failed", &e.to_string(), EXIT_FAILED),
+        }
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        // Echo the server's JSON exactly so the dashboard sees the real schema.
+        println!("{trimmed}");
+        match serde_json::from_str::<Reply>(trimmed) {
+            Ok(Reply::Progress { step, .. }) => {
+                if step == STEP_APP_RESTARTING {
+                    saw_restart_marker = true;
+                }
+            }
+            Ok(Reply::Ok { .. }) | Ok(Reply::Status(_)) | Ok(Reply::UpdateCheck(_)) => {
+                return ExitCode::SUCCESS
+            }
+            Ok(Reply::Err { code, .. }) => {
+                return match code {
+                    ErrCode::Busy => ExitCode::from(EXIT_BUSY),
+                    ErrCode::Failed => ExitCode::from(EXIT_FAILED),
+                }
+            }
+            // A line we can't classify was still echoed; keep reading for the
+            // terminal reply (or let EOF decide).
+            Err(_) => {}
+        }
+    }
+}
+
+/// Print a synthesized client-side error as one JSON line and return `exit`.
+/// Client-only `code`s (`not_running`, `timeout`, ...) sit alongside the
+/// server's `busy`/`failed`; the dashboard treats `code` as an opaque string.
+fn api_err_line(code: &str, message: &str, exit: u8) -> ExitCode {
+    print_json(&serde_json::json!({
+        "type": "err",
+        "code": code,
+        "message": message,
+    }));
+    ExitCode::from(exit)
+}
+
+/// Print a JSON value as one line on stdout.
+fn print_json(value: &serde_json::Value) {
+    println!("{value}");
 }
 
 /// `logs`: print/tail the dashboard log, or open the logs folder. Fully

--- a/src-tauri/src/control/client.rs
+++ b/src-tauri/src/control/client.rs
@@ -633,41 +633,37 @@ fn api_read<R: BufRead>(mut reader: R) -> u8 {
         }
         // Parse before echoing: the `api` contract is NDJSON-only, so a line
         // that is not valid JSON must never reach stdout (it would break a
-        // dashboard doing `json.loads` per line). A recognized Reply is echoed
-        // and dispatched; a line that is valid JSON but not a known Reply is
-        // still echoed (forward-compatible with a newer server) and we keep
-        // reading; anything else is a protocol violation we surface as a
-        // synthesized JSON error and stop.
-        match serde_json::from_str::<Reply>(trimmed) {
+        // dashboard doing `json.loads` per line). Guard that case up front, then
+        // echo exactly once for every valid-JSON line.
+        let reply = serde_json::from_str::<Reply>(trimmed);
+        if reply.is_err() && serde_json::from_str::<serde_json::Value>(trimmed).is_err() {
+            return api_err_line(
+                "protocol_error",
+                "the app sent a line that was not valid JSON",
+                EXIT_FAILED,
+            );
+        }
+        echo_json_line(trimmed);
+        match reply {
+            Ok(Reply::Ok { .. }) | Ok(Reply::Status(_)) | Ok(Reply::UpdateCheck(_)) => {
+                return EXIT_SUCCESS
+            }
+            Ok(Reply::Err { code, .. }) => {
+                return match code {
+                    ErrCode::Busy => EXIT_BUSY,
+                    ErrCode::Failed => EXIT_FAILED,
+                }
+            }
             Ok(Reply::Progress { step, .. }) => {
-                echo_json_line(trimmed);
                 if step == STEP_APP_RESTARTING {
                     saw_restart_marker = true;
                 }
             }
-            Ok(Reply::Ok { .. }) | Ok(Reply::Status(_)) | Ok(Reply::UpdateCheck(_)) => {
-                echo_json_line(trimmed);
-                return EXIT_SUCCESS;
-            }
-            Ok(Reply::Err { code, .. }) => {
-                echo_json_line(trimmed);
-                return match code {
-                    ErrCode::Busy => EXIT_BUSY,
-                    ErrCode::Failed => EXIT_FAILED,
-                };
-            }
-            Err(_) if serde_json::from_str::<serde_json::Value>(trimmed).is_ok() => {
-                // Valid JSON, just not a Reply we recognize: still NDJSON, so
-                // echo it and keep reading for the terminal reply.
-                echo_json_line(trimmed);
-            }
-            Err(_) => {
-                return api_err_line(
-                    "protocol_error",
-                    "the app sent a line that was not valid JSON",
-                    EXIT_FAILED,
-                )
-            }
+            // Valid JSON, just not a Reply we recognize: already echoed (still
+            // NDJSON); keep reading for the terminal reply. This is defensive —
+            // the client and app are the same binary, so their reply shapes
+            // always match — but it keeps a stray line from ending the stream.
+            Err(_) => {}
         }
     }
 }

--- a/src-tauri/src/control/mod.rs
+++ b/src-tauri/src/control/mod.rs
@@ -11,27 +11,35 @@ pub mod ops;
 pub mod protocol;
 pub mod server;
 
-/// Absolute path used to invoke the `esphome-desktop` CLI (its own `api`
-/// subcommands). Handed to the device-builder child as `ESPHOME_DESKTOP_BIN` so
-/// the dashboard can query and trigger updates through the stable `api`
-/// interface without guessing where the binary lives.
-///
-/// On Linux under an AppImage the stable path is `$APPIMAGE`; `current_exe`
-/// there points inside the FUSE mount, which is unmounted once the process that
-/// owns it exits, so a path derived from it can't be re-run later. On
-/// macOS/Windows `current_exe` is the bundle's own binary, which dispatches
-/// subcommands directly (the same binary the macOS PATH wrapper execs).
-pub(crate) fn cli_invocation_path() -> Option<std::path::PathBuf> {
+/// The running AppImage's own path from `$APPIMAGE`, if set and non-empty.
+/// `current_exe` is unusable under an AppImage: it points inside the FUSE
+/// mount, which is unmounted once the process that owns it exits, so a path
+/// derived from it can't be re-run later. Linux-only; `None` elsewhere (there
+/// `current_exe` is the real binary).
+pub(crate) fn appimage_path() -> Option<std::path::PathBuf> {
     #[cfg(target_os = "linux")]
     if let Some(appimage) = std::env::var_os("APPIMAGE") {
         let path = std::path::PathBuf::from(appimage);
         if !path.as_os_str().is_empty() {
-            // `$APPIMAGE` is normally absolute, but canonicalize defensively so
-            // a relative value (rare wrapper launches) still resolves after the
-            // backend changes its working directory; fall back to the raw path
-            // if canonicalization fails.
-            return Some(std::fs::canonicalize(&path).unwrap_or(path));
+            return Some(path);
         }
+    }
+    None
+}
+
+/// Absolute path used to invoke the `esphome-desktop` CLI (its own `api`
+/// subcommands). Handed to the device-builder child as `ESPHOME_DESKTOP_BIN` so
+/// the dashboard can query and trigger updates through the stable `api`
+/// interface without guessing where the binary lives. On macOS/Windows
+/// `current_exe` is the bundle's own binary, which dispatches subcommands
+/// directly (the same binary the macOS PATH wrapper execs).
+pub(crate) fn cli_invocation_path() -> Option<std::path::PathBuf> {
+    if let Some(path) = appimage_path() {
+        // `$APPIMAGE` is normally absolute, but canonicalize defensively so a
+        // relative value (rare wrapper launches) still resolves after the
+        // backend changes its working directory; fall back to the raw path if
+        // canonicalization fails.
+        return Some(std::fs::canonicalize(&path).unwrap_or(path));
     }
     std::env::current_exe().ok()
 }

--- a/src-tauri/src/control/mod.rs
+++ b/src-tauri/src/control/mod.rs
@@ -10,3 +10,23 @@ pub mod client;
 pub mod ops;
 pub mod protocol;
 pub mod server;
+
+/// Absolute path used to invoke the `esphome-desktop` CLI (its own `api`
+/// subcommands). Handed to the device-builder child as `ESPHOME_DESKTOP_BIN` so
+/// the dashboard can query and trigger updates through the stable `api`
+/// interface without guessing where the binary lives.
+///
+/// On Linux under an AppImage the stable path is `$APPIMAGE`; `current_exe`
+/// there points inside the FUSE mount, which is unmounted once the process that
+/// owns it exits, so a path derived from it can't be re-run later. On
+/// macOS/Windows `current_exe` is the bundle's own binary, which dispatches
+/// subcommands directly (the same binary the macOS PATH wrapper execs).
+pub(crate) fn cli_invocation_path() -> Option<std::path::PathBuf> {
+    #[cfg(target_os = "linux")]
+    if let Some(appimage) = std::env::var_os("APPIMAGE") {
+        if !appimage.is_empty() {
+            return Some(std::path::PathBuf::from(appimage));
+        }
+    }
+    std::env::current_exe().ok()
+}

--- a/src-tauri/src/control/mod.rs
+++ b/src-tauri/src/control/mod.rs
@@ -24,8 +24,13 @@ pub mod server;
 pub(crate) fn cli_invocation_path() -> Option<std::path::PathBuf> {
     #[cfg(target_os = "linux")]
     if let Some(appimage) = std::env::var_os("APPIMAGE") {
-        if !appimage.is_empty() {
-            return Some(std::path::PathBuf::from(appimage));
+        let path = std::path::PathBuf::from(appimage);
+        if !path.as_os_str().is_empty() {
+            // `$APPIMAGE` is normally absolute, but canonicalize defensively so
+            // a relative value (rare wrapper launches) still resolves after the
+            // backend changes its working directory; fall back to the raw path
+            // if canonicalization fails.
+            return Some(std::fs::canonicalize(&path).unwrap_or(path));
         }
     }
     std::env::current_exe().ok()

--- a/src-tauri/src/control/mod.rs
+++ b/src-tauri/src/control/mod.rs
@@ -33,13 +33,23 @@ pub(crate) fn appimage_path() -> Option<std::path::PathBuf> {
 /// interface without guessing where the binary lives. On macOS/Windows
 /// `current_exe` is the bundle's own binary, which dispatches subcommands
 /// directly (the same binary the macOS PATH wrapper execs).
+///
+/// The result is always absolute: the backend changes its working directory, so
+/// a relative path would be unusable there. `$APPIMAGE` is normally absolute,
+/// but if it is relative it is canonicalized; should that fail and leave a
+/// relative path, this falls back to `current_exe` rather than export a
+/// cwd-relative value.
 pub(crate) fn cli_invocation_path() -> Option<std::path::PathBuf> {
     if let Some(path) = appimage_path() {
-        // `$APPIMAGE` is normally absolute, but canonicalize defensively so a
-        // relative value (rare wrapper launches) still resolves after the
-        // backend changes its working directory; fall back to the raw path if
-        // canonicalization fails.
-        return Some(std::fs::canonicalize(&path).unwrap_or(path));
+        match std::fs::canonicalize(&path) {
+            Ok(absolute) => return Some(absolute),
+            // Canonicalization failed, but the raw value is already absolute and
+            // thus still usable from any working directory.
+            Err(_) if path.is_absolute() => return Some(path),
+            // Relative and unresolvable: fall through to the always-absolute
+            // current_exe rather than hand the backend a path it can't re-run.
+            Err(_) => {}
+        }
     }
     std::env::current_exe().ok()
 }

--- a/src-tauri/src/control/ops.rs
+++ b/src-tauri/src/control/ops.rs
@@ -15,6 +15,7 @@ use tauri_plugin_autostart::ManagerExt;
 use tauri_plugin_updater::UpdaterExt;
 use tracing::{error, info, warn};
 
+use super::protocol::ComponentUpdate;
 use crate::settings::ReleaseChannel;
 use crate::{tray, AppState};
 
@@ -343,6 +344,72 @@ where
     match tokio::task::spawn_blocking(move || f(&app)).await {
         Ok(result) => result.map_err(|e| e.to_string()),
         Err(join) => Err(join.to_string()),
+    }
+}
+
+/// Whether `latest` is a newer version than `installed`, mapped onto the
+/// [`ComponentUpdate`] the check reply carries. The same `is_newer_version`
+/// gate the update sequences use, so the "available" flag never disagrees with
+/// what an actual `update` would install.
+fn compare(installed: String, latest: String) -> ComponentUpdate {
+    if crate::update::is_newer_version(&latest, &installed) {
+        ComponentUpdate::upgradable(installed, latest)
+    } else {
+        ComponentUpdate::current(installed, latest)
+    }
+}
+
+/// Whether a desktop app self-update is available, without installing it. Reads
+/// the same `updater().check()` the update flow uses, but only reports.
+pub(crate) async fn desktop_update_available(app: &AppHandle) -> ComponentUpdate {
+    let installed = app.package_info().version.to_string();
+    match app.updater() {
+        Ok(updater) => match updater.check().await {
+            Ok(Some(update)) => ComponentUpdate::upgradable(installed, update.version.clone()),
+            Ok(None) => ComponentUpdate::current(installed.clone(), installed),
+            Err(e) => ComponentUpdate::errored(Some(installed), e.to_string()),
+        },
+        Err(e) => ComponentUpdate::errored(Some(installed), e.to_string()),
+    }
+}
+
+/// Whether an ESPHome package update is available, without installing it.
+pub(crate) async fn esphome_update_available(
+    app: &AppHandle,
+    state: &Arc<AppState>,
+    channel: ReleaseChannel,
+) -> ComponentUpdate {
+    let installed = match detect(app, crate::update::get_installed_version).await {
+        Ok(v) => v,
+        Err(e) => return ComponentUpdate::errored(None, e),
+    };
+    // The dev channel has no version-based check: `update` always reinstalls the
+    // latest dev commit, so a passive check can't call it "newer". Report it as
+    // current so the dashboard banner doesn't nag on every dev build.
+    if channel == ReleaseChannel::Dev {
+        return ComponentUpdate::current(installed.clone(), installed);
+    }
+    match state.update_checker.check(channel).await {
+        Ok(Some(latest)) => compare(installed, latest),
+        Ok(None) => ComponentUpdate::current(installed.clone(), installed),
+        Err(e) => ComponentUpdate::errored(Some(installed), e.to_string()),
+    }
+}
+
+/// Whether a device-builder package update is available, without installing it.
+pub(crate) async fn device_builder_update_available(
+    app: &AppHandle,
+    state: &Arc<AppState>,
+    backend: crate::settings::Backend,
+) -> ComponentUpdate {
+    let installed = match detect(app, crate::update::get_installed_device_builder_version).await {
+        Ok(Some(v)) => v,
+        Ok(None) => return ComponentUpdate::not_installed(),
+        Err(e) => return ComponentUpdate::errored(None, e),
+    };
+    match state.update_checker.check_device_builder(backend).await {
+        Ok(latest) => compare(installed, latest),
+        Err(e) => ComponentUpdate::errored(Some(installed), e.to_string()),
     }
 }
 

--- a/src-tauri/src/control/ops.rs
+++ b/src-tauri/src/control/ops.rs
@@ -365,7 +365,7 @@ pub(crate) async fn desktop_update_available(app: &AppHandle) -> ComponentUpdate
     let installed = app.package_info().version.to_string();
     match app.updater() {
         Ok(updater) => match updater.check().await {
-            Ok(Some(update)) => ComponentUpdate::upgradable(installed, update.version.clone()),
+            Ok(Some(update)) => ComponentUpdate::upgradable(installed, update.version),
             Ok(None) => ComponentUpdate::current(installed.clone(), installed),
             Err(e) => ComponentUpdate::errored(Some(installed), e.to_string()),
         },

--- a/src-tauri/src/control/ops.rs
+++ b/src-tauri/src/control/ops.rs
@@ -379,8 +379,11 @@ pub(crate) async fn esphome_update_available(
     state: &Arc<AppState>,
     channel: ReleaseChannel,
 ) -> ComponentUpdate {
-    let installed = match detect(app, crate::update::get_installed_version).await {
-        Ok(v) => v,
+    let installed = match detect(app, crate::update::installed_esphome_version).await {
+        Ok(Some(v)) => v,
+        // ESPHome absent is a normal state ("nothing to update"), not an error —
+        // mirrors the device-builder not-installed path below.
+        Ok(None) => return ComponentUpdate::not_installed(),
         Err(e) => return ComponentUpdate::errored(None, e),
     };
     // The dev channel has no version-based check: `update` always reinstalls the

--- a/src-tauri/src/control/ops.rs
+++ b/src-tauri/src/control/ops.rs
@@ -348,9 +348,9 @@ where
 }
 
 /// Whether `latest` is a newer version than `installed`, mapped onto the
-/// [`ComponentUpdate`] the check reply carries. The same `is_newer_version`
-/// gate the update sequences use, so the "available" flag never disagrees with
-/// what an actual `update` would install.
+/// [`ComponentUpdate`] the check reply carries. Uses the same
+/// `is_newer_version` comparison the update sequences use, so the `available`
+/// flag never disagrees with what an actual `update` would install.
 fn compare(installed: String, latest: String) -> ComponentUpdate {
     if crate::update::is_newer_version(&latest, &installed) {
         ComponentUpdate::upgradable(installed, latest)

--- a/src-tauri/src/control/protocol.rs
+++ b/src-tauri/src/control/protocol.rs
@@ -20,9 +20,10 @@ pub const MAX_LINE_BYTES: usize = 64 * 1024;
 /// by `esphome-desktop api version`. The device-builder dashboard gates on this
 /// so we can evolve the human CLI freely.
 ///
-/// The `api` client echoes server replies verbatim, so the wire shapes of
-/// [`Reply`], [`StatusReply`], and [`UpdateCheckReply`] — their serde `type`
-/// tags and their fields — ARE this public contract, not merely internal types.
+/// The `api` client forwards each server reply as its own JSON line (only the
+/// surrounding whitespace is trimmed), so the wire shapes of [`Reply`],
+/// [`StatusReply`], and [`UpdateCheckReply`] — their serde `type` tags and their
+/// fields — ARE this public contract, not merely internal types.
 /// Renaming/removing a field or changing a tag on them is a breaking change to
 /// the dashboard and must bump this version. Do not refactor them casually.
 pub const API_SCHEMA_VERSION: u32 = 1;

--- a/src-tauri/src/control/protocol.rs
+++ b/src-tauri/src/control/protocol.rs
@@ -4,8 +4,8 @@
 //! Framing is newline-delimited JSON with one request per connection: the
 //! client sends a single [`Request`] line; the server replies with zero or
 //! more [`Reply::Progress`] lines followed by exactly one terminal reply
-//! ([`Reply::Ok`], [`Reply::Err`], or [`Reply::Status`]) and closes the
-//! connection.
+//! ([`Reply::Ok`], [`Reply::Err`], [`Reply::Status`], or
+//! [`Reply::UpdateCheck`]) and closes the connection.
 
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -15,6 +15,12 @@ use crate::settings::{Backend, ReleaseChannel};
 /// Upper bound on a single protocol line. Requests and replies are tiny; a
 /// line this long means a confused peer, not a real client.
 pub const MAX_LINE_BYTES: usize = 64 * 1024;
+
+/// Version of the machine-readable `esphome-desktop api ...` contract, reported
+/// by `esphome-desktop api version`. The device-builder dashboard gates on this
+/// so we can evolve the human CLI freely; bump it only on a breaking change to
+/// the `api` request/reply shapes.
+pub const API_SCHEMA_VERSION: u32 = 1;
 
 /// Name of the control pipe on Windows, where unix sockets are unavailable.
 #[cfg(windows)]
@@ -45,6 +51,9 @@ pub enum Request {
     SetStartup { enable: bool },
     /// Update the desktop app, ESPHome, and the device builder.
     Update,
+    /// Report whether an update is available for any component, without
+    /// installing anything.
+    CheckUpdate,
     /// Restart the dashboard backend.
     Restart,
     /// Quit the app.
@@ -75,6 +84,8 @@ pub enum Reply {
     Progress { step: String, detail: String },
     /// Terminal reply to [`Request::Status`].
     Status(Box<StatusReply>),
+    /// Terminal reply to [`Request::CheckUpdate`].
+    UpdateCheck(Box<UpdateCheckReply>),
 }
 
 impl Reply {
@@ -109,6 +120,79 @@ pub struct StatusReply {
     pub launch_at_startup: bool,
     pub config_dir: PathBuf,
     pub logs_dir: PathBuf,
+}
+
+/// Availability of an update for one component, returned inside
+/// [`UpdateCheckReply`]. A failed check is reported as `error` (with
+/// `available = false`) rather than sinking the whole reply, so one flaky
+/// network call doesn't blind the dashboard to the other components.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ComponentUpdate {
+    /// A newer version than the installed one is available.
+    pub available: bool,
+    /// The currently installed version, if known (`None` when not installed).
+    pub installed: Option<String>,
+    /// The newest available version, if the check succeeded.
+    pub latest: Option<String>,
+    /// Why the check could not complete, if it failed.
+    pub error: Option<String>,
+}
+
+impl ComponentUpdate {
+    /// Installed and current: `latest` is the newest known version (equal to
+    /// `installed` when nothing newer exists).
+    pub fn current(installed: String, latest: String) -> Self {
+        Self {
+            available: false,
+            installed: Some(installed),
+            latest: Some(latest),
+            error: None,
+        }
+    }
+
+    /// A newer version is available.
+    pub fn upgradable(installed: String, latest: String) -> Self {
+        Self {
+            available: true,
+            installed: Some(installed),
+            latest: Some(latest),
+            error: None,
+        }
+    }
+
+    /// The component is not installed; nothing to update.
+    pub fn not_installed() -> Self {
+        Self {
+            available: false,
+            installed: None,
+            latest: None,
+            error: None,
+        }
+    }
+
+    /// The check itself failed.
+    pub fn errored(installed: Option<String>, error: String) -> Self {
+        Self {
+            available: false,
+            installed,
+            latest: None,
+            error: Some(error),
+        }
+    }
+}
+
+/// Terminal reply to [`Request::CheckUpdate`]: per-component update
+/// availability plus a top-level convenience flag.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct UpdateCheckReply {
+    /// True when any component has an update available; the banner trigger.
+    pub any_available: bool,
+    /// The desktop app itself (Tauri self-update from GitHub Releases).
+    pub app: ComponentUpdate,
+    /// The ESPHome Python package.
+    pub esphome: ComponentUpdate,
+    /// The `esphome-device-builder` package (the dashboard backend).
+    pub device_builder: ComponentUpdate,
 }
 
 /// Short lowercase channel name used on the CLI surface (matches the
@@ -199,6 +283,7 @@ mod tests {
             Request::GetStartup,
             Request::SetStartup { enable: false },
             Request::Update,
+            Request::CheckUpdate,
             Request::Restart,
             Request::Quit,
             Request::Status,
@@ -241,12 +326,38 @@ mod tests {
                 config_dir: PathBuf::from("/home/x/esphome"),
                 logs_dir: PathBuf::from("/home/x/.local/share/io.esphome.builder/logs"),
             })),
+            Reply::UpdateCheck(Box::new(UpdateCheckReply {
+                any_available: true,
+                app: ComponentUpdate::upgradable("0.13.0".into(), "0.14.0".into()),
+                esphome: ComponentUpdate::current("2026.6.2".into(), "2026.6.2".into()),
+                device_builder: ComponentUpdate::not_installed(),
+            })),
         ];
         for reply in replies {
             let line = serde_json::to_string(&reply).expect("serialize");
             let back: Reply = serde_json::from_str(&line).expect("deserialize");
             assert_eq!(back, reply, "line: {line}");
         }
+    }
+
+    #[test]
+    fn update_check_reply_shape() {
+        let reply = Reply::UpdateCheck(Box::new(UpdateCheckReply {
+            any_available: false,
+            app: ComponentUpdate::current("0.13.0".into(), "0.13.0".into()),
+            esphome: ComponentUpdate::errored(Some("2026.6.2".into()), "network down".into()),
+            device_builder: ComponentUpdate::not_installed(),
+        }));
+        let value = serde_json::to_value(&reply).expect("serialize");
+        // The type tag lets the dashboard route the line; the error rides
+        // alongside `available:false` instead of failing the whole reply.
+        assert_eq!(value["type"], "update_check");
+        assert_eq!(value["esphome"]["available"], false);
+        assert_eq!(value["esphome"]["error"], "network down");
+        assert_eq!(
+            value["device_builder"]["installed"],
+            serde_json::Value::Null
+        );
     }
 
     #[cfg(unix)]

--- a/src-tauri/src/control/protocol.rs
+++ b/src-tauri/src/control/protocol.rs
@@ -18,8 +18,13 @@ pub const MAX_LINE_BYTES: usize = 64 * 1024;
 
 /// Version of the machine-readable `esphome-desktop api ...` contract, reported
 /// by `esphome-desktop api version`. The device-builder dashboard gates on this
-/// so we can evolve the human CLI freely; bump it only on a breaking change to
-/// the `api` request/reply shapes.
+/// so we can evolve the human CLI freely.
+///
+/// The `api` client echoes server replies verbatim, so the wire shapes of
+/// [`Reply`], [`StatusReply`], and [`UpdateCheckReply`] — their serde `type`
+/// tags and their fields — ARE this public contract, not merely internal types.
+/// Renaming/removing a field or changing a tag on them is a breaking change to
+/// the dashboard and must bump this version. Do not refactor them casually.
 pub const API_SCHEMA_VERSION: u32 = 1;
 
 /// Name of the control pipe on Windows, where unix sockets are unavailable.

--- a/src-tauri/src/control/server.rs
+++ b/src-tauri/src/control/server.rs
@@ -12,7 +12,9 @@ use tokio::sync::mpsc;
 use tracing::{info, warn};
 
 use super::ops::{self, SwitchOutcome, UpdateGuard};
-use super::protocol::{self, backend_name, channel_name, ErrCode, Reply, Request, StatusReply};
+use super::protocol::{
+    self, backend_name, channel_name, ErrCode, Reply, Request, StatusReply, UpdateCheckReply,
+};
 use crate::AppState;
 
 /// Backoff before retrying a failed accept or pipe re-create, so a
@@ -400,6 +402,10 @@ async fn dispatch(
             let _ = tx.send(Reply::ok("quitting"));
             return Some(PostAction::Exit);
         }
+        Request::CheckUpdate => {
+            let check = build_update_check(app, &state).await;
+            let _ = tx.send(Reply::UpdateCheck(Box::new(check)));
+        }
         Request::Status => {
             let status = build_status(app, &state).await;
             let _ = tx.send(Reply::Status(Box::new(status)));
@@ -466,5 +472,27 @@ async fn build_status(app: &AppHandle, state: &Arc<AppState>) -> StatusReply {
         launch_at_startup,
         config_dir: state.daemon.config_dir().clone(),
         logs_dir: state.daemon.logs_dir().clone(),
+    }
+}
+
+/// Check every component for an available update without installing anything.
+/// Read-only, so it takes no [`UpdateGuard`] and is safe to run even while an
+/// update is in flight. The three checks hit the network (GitHub, PyPI) and
+/// spawn Python for the installed versions, so run them concurrently.
+async fn build_update_check(app: &AppHandle, state: &Arc<AppState>) -> UpdateCheckReply {
+    let (channel, backend) = {
+        let settings = state.settings.read().await;
+        (settings.release_channel, settings.backend)
+    };
+    let (app_update, esphome, device_builder) = tokio::join!(
+        ops::desktop_update_available(app),
+        ops::esphome_update_available(app, state, channel),
+        ops::device_builder_update_available(app, state, backend),
+    );
+    UpdateCheckReply {
+        any_available: app_update.available || esphome.available || device_builder.available,
+        app: app_update,
+        esphome,
+        device_builder,
     }
 }

--- a/src-tauri/src/daemon/mod.rs
+++ b/src-tauri/src/daemon/mod.rs
@@ -229,9 +229,14 @@ impl DaemonManager {
             "ESPHOME_DESKTOP_VERSION",
             self.app_handle.package_info().version.to_string(),
         );
-        // The backend also inherits ESPHOME_DESKTOP_BIN (the esphome-desktop CLI
-        // path) from this process, exported at startup so the dashboard can
-        // check for and trigger updates via the `api` interface. See lib.rs.
+        // Tell the backend where the esphome-desktop CLI lives so the dashboard
+        // can check for and trigger updates through the stable `api` interface
+        // (esphome-desktop api check-update / api update). Set beside the other
+        // backend env vars and re-applied on every respawn like them; the
+        // backend's own child processes inherit it too. See control::client.
+        if let Some(bin) = crate::control::cli_invocation_path() {
+            cmd.env("ESPHOME_DESKTOP_BIN", bin);
+        }
 
         // On Windows, force the spawned Python (and any subprocesses it
         // spawns for compile/logs) to use UTF-8 for stdin/stdout/stderr.

--- a/src-tauri/src/daemon/mod.rs
+++ b/src-tauri/src/daemon/mod.rs
@@ -229,6 +229,9 @@ impl DaemonManager {
             "ESPHOME_DESKTOP_VERSION",
             self.app_handle.package_info().version.to_string(),
         );
+        // The backend also inherits ESPHOME_DESKTOP_BIN (the esphome-desktop CLI
+        // path) from this process, exported at startup so the dashboard can
+        // check for and trigger updates via the `api` interface. See lib.rs.
 
         // On Windows, force the spawned Python (and any subprocesses it
         // spawns for compile/logs) to use UTF-8 for stdin/stdout/stderr.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -125,6 +125,29 @@ pub enum CliCommand {
         #[arg(long)]
         json: bool,
     },
+    /// Stable, versioned JSON API for the device-builder integration (hidden
+    /// from help; not for interactive use). Emits newline-delimited JSON only.
+    #[command(subcommand, hide = true)]
+    Api(ApiMethod),
+}
+
+/// Methods of the machine-readable `esphome-desktop api <method>` interface.
+/// This is the contract the device-builder dashboard codes against; unlike the
+/// human subcommands above it emits only NDJSON and is versioned via
+/// [`control::protocol::API_SCHEMA_VERSION`], so the human CLI stays free to
+/// change. Every line is one JSON object the caller can `json.loads`.
+#[derive(clap::Subcommand, Debug, Clone)]
+pub enum ApiMethod {
+    /// Print the API schema version and exit (no running app required)
+    Version,
+    /// Print app and backend status as one JSON object
+    Status,
+    /// Report whether any component has an update available, without installing
+    CheckUpdate,
+    /// Trigger the full update; streams JSON progress then a terminal reply.
+    /// Non-interactive: the backend is restarted without any confirmation, so
+    /// an unattended remote builder recovers on its own.
+    Update,
 }
 
 /// ESPHome Device Builder - System tray application for ESPHome
@@ -430,6 +453,15 @@ pub fn run(cli: Cli) {
             // Log-and-continue: builds just run without caching on failure.
             if let Err(e) = platform::ensure_ccache_on_path(app.handle()) {
                 error!("Failed to set up bundled ccache: {}", e);
+            }
+
+            // Export the esphome-desktop CLI path so the device-builder backend
+            // (and anything it spawns) knows what to call to check for and
+            // trigger updates through the stable `api` interface. Set on this
+            // process before the daemon task spawns, so the child inherits it
+            // like the PATH additions above and picks it up again on restart.
+            if let Some(bin) = control::cli_invocation_path() {
+                std::env::set_var("ESPHOME_DESKTOP_BIN", bin);
             }
 
             // One-shot prompt to remove the pre-rename `/Applications/ESPHome Builder.app`.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -455,15 +455,6 @@ pub fn run(cli: Cli) {
                 error!("Failed to set up bundled ccache: {}", e);
             }
 
-            // Export the esphome-desktop CLI path so the device-builder backend
-            // (and anything it spawns) knows what to call to check for and
-            // trigger updates through the stable `api` interface. Set on this
-            // process before the daemon task spawns, so the child inherits it
-            // like the PATH additions above and picks it up again on restart.
-            if let Some(bin) = control::cli_invocation_path() {
-                std::env::set_var("ESPHOME_DESKTOP_BIN", bin);
-            }
-
             // One-shot prompt to remove the pre-rename `/Applications/ESPHome Builder.app`.
             // No-op on non-macOS and after the user has answered once.
             platform::cleanup_legacy_macos_app(app.handle());

--- a/src-tauri/src/update/mod.rs
+++ b/src-tauri/src/update/mod.rs
@@ -989,6 +989,17 @@ where
 
 /// Get the installed ESPHome version
 pub fn get_installed_version(app_handle: &AppHandle) -> Result<String> {
+    installed_esphome_version(app_handle)?.ok_or_else(|| anyhow::anyhow!("ESPHome not installed"))
+}
+
+/// Installed ESPHome version, distinguishing "not installed" from a real
+/// detection failure: `Ok(Some(v))` when installed, `Ok(None)` when the
+/// `esphome version` command runs but exits non-zero (ESPHome absent), and
+/// `Err` only when the check itself can't run (e.g. Python missing). The
+/// update-availability check uses this so a missing ESPHome shows as "nothing
+/// to update" rather than an error; [`get_installed_version`] keeps the
+/// error-on-absent shape the interactive/tray flows rely on.
+pub fn installed_esphome_version(app_handle: &AppHandle) -> Result<Option<String>> {
     let python_path = platform::get_python_path(app_handle)?;
 
     let mut cmd = std::process::Command::new(&python_path);
@@ -997,17 +1008,16 @@ pub fn get_installed_version(app_handle: &AppHandle) -> Result<String> {
 
     let output = cmd.output().context("Failed to run esphome version")?;
 
-    if output.status.success() {
-        let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        // Extract just the version number
-        let version = version
-            .strip_prefix("Version: ")
-            .unwrap_or(&version)
-            .to_string();
-        Ok(version)
-    } else {
-        anyhow::bail!("ESPHome not installed")
+    if !output.status.success() {
+        return Ok(None);
     }
+    let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    // Extract just the version number
+    let version = version
+        .strip_prefix("Version: ")
+        .unwrap_or(&version)
+        .to_string();
+    Ok(Some(version))
 }
 
 /// Pre-release precedence for a version's tag, following PEP 440 ordering:


### PR DESCRIPTION
# What does this implement/fix?

Lets the ESPHome Device Builder dashboard drive desktop updates itself, so a machine without a working tray (a remote or unattended builder) still gets updated. The app exports `ESPHOME_DESKTOP_BIN` into the backend's environment so the dashboard knows what to call, and adds a stable, versioned JSON interface separate from the human commands: `esphome-desktop api version` (a `schema_version` handshake), `api check-update` (per-component availability so the dashboard can show a banner), and `api update` (trigger the full update). Every `api` line is newline-delimited JSON, valid even on error, so the human CLI's wording stays free to change without breaking the integration.

`api update` reuses the existing non-interactive update path; it stops and restarts the backend without any confirmation, so an unattended remote builder always comes back on its own, and the update completes in the app even if the caller is torn down when the backend restarts.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).
