### PR TITLE
Share the GitHub annotation helper between release scripts

### DIFF
--- a/.github/scripts/_gha.py
+++ b/.github/scripts/_gha.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""Shared GitHub Actions annotation helpers for the release scripts.
+
+The sibling scripts in this directory run by path (they aren't an installed
+package), so each one puts this directory on sys.path before importing.
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+def warn(msg: str) -> None:
+    """Emit a GitHub-Actions-style warning to stderr (also readable locally)."""
+    print(f"::warning::{msg}", file=sys.stderr)
+
+
+def error(msg: str) -> None:
+    """Emit a GitHub-Actions-style error to stderr (also readable locally)."""
+    print(f"::error::{msg}", file=sys.stderr)

--- a/.github/scripts/_gha.py
+++ b/.github/scripts/_gha.py
@@ -10,11 +10,16 @@ from __future__ import annotations
 import sys
 
 
+def _escape(msg: str) -> str:
+    """Escape workflow-command message data per GitHub's escaping rules."""
+    return msg.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
 def warn(msg: str) -> None:
     """Emit a GitHub-Actions-style warning to stderr (also readable locally)."""
-    print(f"::warning::{msg}", file=sys.stderr)
+    print(f"::warning::{_escape(msg)}", file=sys.stderr)
 
 
 def error(msg: str) -> None:
     """Emit a GitHub-Actions-style error to stderr (also readable locally)."""
-    print(f"::error::{msg}", file=sys.stderr)
+    print(f"::error::{_escape(msg)}", file=sys.stderr)

--- a/.github/scripts/bump_bundle_versions.py
+++ b/.github/scripts/bump_bundle_versions.py
@@ -53,6 +53,13 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, TypeVar
 
+# This script runs by path (not as an installed package), so make the sibling
+# _gha helper importable regardless of the caller's cwd.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _gha import error as _error  # noqa: E402
+from _gha import warn as _warn  # noqa: E402
+
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 PREPARE_BUNDLE = REPO_ROOT / "build-scripts" / "prepare_bundle.sh"
 
@@ -88,16 +95,6 @@ PBS_ASSET_RE_TEMPLATE = (
     r"cpython-(?P<py>{minor}\.\d+)\+(?P<pbs>\d+)-"
     r"x86_64-unknown-linux-gnu-install_only_stripped\.tar\.gz"
 )
-
-
-def _warn(msg: str) -> None:
-    """Emit a GitHub-Actions-style warning to stderr (also readable locally)."""
-    print(f"::warning::{msg}", file=sys.stderr)
-
-
-def _error(msg: str) -> None:
-    """Emit a GitHub-Actions-style error to stderr (also readable locally)."""
-    print(f"::error::{msg}", file=sys.stderr)
 
 
 class ResolutionError(Exception):

--- a/.github/scripts/bump_bundle_versions.py
+++ b/.github/scripts/bump_bundle_versions.py
@@ -55,7 +55,9 @@ from typing import Any, TypeVar
 
 # This script runs by path (not as an installed package), so make the sibling
 # _gha helper importable regardless of the caller's cwd.
-sys.path.insert(0, str(Path(__file__).resolve().parent))
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
 
 from _gha import error as _error  # noqa: E402
 from _gha import warn as _warn  # noqa: E402

--- a/.github/scripts/generate_latest_json.py
+++ b/.github/scripts/generate_latest_json.py
@@ -47,7 +47,9 @@ from typing import Any
 
 # This script runs by path (not as an installed package), so make the sibling
 # _gha helper importable regardless of the caller's cwd.
-sys.path.insert(0, str(Path(__file__).resolve().parent))
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
 
 from _gha import warn as _warn  # noqa: E402
 

--- a/.github/scripts/generate_latest_json.py
+++ b/.github/scripts/generate_latest_json.py
@@ -45,6 +45,12 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+# This script runs by path (not as an installed package), so make the sibling
+# _gha helper importable regardless of the caller's cwd.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _gha import warn as _warn  # noqa: E402
+
 # (Tauri updater target, regex matching the .sig asset name)
 # fmt: off
 PLATFORM_SIG_MATCHERS: list[tuple[str, re.Pattern[str]]] = [
@@ -85,11 +91,6 @@ ASSETS_PENDING_BLOCK_RE = re.compile(
     r"^> \[!CAUTION\].*?<!-- ASSETS_PENDING -->\n?",
     re.DOTALL | re.MULTILINE,
 )
-
-
-def _warn(msg: str) -> None:
-    """Emit a GitHub-Actions-style warning to stderr (also readable locally)."""
-    print(f"::warning::{msg}", file=sys.stderr)
 
 
 def _strip_assets_pending_warning(body: str) -> str:


### PR DESCRIPTION
# What does this implement/fix?

Moves the duplicated `::warning::` annotation emitter, plus the `::error::` sibling from bump_bundle_versions.py, into a small shared module `.github/scripts/_gha.py`; both release scripts now import it. Each script inserts its own directory on sys.path before the import, so the helper resolves whether the script is run by path from a workflow or loaded by file location in the tests; no behavior change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- closes #272

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).

