### PR TITLE
Move the Rust CI setup to a composite action

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,0 +1,49 @@
+name: Setup Rust
+description: >-
+  Installs the Rust toolchain and configures the Swatinem/rust-cache settings
+  shared by every Rust CI job. Per-job knobs (toolchain, targets, components,
+  cache key, cache-bin) come in as inputs.
+
+inputs:
+  toolchain:
+    description: Rust toolchain specification passed to dtolnay/rust-toolchain.
+    required: false
+    default: stable
+  targets:
+    description: Comma-separated list of extra target triples to install.
+    required: false
+    default: ""
+  components:
+    description: Comma-separated list of toolchain components to install.
+    required: false
+    default: ""
+  cache-key:
+    description: Swatinem/rust-cache key for this job.
+    required: true
+  cache-bin:
+    description: >-
+      Whether Swatinem/rust-cache caches ~/.cargo/bin. Defaults to "false" as
+      a workaround for Swatinem/rust-cache#341 — caching ~/.cargo/bin produces
+      broken cargo/rustc symlinks on the new macOS runner image (harmless to
+      skip on the other platforms).
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Rust
+      uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # v1, toolchain selected via the input
+      with:
+        toolchain: ${{ inputs.toolchain }}
+        targets: ${{ inputs.targets }}
+        components: ${{ inputs.components }}
+
+    - name: Setup Rust cache
+      uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      with:
+        workspaces: src-tauri
+        key: ${{ inputs.cache-key }}
+        # Workaround for Swatinem/rust-cache#341 — caching ~/.cargo/bin
+        # produces broken cargo/rustc symlinks on the new macOS runner image.
+        cache-bin: ${{ inputs.cache-bin }}

--- a/.github/actions/stub-bundle-dirs/action.yml
+++ b/.github/actions/stub-bundle-dirs/action.yml
@@ -1,0 +1,16 @@
+name: Stub bundle resource dirs
+description: >-
+  Creates empty stubs for the gitignored `python`, `git` and `ccache` dirs
+  that `tauri.conf.json` lists as bundle resources. They're populated by
+  prepare_bundle.sh only for real bundling; a plain `cargo test`/`clippy`
+  never bundles, but the stubs keep config parsing from tripping on the
+  missing paths. Keep the list in sync with tauri.conf.json and
+  prepare_bundle.sh.
+
+runs:
+  using: composite
+  steps:
+    - name: Stub bundle resource dirs
+      # `bash` so `mkdir -p` works on the Windows runner too.
+      shell: bash
+      run: mkdir -p src-tauri/python src-tauri/git src-tauri/ccache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,19 +91,13 @@ jobs:
         if: matrix.platform == 'linux'
         uses: ./.github/actions/linux-tauri-deps
 
+      # Floating `stable` toolchain (the action's default), unlike the pinned
+      # lint gates in lint-test.yml.
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+        uses: ./.github/actions/setup-rust
         with:
           targets: ${{ matrix.rust_target }}
-
-      - name: Setup Rust cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          workspaces: src-tauri
-          key: ${{ matrix.target }}
-          # Workaround for Swatinem/rust-cache#341 — caching ~/.cargo/bin
-          # produces broken cargo/rustc symlinks on the new macOS runner image.
-          cache-bin: false
+          cache-key: ${{ matrix.target }}
 
       # Resolve a tauri-cli version from the locked `tauri` crate version so it
       # tracks Dependabot's cargo bumps automatically (no hardcoded version to go

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -44,24 +44,17 @@ jobs:
       # adopt newer lints. 1.96.0 is the version that established the green
       # clippy/fmt baseline this workflow enforces.
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # v1, pinned via toolchain: below
+        uses: ./.github/actions/setup-rust
         with:
           toolchain: 1.96.0
           components: clippy, rustfmt
+          cache-key: lint-test
+          # The rust-cache#341 workaround (the action's default) only matters
+          # on macOS; this job has always cached ~/.cargo/bin, so keep doing so.
+          cache-bin: "true"
 
-      - name: Setup Rust cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          workspaces: src-tauri
-          key: lint-test
-
-      # `tauri.conf.json` lists `python`, `git` and `ccache` as bundle
-      # resources. Those directories are gitignored and absent on a fresh
-      # checkout (they're populated by prepare_bundle.sh only for real
-      # bundling). A plain `cargo test`/`clippy` never bundles, but create empty
-      # stubs so config parsing can't trip on the missing paths.
       - name: Stub bundle resource dirs
-        run: mkdir -p src-tauri/python src-tauri/git src-tauri/ccache
+        uses: ./.github/actions/stub-bundle-dirs
 
       # Required gates. clippy and rustfmt were introduced as advisory in the
       # first iteration of this workflow because they had never run in CI and the
@@ -116,29 +109,17 @@ jobs:
       # deps are needed: Tauri uses the system WebView2 (Windows) / WKWebView
       # (macOS), not the GTK/webkit stack.
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # v1, pinned via toolchain: below
+        uses: ./.github/actions/setup-rust
         with:
           toolchain: 1.96.0
           components: clippy, rustfmt
+          cache-key: lint-test-${{ matrix.os }}
 
-      - name: Setup Rust cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          workspaces: src-tauri
-          key: lint-test-${{ matrix.os }}
-          # Workaround for Swatinem/rust-cache#341 — caching ~/.cargo/bin
-          # produces broken cargo/rustc symlinks on the new macOS runner image
-          # (matches build.yml). Harmless on Windows.
-          cache-bin: false
-
-      # Stub the gitignored `python`, `git` and `ccache` bundle resources (see
-      # the Linux job). `tauri.conf.json` declares all three at the top-level
-      # `bundle` block, so they're resources on macOS/Windows too (git = MinGit,
-      # ccache = bundled ccache on Windows). `bash` is forced so `mkdir -p` works
-      # on the Windows runner too.
+      # `tauri.conf.json` declares `python`, `git` and `ccache` at the
+      # top-level `bundle` block, so they're resources on macOS/Windows too
+      # (git = MinGit, ccache = bundled ccache on Windows).
       - name: Stub bundle resource dirs
-        shell: bash
-        run: mkdir -p src-tauri/python src-tauri/git src-tauri/ccache
+        uses: ./.github/actions/stub-bundle-dirs
 
       # fmt is cfg-agnostic and already green on Linux; advisory here only to
       # guard against a Windows newline quirk on this first run.


### PR DESCRIPTION
# What does this implement/fix?

Moves the pinned dtolnay/rust-toolchain plus Swatinem/rust-cache setup, duplicated three times across build.yml and lint-test.yml, into a shared composite action at .github/actions/setup-rust; per job differences (toolchain, targets, components, cache key, cache-bin) become inputs, and the action keeps the exact SHA pins and the rust-cache#341 cache-bin workaround comment. The stub bundle resource dirs step that appeared twice in lint-test.yml moves into a second tiny action at .github/actions/stub-bundle-dirs, which also notes that the dir list must stay in sync with tauri.conf.json and prepare_bundle.sh. No behavior change; each job installs the same toolchain and uses the same cache settings as before, including the Linux lint job keeping cache-bin true.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- closes #270

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).

Stacked on #278; merge that first.

