### PR TITLE
Derive download links from the update manifest

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -550,8 +550,11 @@
       // kind, falling back to a hand-built release-asset filename.
       function urlFor(target, kind, fallbackFilename) {
         if (manifestDownloads) {
-          const entry = (manifestDownloads[target] || []).find((d) => d.kind === kind);
-          if (entry) return entry.url;
+          // Tolerate a malformed manifest: only trust a well-formed entry,
+          // otherwise fall back to the template-built URL.
+          const list = manifestDownloads[target];
+          const entry = Array.isArray(list) ? list.find((d) => d && d.kind === kind) : undefined;
+          if (entry && typeof entry.url === 'string') return entry.url;
         }
         return asset(fallbackFilename);
       }
@@ -624,7 +627,8 @@
         const btn = document.getElementById('mac-download');
 
         function refresh(a) {
-          btn.href = files[a]();
+          // A stale persisted arch value must not break the page.
+          btn.href = (files[a] || files.arm64)();
         }
 
         const arch = segmented('#panel-macos .segmented button', 'arch', 'arm64', refresh);
@@ -663,7 +667,10 @@
         };
 
         function refresh() {
-          const entry = files[arch.get()][format.get()];
+          // Same guard as macOS: stale persisted arch or format values fall
+          // back to the defaults instead of throwing.
+          const perArch = files[arch.get()] || files.x64;
+          const entry = perArch[format.get()] || perArch.deb;
           btn.href = entry.url();
           label.textContent = entry.label;
           Object.keys(installBlocks).forEach((k) => {

--- a/web/index.html
+++ b/web/index.html
@@ -555,6 +555,9 @@
           const list = manifestDownloads[target];
           const entry = Array.isArray(list) ? list.find((d) => d && d.kind === kind) : undefined;
           if (entry && typeof entry.url === 'string') return entry.url;
+          // A loaded manifest without this pair means the asset naming
+          // drifted; that is exactly what this page must not hide.
+          console.warn('latest.json has no ' + kind + ' entry for ' + target + '; using template-built URL');
         }
         return asset(fallbackFilename);
       }

--- a/web/index.html
+++ b/web/index.html
@@ -556,7 +556,7 @@
         return asset(fallbackFilename);
       }
 
