### PR TITLE
Move the Linux dependency install to a composite action

### DIFF
--- a/.github/actions/linux-tauri-deps/action.yml
+++ b/.github/actions/linux-tauri-deps/action.yml
@@ -1,0 +1,19 @@
+name: Install Linux Tauri deps
+description: >-
+  Installs the system packages the Tauri crate needs on Linux runners.
+  webkit2gtk/rsvg/appindicator are required just to compile; patchelf is only
+  used when bundling, but it is tiny, so every caller gets the same set to
+  keep the workflows from drifting apart again.
+
+runs:
+  using: composite
+  steps:
+    - name: Install Linux dependencies
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          libwebkit2gtk-4.1-dev \
+          librsvg2-dev \
+          patchelf \
+          libayatana-appindicator3-dev

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,13 +89,7 @@ jobs:
       # Linux-specific dependencies
       - name: Install Linux dependencies
         if: matrix.platform == 'linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libwebkit2gtk-4.1-dev \
-            librsvg2-dev \
-            patchelf \
-            libayatana-appindicator3-dev
+        uses: ./.github/actions/linux-tauri-deps
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -31,15 +31,10 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       # Tauri links against the system webkit/appindicator stack on Linux, so
-      # even a plain `cargo test` needs these to compile. Mirror the dependency
-      # set used by the Build workflow's Linux jobs.
+      # even a plain `cargo test` needs these to compile. Same dependency set
+      # as the Build workflow's Linux jobs (shared composite action).
       - name: Install Linux dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libwebkit2gtk-4.1-dev \
-            librsvg2-dev \
-            libayatana-appindicator3-dev
+        uses: ./.github/actions/linux-tauri-deps
 
       # Pin the toolchain version (unlike the Build workflow, which floats
       # `stable`). clippy and rustfmt are *required* gates below, so a floating


### PR DESCRIPTION
# What does this implement/fix?

Moves the duplicated Linux apt dependency install from build.yml and lint-test.yml into a shared composite action at .github/actions/linux-tauri-deps, so the package list lives in one place. The two copies had drifted; patchelf was only in build.yml because only bundling needs it, and the action now installs it for both callers since that is the simpler option and it is harmless for the lint job, which only compiles. No behavior change for the Build workflow; the lint job additionally installs patchelf.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- closes #267

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).

