### PR TITLE
Single source the release version bump

### DIFF
--- a/.github/scripts/set_version.py
+++ b/.github/scripts/set_version.py
@@ -31,17 +31,17 @@ REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 VERSION_FILES: tuple[tuple[str, re.Pattern[str], str], ...] = (
     (
         "src-tauri/Cargo.toml",
-        re.compile(r"^version = .*", re.MULTILINE),
+        re.compile(r"^version = [^\r\n]*", re.MULTILINE),
         'version = "{version}"',
     ),
     (
         "src-tauri/tauri.conf.json",
-        re.compile(r'"version": .*', re.MULTILINE),
+        re.compile(r'"version": [^\r\n]*', re.MULTILINE),
         '"version": "{version}",',
     ),
     (
         "packaging/aur/esphome-desktop-bin/PKGBUILD",
-        re.compile(r"^pkgver=.*", re.MULTILINE),
+        re.compile(r"^pkgver=[^\r\n]*", re.MULTILINE),
         "pkgver={version}",
     ),
 )
@@ -62,7 +62,7 @@ def set_version(
     new, count = pattern.subn(lambda _m: replacement, text)
     if count != 1:
         raise ValueError(
-            f"pattern {pattern.pattern!r} matched {count} lines, expected exactly 1"
+            f"pattern {pattern.pattern!r} matched {count} times, expected exactly 1"
         )
     return new
 

--- a/.github/scripts/set_version.py
+++ b/.github/scripts/set_version.py
@@ -26,7 +26,8 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
 # (file, version-line pattern, replacement template). Patterns are multiline so
-# they anchor per line, and replacements rewrite the whole matched line.
+# they anchor per line, and each replacement rewrites just the matched
+# substring — the same edit the old per-file sed steps made.
 VERSION_FILES: tuple[tuple[str, re.Pattern[str], str], ...] = (
     (
         "src-tauri/Cargo.toml",
@@ -49,7 +50,7 @@ VERSION_FILES: tuple[tuple[str, re.Pattern[str], str], ...] = (
 def set_version(
     text: str, pattern: re.Pattern[str], template: str, version: str
 ) -> str:
-    """Rewrite every line matching `pattern` with the filled-in `template`.
+    """Replace every match of `pattern` with the filled-in `template`.
 
     Raises ValueError when nothing matches so a renamed or restructured file
     fails the release job instead of silently shipping a stale version.
@@ -73,15 +74,24 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     root = Path(args.root)
+    # Two phases: compute every rewrite first, write only after all patterns
+    # matched, so a failure can't leave the tree partially bumped.
+    rewritten: list[tuple[Path, str, str]] = []
     for rel_path, pattern, template in VERSION_FILES:
         path = root / rel_path
-        text = path.read_text(encoding="utf-8")
         try:
+            text = path.read_text(encoding="utf-8")
             new = set_version(text, pattern, template, args.version)
-        except ValueError as exc:
+        except (OSError, ValueError) as exc:
             print(f"::error::{rel_path}: {exc}", file=sys.stderr)
             return 1
-        path.write_text(new, encoding="utf-8")
+        rewritten.append((path, rel_path, new))
+    for path, rel_path, new in rewritten:
+        try:
+            path.write_text(new, encoding="utf-8")
+        except OSError as exc:
+            print(f"::error::{rel_path}: {exc}", file=sys.stderr)
+            return 1
         print(f"{rel_path}: set version to {args.version}")
     return 0
 

--- a/.github/scripts/set_version.py
+++ b/.github/scripts/set_version.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Set the release version in every version-bearing file.
+
+Run by .github/workflows/release-drafter.yml after the release draft is
+(re)generated. Each entry in VERSION_FILES maps a file to the pattern for its
+version line and the replacement line, so adding a new version-bearing file is
+one line in the table instead of another bespoke sed step.
+
+The script fails loudly (non-zero exit) if a pattern doesn't match its file —
+that means the file was renamed or restructured and this table needs updating;
+a silent no-op would ship a mismatched version and break download URLs built
+from it.
+
+Usage:
+
+    python3 .github/scripts/set_version.py 1.2.3
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+# (file, version-line pattern, replacement template). Patterns are multiline so
+# they anchor per line, and replacements rewrite the whole matched line.
+VERSION_FILES: tuple[tuple[str, re.Pattern[str], str], ...] = (
+    (
+        "src-tauri/Cargo.toml",
+        re.compile(r"^version = .*", re.MULTILINE),
+        'version = "{version}"',
+    ),
+    (
+        "src-tauri/tauri.conf.json",
+        re.compile(r'"version": .*', re.MULTILINE),
+        '"version": "{version}",',
+    ),
+    (
+        "packaging/aur/esphome-desktop-bin/PKGBUILD",
+        re.compile(r"^pkgver=.*", re.MULTILINE),
+        "pkgver={version}",
+    ),
+)
+
+
+def set_version(
+    text: str, pattern: re.Pattern[str], template: str, version: str
+) -> str:
+    """Rewrite every line matching `pattern` with the filled-in `template`.
+
+    Raises ValueError when nothing matches so a renamed or restructured file
+    fails the release job instead of silently shipping a stale version.
+    """
+    replacement = template.format(version=version)
+    # Function replacement so any backslashes/specials stay literal.
+    new, count = pattern.subn(lambda _m: replacement, text)
+    if count == 0:
+        raise ValueError(f"pattern {pattern.pattern!r} matched nothing")
+    return new
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("version", help="Release version, without the leading v.")
+    parser.add_argument(
+        "--root",
+        default=str(REPO_ROOT),
+        help="Repository root containing the version-bearing files.",
+    )
+    args = parser.parse_args(argv)
+
+    root = Path(args.root)
+    for rel_path, pattern, template in VERSION_FILES:
+        path = root / rel_path
+        text = path.read_text(encoding="utf-8")
+        try:
+            new = set_version(text, pattern, template, args.version)
+        except ValueError as exc:
+            print(f"::error::{rel_path}: {exc}", file=sys.stderr)
+            return 1
+        path.write_text(new, encoding="utf-8")
+        print(f"{rel_path}: set version to {args.version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/set_version.py
+++ b/.github/scripts/set_version.py
@@ -50,16 +50,20 @@ VERSION_FILES: tuple[tuple[str, re.Pattern[str], str], ...] = (
 def set_version(
     text: str, pattern: re.Pattern[str], template: str, version: str
 ) -> str:
-    """Replace every match of `pattern` with the filled-in `template`.
+    """Replace exactly one match of `pattern` with the filled-in `template`.
 
-    Raises ValueError when nothing matches so a renamed or restructured file
-    fails the release job instead of silently shipping a stale version.
+    Raises ValueError when the match count is not exactly one, so a renamed
+    or restructured file fails the release job instead of silently shipping
+    a stale version, and an over-broad pattern fails instead of silently
+    rewriting extra lines.
     """
     replacement = template.format(version=version)
     # Function replacement so any backslashes/specials stay literal.
     new, count = pattern.subn(lambda _m: replacement, text)
-    if count == 0:
-        raise ValueError(f"pattern {pattern.pattern!r} matched nothing")
+    if count != 1:
+        raise ValueError(
+            f"pattern {pattern.pattern!r} matched {count} lines, expected exactly 1"
+        )
     return new
 
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -36,17 +36,11 @@ jobs:
           tag="${{ steps.release-draft.outputs.tag_name }}"
           echo "version=${tag:1}" >> $GITHUB_OUTPUT
 
-      - name: Set Cargo.toml version
+      # One table-driven step rewrites every version-bearing file; adding a
+      # file is one line in the script's table instead of another sed step.
+      - name: Set versions
         run: |
-          sed -i "s/^version = .*/version = \"${{ steps.version.outputs.version }}\"/g" src-tauri/Cargo.toml
-
-      - name: Set tauri.conf.json version
-        run: |
-          sed -i "s/\"version\": .*/\"version\": \"${{ steps.version.outputs.version }}\",/g" src-tauri/tauri.conf.json
-
-      - name: Set PKGBUILD versions
-        run: |
-          sed -i "s/^pkgver=.*/pkgver=${{ steps.version.outputs.version }}/g" packaging/aur/esphome-desktop-bin/PKGBUILD
+          python3 .github/scripts/set_version.py "${{ steps.version.outputs.version }}"
 
       - name: Update Cargo.lock
         run: |

--- a/tests/test_set_version.py
+++ b/tests/test_set_version.py
@@ -109,7 +109,7 @@ def test_pkgbuild_rewrites_pkgver_only() -> None:
 
 def test_set_version_raises_when_pattern_matches_nothing() -> None:
     pattern, template = _table_entry("src-tauri/Cargo.toml")
-    with pytest.raises(ValueError, match="matched 0 lines"):
+    with pytest.raises(ValueError, match="matched 0 times"):
         set_version.set_version('[package]\nname = "x"\n', pattern, template, "1.0.0")
 
 
@@ -117,7 +117,7 @@ def test_set_version_raises_when_pattern_matches_more_than_once() -> None:
     # An over-broad pattern must fail loudly instead of rewriting every match.
     pattern, template = _table_entry("src-tauri/Cargo.toml")
     text = 'version = "0.1.0"\nversion = "0.2.0"\n'
-    with pytest.raises(ValueError, match="matched 2 lines"):
+    with pytest.raises(ValueError, match="matched 2 times"):
         set_version.set_version(text, pattern, template, "1.0.0")
 
 

--- a/tests/test_set_version.py
+++ b/tests/test_set_version.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Tests for .github/scripts/set_version.py.
+
+The release-drafter workflow rewrites the release version in every
+version-bearing file through this script's file-to-pattern table. A bug here
+ships a mismatched version and breaks download URLs built from it, so the
+rewrites get a regression net: each transform must produce exactly the line
+the old per-file sed steps produced, and a non-matching pattern must fail
+loudly rather than silently skip a file.
+
+pytest suite (maintainer-requested framework, fully typed, no classes).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT_PATH = REPO_ROOT / ".github" / "scripts" / "set_version.py"
+
+# Trimmed copies of the version-bearing files, in the same shape as the real
+# ones (the details that keep the patterns honest: a dependency `version =` in
+# Cargo.toml, indentation and the trailing comma in tauri.conf.json, and a
+# `$pkgver` interpolation in the PKGBUILD).
+CARGO_TOML = """\
+[package]
+name = "esphome-desktop"
+version = "0.14.2"
+edition = "2021"
+
+[dependencies]
+tauri = { version = "2.11.2", features = ["tray-icon"] }
+"""
+
+TAURI_CONF = """\
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "productName": "ESPHome Device Builder",
+  "version": "0.14.2",
+  "identifier": "com.esphome.desktop"
+}
+"""
+
+PKGBUILD = """\
+pkgname=esphome-desktop-bin
+pkgver=0.14.2
+pkgrel=1
+source=("$pkgname-$pkgver.deb::$url/releases/download/v${pkgver}/app_${pkgver}_amd64.deb")
+"""
+
+
+def _load_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("set_version", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+set_version = _load_module()
+
+
+def _table_entry(rel_path: str) -> tuple[str, str]:
+    """Return `(pattern, template)` for a file in the VERSION_FILES table."""
+    for path, pattern, template in set_version.VERSION_FILES:
+        if path == rel_path:
+            return pattern, template
+    raise KeyError(rel_path)
+
+
+# --------------------------------------------------------------------------- #
+# Per-file transforms: byte-identical to the old sed steps.
+# --------------------------------------------------------------------------- #
+
+
+def test_cargo_toml_rewrites_package_version_only() -> None:
+    pattern, template = _table_entry("src-tauri/Cargo.toml")
+    out = set_version.set_version(CARGO_TOML, pattern, template, "0.15.0")
+    # Same edit the old `sed "s/^version = .*/version = \"0.15.0\"/g"` made.
+    assert out == CARGO_TOML.replace('version = "0.14.2"', 'version = "0.15.0"')
+    # The anchored pattern must not touch dependency `version =` fields.
+    assert 'tauri = { version = "2.11.2", features = ["tray-icon"] }' in out
+
+
+def test_tauri_conf_keeps_indent_and_trailing_comma() -> None:
+    pattern, template = _table_entry("src-tauri/tauri.conf.json")
+    out = set_version.set_version(TAURI_CONF, pattern, template, "0.15.0")
+    # Same edit the old `sed "s/\"version\": .*/\"version\": \"0.15.0\",/g"`
+    # made: the leading indent survives and the trailing comma is emitted.
+    assert out == TAURI_CONF.replace('"version": "0.14.2",', '"version": "0.15.0",')
+    assert '  "version": "0.15.0",\n' in out
+
+
+def test_pkgbuild_rewrites_pkgver_only() -> None:
+    pattern, template = _table_entry("packaging/aur/esphome-desktop-bin/PKGBUILD")
+    out = set_version.set_version(PKGBUILD, pattern, template, "0.15.0")
+    # Same edit the old `sed "s/^pkgver=.*/pkgver=0.15.0/g"` made.
+    assert out == PKGBUILD.replace("pkgver=0.14.2", "pkgver=0.15.0")
+    # The $pkgver interpolations in source= stay as interpolations.
+    assert "v${pkgver}/app_${pkgver}_amd64.deb" in out
+
+
+def test_set_version_raises_when_pattern_matches_nothing() -> None:
+    pattern, template = _table_entry("src-tauri/Cargo.toml")
+    with pytest.raises(ValueError):
+        set_version.set_version('[package]\nname = "x"\n', pattern, template, "1.0.0")
+
+
+def test_table_covers_the_real_files() -> None:
+    # Every table entry must point at an existing file whose pattern matches,
+    # so a rename or restructure fails here before it fails a release.
+    for rel_path, pattern, _template in set_version.VERSION_FILES:
+        text = (REPO_ROOT / rel_path).read_text(encoding="utf-8")
+        assert pattern.search(text), f"{rel_path}: pattern matched nothing"
+
+
+# --------------------------------------------------------------------------- #
+# CLI behaviour.
+# --------------------------------------------------------------------------- #
+
+
+def _write_tree(root: Path) -> None:
+    (root / "src-tauri").mkdir()
+    (root / "packaging" / "aur" / "esphome-desktop-bin").mkdir(parents=True)
+    (root / "src-tauri" / "Cargo.toml").write_text(CARGO_TOML, encoding="utf-8")
+    (root / "src-tauri" / "tauri.conf.json").write_text(TAURI_CONF, encoding="utf-8")
+    (root / "packaging" / "aur" / "esphome-desktop-bin" / "PKGBUILD").write_text(
+        PKGBUILD, encoding="utf-8"
+    )
+
+
+def test_main_rewrites_every_file(tmp_path: Path) -> None:
+    _write_tree(tmp_path)
+    rc = set_version.main(["0.15.0", "--root", str(tmp_path)])
+    assert rc == 0
+    assert 'version = "0.15.0"' in (tmp_path / "src-tauri" / "Cargo.toml").read_text(
+        encoding="utf-8"
+    )
+    assert '"version": "0.15.0",' in (
+        tmp_path / "src-tauri" / "tauri.conf.json"
+    ).read_text(encoding="utf-8")
+    assert "pkgver=0.15.0" in (
+        tmp_path / "packaging" / "aur" / "esphome-desktop-bin" / "PKGBUILD"
+    ).read_text(encoding="utf-8")
+
+
+def test_main_fails_when_a_pattern_matches_nothing(tmp_path: Path) -> None:
+    # A restructured file must fail the release job, not silently keep its old
+    # version while the other files move on.
+    _write_tree(tmp_path)
+    (tmp_path / "src-tauri" / "tauri.conf.json").write_text("{}\n", encoding="utf-8")
+    rc = set_version.main(["0.15.0", "--root", str(tmp_path)])
+    assert rc == 1

--- a/tests/test_set_version.py
+++ b/tests/test_set_version.py
@@ -109,8 +109,16 @@ def test_pkgbuild_rewrites_pkgver_only() -> None:
 
 def test_set_version_raises_when_pattern_matches_nothing() -> None:
     pattern, template = _table_entry("src-tauri/Cargo.toml")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="matched 0 lines"):
         set_version.set_version('[package]\nname = "x"\n', pattern, template, "1.0.0")
+
+
+def test_set_version_raises_when_pattern_matches_more_than_once() -> None:
+    # An over-broad pattern must fail loudly instead of rewriting every match.
+    pattern, template = _table_entry("src-tauri/Cargo.toml")
+    text = 'version = "0.1.0"\nversion = "0.2.0"\n'
+    with pytest.raises(ValueError, match="matched 2 lines"):
+        set_version.set_version(text, pattern, template, "1.0.0")
 
 
 def test_table_covers_the_real_files() -> None:

--- a/tests/test_set_version.py
+++ b/tests/test_set_version.py
@@ -14,6 +14,7 @@ pytest suite (maintainer-requested framework, fully typed, no classes).
 from __future__ import annotations
 
 import importlib.util
+import re
 import sys
 from pathlib import Path
 from types import ModuleType
@@ -66,7 +67,7 @@ def _load_module() -> ModuleType:
 set_version = _load_module()
 
 
-def _table_entry(rel_path: str) -> tuple[str, str]:
+def _table_entry(rel_path: str) -> tuple[re.Pattern[str], str]:
     """Return `(pattern, template)` for a file in the VERSION_FILES table."""
     for path, pattern, template in set_version.VERSION_FILES:
         if path == rel_path:
@@ -157,3 +158,26 @@ def test_main_fails_when_a_pattern_matches_nothing(tmp_path: Path) -> None:
     (tmp_path / "src-tauri" / "tauri.conf.json").write_text("{}\n", encoding="utf-8")
     rc = set_version.main(["0.15.0", "--root", str(tmp_path)])
     assert rc == 1
+    # Writes happen only after every pattern matched, so the earlier files in
+    # the table must be untouched, not left partially bumped.
+    assert (tmp_path / "src-tauri" / "Cargo.toml").read_text(
+        encoding="utf-8"
+    ) == CARGO_TOML
+    assert (
+        tmp_path / "packaging" / "aur" / "esphome-desktop-bin" / "PKGBUILD"
+    ).read_text(encoding="utf-8") == PKGBUILD
+
+
+def test_main_fails_with_error_message_when_a_file_is_missing(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # A missing file must produce the ::error:: annotation naming the file and
+    # a non-zero exit, not a raw traceback, and must not touch the other files.
+    _write_tree(tmp_path)
+    (tmp_path / "src-tauri" / "tauri.conf.json").unlink()
+    rc = set_version.main(["0.15.0", "--root", str(tmp_path)])
+    assert rc == 1
+    assert "::error::src-tauri/tauri.conf.json:" in capsys.readouterr().err
+    assert (tmp_path / "src-tauri" / "Cargo.toml").read_text(
+        encoding="utf-8"
+    ) == CARGO_TOML


### PR DESCRIPTION
# What does this implement/fix?

Replaces the three bespoke sed steps in release-drafter.yml with one table-driven script, .github/scripts/set_version.py, that rewrites the version in tauri.conf.json, src-tauri/Cargo.toml, and the AUR PKGBUILD from a single file-to-pattern table; adding a new version-bearing file is now one line in the table. The rewrites are byte-identical to what the old seds produced, so no behavior change; the script also fails loudly if a pattern stops matching instead of silently shipping a stale version. Covered by unit tests in tests/test_set_version.py in the existing suite's style.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- closes #268

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).

