### PR TITLE
Fix flaky interpreter_is_usable test on Linux CI

### DIFF
--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -2364,7 +2364,20 @@ mod tests {
         let base = unique_temp_dir("interp-healthy");
         let _ = std::fs::remove_dir_all(&base);
         let bin = write_stub_interpreter(&base, "exit 0");
-        assert!(interpreter_is_usable(&bin));
+        // Retry to ride out a transient ETXTBSY ("text file busy"): this test
+        // binary is multithreaded, and a concurrent fork in another test can
+        // briefly leave the just-written stub open for writing, so the first
+        // execve of it can fail even though the interpreter is fine. Linux
+        // enforces this; macOS does not, which is why only Linux CI flaked.
+        let mut usable = false;
+        for _ in 0..20 {
+            if interpreter_is_usable(&bin) {
+                usable = true;
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+        assert!(usable);
         let _ = std::fs::remove_dir_all(&base);
     }
 

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -2369,15 +2369,24 @@ mod tests {
         // briefly leave the just-written stub open for writing, so the first
         // execve of it can fail even though the interpreter is fine. Linux
         // enforces this; macOS does not, which is why only Linux CI flaked.
+        const ATTEMPTS: usize = 20;
         let mut usable = false;
-        for _ in 0..20 {
+        for attempt in 0..ATTEMPTS {
             if interpreter_is_usable(&bin) {
                 usable = true;
                 break;
             }
-            std::thread::sleep(std::time::Duration::from_millis(50));
+            // Don't sleep after the final attempt: nothing follows it, so it
+            // would only delay a genuine failure's assert.
+            if attempt + 1 < ATTEMPTS {
+                std::thread::sleep(std::time::Duration::from_millis(50));
+            }
         }
-        assert!(usable);
+        assert!(
+            usable,
+            "interpreter_is_usable never returned true after {ATTEMPTS} attempts \
+             (a real exec failure, not the transient ETXTBSY this retry covers)"
+        );
         let _ = std::fs::remove_dir_all(&base);
     }
 


### PR DESCRIPTION
# What does this implement/fix?

Fixes a flaky `platform::tests::interpreter_is_usable_true_for_healthy_interpreter` failure that intermittently fails "Rust lint & test" on Linux CI. The test writes an executable stub then immediately execs it; because the test binary is multithreaded, a concurrent fork in another test can briefly leave the just-written stub open for writing, so the first execve fails with ETXTBSY (text file busy). Linux enforces this, macOS does not, which is why only Linux flaked. The test now retries a few times to ride out that window; no production code changes.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).
