### PR TITLE
Deduplicate AppImage discovery and tag strip in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -264,6 +264,17 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
 
+      # Locate the built AppImage once. The inject step below repacks it in
+      # place and the re-sign step must sign that same file, so both read this
+      # output rather than repeating the find.
+      - name: Locate AppImage
+        id: appimage
+        if: contains(matrix.bundles, 'appimage')
+        run: |
+          set -euo pipefail
+          APPIMAGE=$(find src-tauri/target/release/bundle/appimage -name "*.AppImage" | head -1)
+          echo "path=$APPIMAGE" >> "$GITHUB_OUTPUT"
+
       # The sharun-based AppImage format uses DwarFS and does not include Tauri
       # resources. The build leaves the AppDir intact, so we inject Python into
       # it and repack with mkdwarfs + the uruntime header.
@@ -272,7 +283,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          APPIMAGE=$(find src-tauri/target/release/bundle/appimage -name "*.AppImage" | head -1)
+          APPIMAGE="${{ steps.appimage.outputs.path }}"
           APPDIR="src-tauri/target/release/bundle/appimage/ESPHome Device Builder.AppDir"
           echo "Found AppImage: $APPIMAGE"
           echo "AppDir: $APPDIR"
@@ -353,7 +364,7 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: |
           set -euo pipefail
-          APPIMAGE=$(find src-tauri/target/release/bundle/appimage -name "*.AppImage" | head -1)
+          APPIMAGE="${{ steps.appimage.outputs.path }}"
           cargo tauri signer sign \
             --private-key "$TAURI_SIGNING_PRIVATE_KEY" \
             --password "$TAURI_SIGNING_PRIVATE_KEY_PASSWORD" \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -272,8 +272,12 @@ jobs:
         if: contains(matrix.bundles, 'appimage')
         run: |
           set -euo pipefail
-          APPIMAGE=$(find src-tauri/target/release/bundle/appimage -name "*.AppImage" | head -1)
-          echo "path=$APPIMAGE" >> "$GITHUB_OUTPUT"
+          mapfile -t APPIMAGES < <(find src-tauri/target/release/bundle/appimage -name "*.AppImage")
+          if [ "${#APPIMAGES[@]}" -ne 1 ]; then
+            echo "expected exactly one AppImage, found ${#APPIMAGES[@]}: ${APPIMAGES[*]}" >&2
+            exit 1
+          fi
+          printf 'path=%s\n' "${APPIMAGES[0]}" >> "$GITHUB_OUTPUT"
 
       # The sharun-based AppImage format uses DwarFS and does not include Tauri
       # resources. The build leaves the AppDir intact, so we inject Python into

--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -16,6 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    # The stripped release version, computed once here and reused by the
+    # publish job instead of stripping the tag again.
+    outputs:
+      version: ${{ steps.release.outputs.version }}
 
     steps:
       - name: Checkout
@@ -101,13 +105,6 @@ jobs:
     environment: aur
 
     steps:
-      - name: Get version
-        id: release
-        run: |
-          VERSION="${{ github.event.release.tag_name }}"
-          VERSION="${VERSION#v}"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
       - name: Download artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -134,7 +131,7 @@ jobs:
           cp ../aur-pkg/PKGBUILD PKGBUILD
           cp ../aur-pkg/.SRCINFO .SRCINFO
           git add PKGBUILD .SRCINFO
-          git commit -m "Update to version ${{ steps.release.outputs.version }}"
+          git commit -m "Update to version ${{ needs.generate.outputs.version }}"
           GIT_SSH_COMMAND="ssh -i ~/.ssh/aur" git push origin master
 
       - name: Cleanup


### PR DESCRIPTION
# What does this implement/fix?

In build.yml the AppImage path is now located once in a dedicated Locate AppImage step and both the Python inject step and the updater re-sign step read its output, so the re-sign step is guaranteed to sign the same file the build produced. In publish-aur.yml the v prefix strip now happens once in the generate job, which exposes the stripped version as a job output that the publish job reuses; deploy-pages.yml and release-drafter.yml already strip once into a step output, so they are untouched. No behavior change; each site keeps the exact stripping semantics it had.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- closes #273

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).

Stacked on #280; merge that first.