-      fetch('latest.json')
+      fetch('latest.json', { cache: 'no-store' })
         .then((r) => (r.ok ? r.json() : null))
         .then((manifest) => {
           if (manifest && manifest.downloads) {
@@ -611,13 +611,13 @@
         };
         const btn = document.getElementById('mac-download');
 
-        function refresh() {
-          btn.href = files[arch.get()]();
+        function refresh(a) {
+          btn.href = files[a]();
         }
 
         const arch = segmented('#panel-macos .segmented button', 'arch', 'arm64', refresh);
-        refresh();
-        onManifest.push(refresh);
+        refresh(arch.get());
+        onManifest.push(() => refresh(arch.get()));
 
         if (detected === 'macos') {
           detectArchAsync().then((a) => { if (a) arch.set(a); });

--- a/web/index.html
+++ b/web/index.html
@@ -562,7 +562,8 @@
         return asset(fallbackFilename);
       }
 
-      fetch('latest.json', { cache: 'no-store' })
+      // no-cache revalidates on each load but still allows conditional 304s.
+      fetch('latest.json', { cache: 'no-cache' })
         .then((r) => {
           if (!r.ok) {
             console.warn('latest.json returned ' + r.status + '; using template-built download URLs');
@@ -573,7 +574,10 @@
         .then((manifest) => {
           if (manifest && manifest.downloads) {
             manifestDownloads = manifest.downloads;
-            onManifest.forEach((refresh) => refresh());
+            onManifest.forEach((refresh) => {
+              // One failing refresh must not keep the rest on fallback URLs.
+              try { refresh(); } catch (e) { console.warn('manifest refresh failed', e); }
+            });
           } else if (manifest) {
             console.warn('latest.json has no downloads block; using template-built download URLs');
           }

--- a/web/index.html
+++ b/web/index.html
@@ -537,6 +537,35 @@
         return { set, get: () => value };
       }
 
+      // ---- Release manifest ----
+      // The deploy workflow publishes latest.json next to this page; its
+      // `downloads` block carries the real release-asset URLs. Prefer those
+      // over hand-built filenames so the page can't drift from the actual
+      // asset naming; the template-built fallbacks below only apply when the
+      // fetch fails (offline, manifest missing, etc).
+      let manifestDownloads = null;
+      const onManifest = [];
+
+      // Resolve the download URL for a Tauri platform target + installer
+      // kind, falling back to a hand-built release-asset filename.
+      function urlFor(target, kind, fallbackFilename) {
+        if (manifestDownloads) {
+          const entry = (manifestDownloads[target] || []).find((d) => d.kind === kind);
+          if (entry) return entry.url;
+        }
+        return asset(fallbackFilename);
+      }
+
+      fetch('latest.json')
+        .then((r) => (r.ok ? r.json() : null))
+        .then((manifest) => {
+          if (manifest && manifest.downloads) {
+            manifestDownloads = manifest.downloads;
+            onManifest.forEach((refresh) => refresh());
+          }
+        })
+        .catch(() => { /* keep the template-built fallback URLs */ });
+
       // ---- Tabs ----
       const TAB_ORDER = ['windows', 'macos', 'linux'];
       const tabs = document.querySelectorAll('[role="tab"]');
@@ -566,20 +595,29 @@
 
       // ---- Windows ----
       function setupWindows() {
-        document.getElementById('windows-download').href = asset(`ESPHome.Device.Builder_${VERSION}_x64-setup.exe`);
+        function refresh() {
+          document.getElementById('windows-download').href =
+            urlFor('windows-x86_64', 'nsis', `ESPHome.Device.Builder_${VERSION}_x64-setup.exe`);
+        }
+        refresh();
+        onManifest.push(refresh);
       }
 
       // ---- macOS ----
       function setupMacOS(detected) {
         const files = {
-          arm64: asset(`ESPHome.Device.Builder_${VERSION}_aarch64.dmg`),
-          x64: asset(`ESPHome.Device.Builder_${VERSION}_x64.dmg`),
+          arm64: () => urlFor('darwin-aarch64', 'dmg', `ESPHome.Device.Builder_${VERSION}_aarch64.dmg`),
+          x64: () => urlFor('darwin-x86_64', 'dmg', `ESPHome.Device.Builder_${VERSION}_x64.dmg`),
         };
         const btn = document.getElementById('mac-download');
-        const arch = segmented('#panel-macos .segmented button', 'arch', 'arm64', (a) => {
-          btn.href = files[a];
-        });
-        btn.href = files[arch.get()];
+
+        function refresh() {
+          btn.href = files[arch.get()]();
+        }
+
+        const arch = segmented('#panel-macos .segmented button', 'arch', 'arm64', refresh);
+        refresh();
+        onManifest.push(refresh);
 
         if (detected === 'macos') {
           detectArchAsync().then((a) => { if (a) arch.set(a); });
@@ -588,19 +626,19 @@
 
       // ---- Linux ----
       function setupLinux(detected) {
-        const AUR = { url: 'https://aur.archlinux.org/packages/esphome-desktop-bin', label: 'View on AUR' };
+        const AUR = { url: () => 'https://aur.archlinux.org/packages/esphome-desktop-bin', label: 'View on AUR' };
         const files = {
           x64: {
-            deb: { url: asset(`ESPHome.Device.Builder_${VERSION}_amd64.deb`), label: 'Download .deb' },
-            rpm: { url: asset(`ESPHome.Device.Builder-${VERSION}-1.x86_64.rpm`), label: 'Download .rpm' },
+            deb: { url: () => urlFor('linux-x86_64', 'deb', `ESPHome.Device.Builder_${VERSION}_amd64.deb`), label: 'Download .deb' },
+            rpm: { url: () => urlFor('linux-x86_64', 'rpm', `ESPHome.Device.Builder-${VERSION}-1.x86_64.rpm`), label: 'Download .rpm' },
             aur: AUR,
-            appimage: { url: asset(`ESPHome.Device.Builder_${VERSION}_amd64.AppImage`), label: 'Download AppImage' },
+            appimage: { url: () => urlFor('linux-x86_64', 'appimage', `ESPHome.Device.Builder_${VERSION}_amd64.AppImage`), label: 'Download AppImage' },
           },
           arm64: {
-            deb: { url: asset(`ESPHome.Device.Builder_${VERSION}_arm64.deb`), label: 'Download .deb' },
-            rpm: { url: asset(`ESPHome.Device.Builder-${VERSION}-1.aarch64.rpm`), label: 'Download .rpm' },
+            deb: { url: () => urlFor('linux-aarch64', 'deb', `ESPHome.Device.Builder_${VERSION}_arm64.deb`), label: 'Download .deb' },
+            rpm: { url: () => urlFor('linux-aarch64', 'rpm', `ESPHome.Device.Builder-${VERSION}-1.aarch64.rpm`), label: 'Download .rpm' },
             aur: AUR,
-            appimage: { url: asset(`ESPHome.Device.Builder_${VERSION}_aarch64.AppImage`), label: 'Download AppImage' },
+            appimage: { url: () => urlFor('linux-aarch64', 'appimage', `ESPHome.Device.Builder_${VERSION}_aarch64.AppImage`), label: 'Download AppImage' },
           },
         };
         const btn = document.getElementById('linux-download');
@@ -614,7 +652,7 @@
 
         function refresh() {
           const entry = files[arch.get()][format.get()];
-          btn.href = entry.url;
+          btn.href = entry.url();
           label.textContent = entry.label;
           Object.keys(installBlocks).forEach((k) => {
             installBlocks[k].hidden = k !== format.get();
@@ -624,6 +662,7 @@
         const format = segmented('#panel-linux [aria-label="Linux package format"] button', 'format', 'deb', refresh);
         const arch = segmented('#panel-linux [aria-label="Linux architecture"] button', 'arch', 'x64', refresh);
         refresh();
+        onManifest.push(refresh);
 
         if (detected === 'linux') {
           if (/aarch64|arm64/i.test(`${platform} ${ua}`)) arch.set('arm64');

--- a/web/index.html
+++ b/web/index.html
@@ -557,14 +557,26 @@
       }
 
       fetch('latest.json', { cache: 'no-store' })
-        .then((r) => (r.ok ? r.json() : null))
+        .then((r) => {
+          if (!r.ok) {
+            console.warn('latest.json returned ' + r.status + '; using template-built download URLs');
+            return null;
+          }
+          return r.json();
+        })
         .then((manifest) => {
           if (manifest && manifest.downloads) {
             manifestDownloads = manifest.downloads;
             onManifest.forEach((refresh) => refresh());
+          } else if (manifest) {
+            console.warn('latest.json has no downloads block; using template-built download URLs');
           }
         })
-        .catch(() => { /* keep the template-built fallback URLs */ });
+        .catch((e) => {
+          // Keep the template-built fallback URLs, but leave a trail so a
+          // broken manifest deploy is diagnosable from the console.
+          console.warn('latest.json fetch failed; using template-built download URLs', e);
+        });
 
       // ---- Tabs ----
       const TAB_ORDER = ['windows', 'macos', 'linux'];


### PR DESCRIPTION
# What does this implement/fix?

The download page in web/index.html now fetches the published latest.json (mirrored next to the page by deploy-pages) and takes each platform's installer URL from its `downloads` block, so the Windows, macOS, and Linux links are derived from the actual release assets instead of hand-built `ESPHome.Device.Builder_${VERSION}_<arch>.<ext>` template strings. If the fetch fails the page keeps the template-built URLs as a fallback, so behavior is unchanged when the manifest is unavailable. The manifest already carries every platform and format the page offers, so generate_latest_json.py needed no changes; the AUR packaging keeps its pinned URL, since PKGBUILD and publish-aur.yml cannot practically consume latest.json at install time.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- closes #266

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).

