### PR TITLE
Add a shared helper for Python subprocess capture

### DIFF
--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -682,10 +682,10 @@ fn snapshot_preserved_versions(
 /// gutted stdlib still executes it cleanly while every import fails.
 #[cfg(not(target_os = "windows"))]
 fn interpreter_is_usable(python_bin: &Path) -> bool {
-    let mut cmd = std::process::Command::new(python_bin);
-    cmd.args(["-c", "import importlib.metadata"]);
-    configure_no_window_command(&mut cmd);
-    matches!(cmd.output(), Ok(o) if o.status.success())
+    matches!(
+        run_python_capture(python_bin, ["-c", "import importlib.metadata"]),
+        Ok(o) if o.status.success()
+    )
 }
 
 /// Read the consecutive-defer counter, returning 0 when the marker is missing
@@ -791,11 +791,7 @@ fn read_package_version(python_bin: &Path, package: &str) -> Result<Option<Strin
         "from importlib.metadata import version, PackageNotFoundError\ntry: print(version('{}'))\nexcept PackageNotFoundError: pass",
         package
     );
-    let mut cmd = std::process::Command::new(python_bin);
-    cmd.args(["-c", &script]);
-    configure_no_window_command(&mut cmd);
-    let output = cmd
-        .output()
+    let output = run_python_capture(python_bin, ["-c", &script])
         .with_context(|| format!("Failed to run version probe for {package} via {python_bin:?}"))?;
     parse_probe_output(
         package,
@@ -1030,11 +1026,40 @@ pub fn is_esphome_ready(app_handle: &AppHandle) -> bool {
     };
 
     // Try to run esphome version
-    let mut cmd = std::process::Command::new(&python_path);
-    cmd.args(["-m", "esphome", "version"]);
-    configure_no_window_command(&mut cmd);
+    run_python_capture(&python_path, ["-m", "esphome", "version"])
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
 
-    cmd.output().map(|o| o.status.success()).unwrap_or(false)
+/// Spawn the given Python interpreter with `args`, suppress the console
+/// window on Windows, and capture its output. This only removes the
+/// spawn/capture boilerplate: it adds no flags of its own (callers pass
+/// exactly the flags they need, `-I` included or not), and callers keep their
+/// own policy for exit status, logging, and stdout/stderr interpretation.
+pub fn run_python_capture<S: AsRef<OsStr>>(
+    python: &Path,
+    args: impl IntoIterator<Item = S>,
+) -> std::io::Result<std::process::Output> {
+    let mut cmd = std::process::Command::new(python);
+    cmd.args(args);
+    configure_no_window_command(&mut cmd);
+    cmd.output()
+}
+
+/// [`run_python_capture`], returning the trimmed stdout on a successful exit
+/// and `None` on a non-zero exit. stderr is discarded, so callers that need
+/// it (or the exit status) should use [`run_python_capture`] directly.
+pub fn run_python_capture_stdout<S: AsRef<OsStr>>(
+    python: &Path,
+    args: impl IntoIterator<Item = S>,
+) -> std::io::Result<Option<String>> {
+    let output = run_python_capture(python, args)?;
+    if !output.status.success() {
+        return Ok(None);
+    }
+    Ok(Some(
+        String::from_utf8_lossy(&output.stdout).trim().to_string(),
+    ))
 }
 
 /// Configure std::process::Command to not create a console window on Windows

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -1047,8 +1047,9 @@ pub fn run_python_capture<S: AsRef<OsStr>>(
 }
 
 /// [`run_python_capture`], returning the trimmed stdout on a successful exit
-/// and `None` on a non-zero exit. stderr is discarded, so callers that need
-/// it (or the exit status) should use [`run_python_capture`] directly.
+/// and `None` on a non-zero exit. stderr is captured but not returned, so
+/// callers that need it (or the exit status) should use
+/// [`run_python_capture`] directly.
 pub fn run_python_capture_stdout<S: AsRef<OsStr>>(
     python: &Path,
     args: impl IntoIterator<Item = S>,

--- a/src-tauri/src/update/mod.rs
+++ b/src-tauri/src/update/mod.rs
@@ -709,16 +709,16 @@ const DEVICE_BUILDER_MAINT_PY: &str = include_str!("../../scripts/device_builder
 pub fn get_installed_device_builder_version(app_handle: &AppHandle) -> Result<Option<String>> {
     let python_path = platform::get_python_path(app_handle)?;
 
-    let mut cmd = std::process::Command::new(&python_path);
     // Enumerate all device-builder distributions and take the highest version,
     // which is robust to the duplicate dist-info pileup that makes a plain
     // `importlib.metadata.version(...)` return None or an older version (#190).
     // `-I` (isolated) keeps user site-packages, PYTHONPATH and sitecustomize off
     // sys.path so detection only ever sees the managed bundled install.
-    cmd.args(["-I", "-c", DEVICE_BUILDER_MAINT_PY, "detect"]);
-    platform::configure_no_window_command(&mut cmd);
-
-    let output = cmd.output().context("Failed to run python")?;
+    let output = platform::run_python_capture(
+        &python_path,
+        ["-I", "-c", DEVICE_BUILDER_MAINT_PY, "detect"],
+    )
+    .context("Failed to run python")?;
 
     if output.status.success() {
         // `detect` logs skipped/unreadable distributions to stderr; surface it so
@@ -761,14 +761,14 @@ pub fn get_installed_device_builder_version(app_handle: &AppHandle) -> Result<Op
 pub fn dedupe_device_builder_dist_info(app_handle: &AppHandle) -> Result<()> {
     let python_path = platform::get_python_path(app_handle)?;
 
-    let mut cmd = std::process::Command::new(&python_path);
     // `-I` (isolated) keeps user site-packages, PYTHONPATH and sitecustomize off
     // sys.path so this destructive prune can only ever touch the managed bundled
     // install, never a user-site or externally-injected tree.
-    cmd.args(["-I", "-c", DEVICE_BUILDER_MAINT_PY, "dedupe"]);
-    platform::configure_no_window_command(&mut cmd);
-
-    let output = cmd.output().context("Failed to run dist-info dedup")?;
+    let output = platform::run_python_capture(
+        &python_path,
+        ["-I", "-c", DEVICE_BUILDER_MAINT_PY, "dedupe"],
+    )
+    .context("Failed to run dist-info dedup")?;
 
     if output.status.success() {
         // The helper logs dist-info it couldn't read or remove to stderr;
@@ -965,16 +965,12 @@ where
 pub fn installed_esphome_version(app_handle: &AppHandle) -> Result<Option<String>> {
     let python_path = platform::get_python_path(app_handle)?;
 
-    let mut cmd = std::process::Command::new(&python_path);
-    cmd.args(["-m", "esphome", "version"]);
-    platform::configure_no_window_command(&mut cmd);
-
-    let output = cmd.output().context("Failed to run esphome version")?;
-
-    if !output.status.success() {
+    let Some(version) =
+        platform::run_python_capture_stdout(&python_path, ["-m", "esphome", "version"])
+            .context("Failed to run esphome version")?
+    else {
         return Ok(None);
-    }
-    let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    };
     // Extract just the version number
     let version = version
         .strip_prefix("Version: ")


### PR DESCRIPTION
# What does this implement/fix?

Adds `platform::run_python_capture`, which spawns the given Python with the given args, applies `configure_no_window_command`, and captures the output, plus a thin `run_python_capture_stdout` wrapper that returns trimmed stdout on a successful exit. The six duplicated spawn/capture sites in update/mod.rs (`get_installed_device_builder_version`, `dedupe_device_builder_dist_info`, `installed_esphome_version`) and platform/mod.rs (`interpreter_is_usable`, `read_package_version`, `is_esphome_ready`) now go through the helper; the seventh copy in settings was removed by the parent PR. Each call site keeps its exact args, non zero exit handling, and logging, so the existing flag differences between sites (`-I` present or not) are preserved as is; no behavior change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- closes #254

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).

Stacked on #275; merge that first.

