### PR TITLE
Add a download_verified helper to prepare_bundle.sh

### DIFF
--- a/build-scripts/prepare_bundle.sh
+++ b/build-scripts/prepare_bundle.sh
@@ -112,20 +112,40 @@ compute_sha256() {
     fi
 }
 
-# Verify a file against an expected SHA-256, exiting on mismatch. Thin wrapper
-# over compute_sha256 used by the MinGit download, whose expected digest is a
-# pinned constant rather than a SHA256SUMS lookup.
-verify_sha256() {
-    local file="$1"
+# Download a URL to a destination path, verified against an expected SHA-256.
+# A cached file already at the destination is reused only if its digest
+# matches; on mismatch it is re-downloaded. `--fail` makes an HTTP error a
+# non-zero exit (not a 200-status error body written to disk) and `--retry`
+# rides out transient blips. The download goes to a temp path that is promoted
+# onto the destination only after the digest checks out, so an interrupted or
+# corrupt download never becomes a sticky, always-failing cache entry (the
+# fixed-path cache trap from #152/#153).
+download_verified() {
+    local url="$1"
     local expected="$2"
+    local dest="$3"
+
+    if [[ -f "$dest" ]] && [[ "$(compute_sha256 "$dest")" == "$expected" ]]; then
+        echo "Using cached download: $dest"
+        return
+    fi
+    [[ -f "$dest" ]] && echo "Cached file checksum mismatch — re-downloading"
+    local partial="${dest}.partial.$$"
+    if ! curl -fL --retry 3 -o "$partial" "$url"; then
+        rm -f "$partial"
+        echo "ERROR: failed to download $url" >&2
+        exit 1
+    fi
     local actual
-    actual=$(compute_sha256 "$file") || exit 1
+    actual=$(compute_sha256 "$partial")
     if [[ "$actual" != "$expected" ]]; then
-        echo "ERROR: checksum mismatch for $file" >&2
+        rm -f "$partial"
+        echo "ERROR: checksum mismatch for $(basename "$dest")" >&2
         echo "  expected: $expected" >&2
         echo "  actual:   $actual" >&2
         exit 1
     fi
+    mv -f "$partial" "$dest"
     echo "Verified SHA-256: $actual"
 }
 
@@ -166,28 +186,7 @@ download_and_extract_python() {
         exit 1
     fi
 
-    if [[ -f "$temp_file" ]] && [[ "$(compute_sha256 "$temp_file")" == "$expected_sha" ]]; then
-        echo "Using cached download: $temp_file"
-    else
-        [[ -f "$temp_file" ]] && echo "Cached file checksum mismatch — re-downloading"
-        local partial="${temp_file}.partial.$$"
-        if ! curl -fL --retry 3 -o "$partial" "$url"; then
-            rm -f "$partial"
-            echo "ERROR: failed to download $url" >&2
-            exit 1
-        fi
-        local actual_sha
-        actual_sha=$(compute_sha256 "$partial")
-        if [[ "$actual_sha" != "$expected_sha" ]]; then
-            rm -f "$partial"
-            echo "ERROR: checksum mismatch for $filename" >&2
-            echo "  expected: $expected_sha" >&2
-            echo "  actual:   $actual_sha" >&2
-            exit 1
-        fi
-        mv "$partial" "$temp_file"
-        echo "Verified SHA-256: $actual_sha"
-    fi
+    download_verified "$url" "$expected_sha" "$temp_file"
 
     echo ""
     echo "=== Extracting Python for ${platform} ==="
@@ -223,20 +222,7 @@ prepare_git_for_platform() {
 
     echo ""
     echo "=== Downloading MinGit ${MINGIT_VERSION} ==="
-    if [[ -f "$temp_file" ]]; then
-        echo "Using cached download: $temp_file"
-        verify_sha256 "$temp_file" "$MINGIT_SHA256"
-    else
-        # `--fail` so an HTTP error is a non-zero exit (not a 200-status error
-        # body written to disk) and `--retry` to ride out transient blips.
-        # Download to a .partial and only rename onto the cache path once the
-        # checksum passes, so an interrupted or corrupt download never becomes a
-        # sticky, always-failing cache entry (the fixed-path cache trap from
-        # #152/#153).
-        curl -fL --retry 3 -o "${temp_file}.partial" "$MINGIT_URL"
-        verify_sha256 "${temp_file}.partial" "$MINGIT_SHA256"
-        mv -f "${temp_file}.partial" "$temp_file"
-    fi
+    download_verified "$MINGIT_URL" "$MINGIT_SHA256" "$temp_file"
 
     echo ""
     echo "=== Extracting MinGit into ${GIT_BUNDLE_DIR} ==="
@@ -276,14 +262,7 @@ prepare_patch_for_windows() {
 
     echo ""
     echo "=== Downloading PortableGit (for patch.exe) ==="
-    if [[ -f "$temp_file" ]]; then
-        echo "Using cached download: $temp_file"
-        verify_sha256 "$temp_file" "$PORTABLEGIT_SHA256"
-    else
-        curl -fL --retry 3 -o "${temp_file}.partial" "$PORTABLEGIT_URL"
-        verify_sha256 "${temp_file}.partial" "$PORTABLEGIT_SHA256"
-        mv -f "${temp_file}.partial" "$temp_file"
-    fi
+    download_verified "$PORTABLEGIT_URL" "$PORTABLEGIT_SHA256" "$temp_file"
 
     echo ""
     echo "=== Extracting patch.exe into ${patch_dir} ==="
@@ -355,17 +334,7 @@ prepare_ccache_for_platform() {
 
     echo ""
     echo "=== Downloading ccache ${CCACHE_VERSION} ==="
-    if [[ -f "$temp_file" ]]; then
-        echo "Using cached download: $temp_file"
-        verify_sha256 "$temp_file" "$CCACHE_SHA256"
-    else
-        # `--fail`/`--retry` and the .partial->rename dance mirror the MinGit
-        # download so an interrupted or corrupt fetch never becomes a sticky,
-        # always-failing cache entry.
-        curl -fL --retry 3 -o "${temp_file}.partial" "$CCACHE_URL"
-        verify_sha256 "${temp_file}.partial" "$CCACHE_SHA256"
-        mv -f "${temp_file}.partial" "$temp_file"
-    fi
+    download_verified "$CCACHE_URL" "$CCACHE_SHA256" "$temp_file"
 
     echo ""
     echo "=== Extracting ccache.exe into ${CCACHE_BUNDLE_DIR} ==="

--- a/build-scripts/prepare_bundle.sh
+++ b/build-scripts/prepare_bundle.sh
@@ -125,19 +125,34 @@ download_verified() {
     local expected="$2"
     local dest="$3"
 
-    if [[ -f "$dest" ]] && [[ "$(compute_sha256 "$dest")" == "$expected" ]]; then
-        echo "Using cached download: $dest"
-        return
+    if [[ -f "$dest" ]]; then
+        local cached
+        if ! cached=$(compute_sha256 "$dest"); then
+            echo "ERROR: failed to hash cached $dest" >&2
+            exit 1
+        fi
+        if [[ "$cached" == "$expected" ]]; then
+            echo "Using cached download: $dest"
+            return
+        fi
+        echo "Cached file checksum mismatch — re-downloading"
     fi
-    [[ -f "$dest" ]] && echo "Cached file checksum mismatch — re-downloading"
     local partial="${dest}.partial.$$"
+    # Remove the partial if the script dies mid-download (SIGINT/SIGTERM or any
+    # exit before the file is promoted). The script sets no other traps, so
+    # clearing these after the promotion below cannot clobber anything.
+    trap 'rm -f "$partial"' INT TERM EXIT
     if ! curl -fL --retry 3 -o "$partial" "$url"; then
         rm -f "$partial"
         echo "ERROR: failed to download $url" >&2
         exit 1
     fi
     local actual
-    actual=$(compute_sha256 "$partial")
+    if ! actual=$(compute_sha256 "$partial"); then
+        rm -f "$partial"
+        echo "ERROR: failed to hash downloaded $(basename "$dest")" >&2
+        exit 1
+    fi
     if [[ "$actual" != "$expected" ]]; then
         rm -f "$partial"
         echo "ERROR: checksum mismatch for $(basename "$dest")" >&2
@@ -146,6 +161,7 @@ download_verified() {
         exit 1
     fi
     mv -f "$partial" "$dest"
+    trap - INT TERM EXIT
     echo "Verified SHA-256: $actual"
 }
 


### PR DESCRIPTION
# What does this implement/fix?

Extracts the repeated cached check, curl to a .partial path, SHA-256 verify and rename dance in build-scripts/prepare_bundle.sh into a single download_verified helper, now used by the python-build-standalone, MinGit, PortableGit and ccache downloads. The python call site keeps its SHA256SUMS lookup and passes the resolved digest to the helper; the unused verify_sha256 wrapper is removed. All four downloads now share the strongest variant of the cache poisoning guard, so a cached file with a bad checksum is re-downloaded instead of failing the build and bad partials are always cleaned up; no other behavior change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- closes #269

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).

