### PR TITLE
Remove the duplicate ESPHome version probe in settings

### DIFF
--- a/src-tauri/src/settings/mod.rs
+++ b/src-tauri/src/settings/mod.rs
@@ -215,9 +215,13 @@ impl Settings {
         let settings_path = Self::settings_path(app_handle)?;
 
         let mut settings = load_settings_file(&settings_path);
-        settings.installed_version = crate::update::installed_esphome_version(app_handle)
-            .ok()
-            .flatten();
+        settings.installed_version = match crate::update::installed_esphome_version(app_handle) {
+            Ok(version) => version,
+            Err(e) => {
+                debug!("Could not detect installed ESPHome version: {e}");
+                None
+            }
+        };
         Ok(settings)
     }
 

--- a/src-tauri/src/settings/mod.rs
+++ b/src-tauri/src/settings/mod.rs
@@ -215,7 +215,9 @@ impl Settings {
         let settings_path = Self::settings_path(app_handle)?;
 
         let mut settings = load_settings_file(&settings_path);
-        settings.installed_version = detect_installed_version(app_handle).ok();
+        settings.installed_version = crate::update::installed_esphome_version(app_handle)
+            .ok()
+            .flatten();
         Ok(settings)
     }
 
@@ -338,29 +340,6 @@ fn unique_backup_path(path: &Path) -> PathBuf {
             return candidate;
         }
         n += 1;
-    }
-}
-
-/// Detect the installed ESPHome version from the venv
-fn detect_installed_version(app_handle: &AppHandle) -> Result<String> {
-    let python_path = platform::get_python_path(app_handle)?;
-
-    let mut cmd = std::process::Command::new(&python_path);
-    cmd.args(["-m", "esphome", "version"]);
-    platform::configure_no_window_command(&mut cmd);
-
-    let output = cmd.output().context("Failed to run esphome version")?;
-
-    if output.status.success() {
-        let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        // Extract just the version number (e.g., "2024.1.0" from "Version: 2024.1.0")
-        let version = version
-            .strip_prefix("Version: ")
-            .unwrap_or(&version)
-            .to_string();
-        Ok(version)
-    } else {
-        anyhow::bail!("ESPHome not installed")
     }
 }
 


### PR DESCRIPTION
# What does this implement/fix?

Deletes `settings::detect_installed_version`, which duplicated the `python -m esphome version` probe in `update::installed_esphome_version`; `Settings::load` now calls `crate::update::installed_esphome_version(app).ok().flatten()` instead. The field stays `installed_version: Option<String>` either way; the only semantic difference is that the settings path no longer treats a failed probe differently from not installed, since both end up as `None`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- closes #252

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).

