### PR TITLE
Unify the ESPHome and device builder check and notify flows

### DIFF
--- a/src-tauri/src/app_update/mod.rs
+++ b/src-tauri/src/app_update/mod.rs
@@ -15,7 +15,6 @@ use std::time::Duration;
 
 use tauri::{AppHandle, Manager};
 use tauri_plugin_dialog::MessageDialogKind;
-use tauri_plugin_notification::NotificationExt;
 use tauri_plugin_updater::UpdaterExt;
 use tracing::{debug, error, info, warn};
 
@@ -121,18 +120,13 @@ pub async fn check_and_notify(app_handle: &AppHandle, tray_available: bool) -> N
                 "Desktop update available in background: {} (current: {})",
                 update.version, update.current_version
             );
-            if let Err(e) = app_handle
-                .notification()
-                .builder()
-                .title("ESPHome Device Builder Update Available")
-                .body(format!(
-                    "Version {} is available (you have {}). {}",
-                    update.version,
-                    update.current_version,
-                    crate::updates_menu_hint(tray_available)
-                ))
-                .show()
-            {
+            if let Err(e) = crate::update::notify_update_available(
+                app_handle,
+                "ESPHome Device Builder Update Available",
+                &format!("Version {}", update.version),
+                &update.current_version,
+                tray_available,
+            ) {
                 error!("Failed to show desktop-update notification: {}", e);
             }
             NextStep::Skip

--- a/src-tauri/src/update/mod.rs
+++ b/src-tauri/src/update/mod.rs
@@ -194,14 +194,21 @@ impl UpdateChecker {
             }
         };
 
-        // Compare versions and ask the user (dev never reaches here, so
-        // channel_name only ever yields "stable" or "beta")
+        // Compare versions and ask the user. Dev is handled at the top of
+        // this function, so channel_name only ever yields "stable" or "beta";
+        // keep that invariant explicit.
+        let channel_label = match channel {
+            ReleaseChannel::Stable | ReleaseChannel::Beta => channel_name(channel),
+            ReleaseChannel::Dev => {
+                unreachable!("dev channel is handled before the shared check tail")
+            }
+        };
         prompt_if_newer(
             app_handle,
             &UpdateWording {
                 component: "ESPHome",
                 log_prefix: "Update",
-                channel_label: Some(channel_name(channel)),
+                channel_label: Some(channel_label),
             },
             "Update Available",
             latest,
@@ -247,14 +254,21 @@ impl UpdateChecker {
             }
         };
 
-        // Compare versions and notify (dev never reaches here, so
-        // channel_name only ever yields "stable" or "beta")
+        // Compare versions and notify. Dev is handled at the top of this
+        // function, so channel_name only ever yields "stable" or "beta";
+        // keep that invariant explicit.
+        let channel_label = match channel {
+            ReleaseChannel::Stable | ReleaseChannel::Beta => channel_name(channel),
+            ReleaseChannel::Dev => {
+                unreachable!("dev channel is handled before the shared check tail")
+            }
+        };
         notify_if_newer(
             app_handle,
             &UpdateWording {
                 component: "ESPHome",
                 log_prefix: "Update",
-                channel_label: Some(channel_name(channel)),
+                channel_label: Some(channel_label),
             },
             &latest,
             &installed,
@@ -541,6 +555,22 @@ impl UpdateWording<'_> {
             None => format!("{} {}", self.component, version),
         }
     }
+
+    /// Full body of the "would you like to update now?" confirm dialog shown
+    /// by [`prompt_if_newer`].
+    fn prompt_message(&self, latest: &str, installed: &str) -> String {
+        format!(
+            "{} is available.\n\nYou currently have version {}.\n\nWould you like to update now?",
+            self.subject(latest),
+            installed
+        )
+    }
+
+    /// Title of the background "update available" notification shown by
+    /// [`notify_if_newer`].
+    fn notification_title(&self) -> String {
+        format!("{} Update Available", self.component)
+    }
 }
 
 /// Shared tail of the user-initiated update checks: compare versions and, when
@@ -576,11 +606,7 @@ async fn prompt_if_newer(
         wording.log_prefix, installed, latest, installed
     );
 
-    let msg = format!(
-        "{} is available.\n\nYou currently have version {}.\n\nWould you like to update now?",
-        wording.subject(&latest),
-        installed
-    );
+    let msg = wording.prompt_message(&latest, installed);
     if crate::dialog::confirm(app_handle, title, msg, "Update Now", "Later").await {
         Some(latest)
     } else {
@@ -611,7 +637,7 @@ fn notify_if_newer(
 
     if let Err(e) = notify_update_available(
         app_handle,
-        &format!("{} Update Available", wording.component),
+        &wording.notification_title(),
         &wording.subject(latest),
         installed,
         tray_available,
@@ -634,13 +660,19 @@ pub(crate) fn notify_update_available(
         .notification()
         .builder()
         .title(title)
-        .body(format!(
-            "{} is available (you have {}). {}",
-            subject,
-            installed,
-            crate::updates_menu_hint(tray_available)
-        ))
+        .body(update_notification_body(subject, installed, tray_available))
         .show()
+}
+
+/// Body of the standard "update available" notification, shared by every
+/// caller of [`notify_update_available`].
+fn update_notification_body(subject: &str, installed: &str, tray_available: bool) -> String {
+    format!(
+        "{} is available (you have {}). {}",
+        subject,
+        installed,
+        crate::updates_menu_hint(tray_available)
+    )
 }
 
 /// Choose the version to offer on the beta channel.
@@ -1170,17 +1202,80 @@ mod tests {
         args.iter().any(|a| a == flag)
     }
 
-    #[test]
-    fn subject_appends_channel_label_when_present() {
-        let esphome = UpdateWording {
+    /// The ESPHome wording as built by the check tails (channel label present).
+    fn esphome_wording() -> UpdateWording<'static> {
+        UpdateWording {
             component: "ESPHome",
             log_prefix: "Update",
             channel_label: Some("stable"),
-        };
-        assert_eq!(esphome.subject("2025.1.0"), "ESPHome 2025.1.0 (stable)");
+        }
+    }
+
+    #[test]
+    fn subject_appends_channel_label_when_present() {
+        assert_eq!(
+            esphome_wording().subject("2025.1.0"),
+            "ESPHome 2025.1.0 (stable)"
+        );
         assert_eq!(
             DEVICE_BUILDER_WORDING.subject("1.2.3"),
             "ESPHome Device Builder 1.2.3"
+        );
+    }
+
+    #[test]
+    fn prompt_message_pins_exact_dialog_text() {
+        assert_eq!(
+            esphome_wording().prompt_message("2025.1.0", "2024.12.2"),
+            "ESPHome 2025.1.0 (stable) is available.\n\n\
+             You currently have version 2024.12.2.\n\n\
+             Would you like to update now?"
+        );
+        assert_eq!(
+            DEVICE_BUILDER_WORDING.prompt_message("1.2.3", "1.2.2"),
+            "ESPHome Device Builder 1.2.3 is available.\n\n\
+             You currently have version 1.2.2.\n\n\
+             Would you like to update now?"
+        );
+    }
+
+    #[test]
+    fn notification_title_pins_exact_text() {
+        assert_eq!(
+            esphome_wording().notification_title(),
+            "ESPHome Update Available"
+        );
+        assert_eq!(
+            DEVICE_BUILDER_WORDING.notification_title(),
+            "ESPHome Device Builder Update Available"
+        );
+    }
+
+    #[test]
+    fn notification_body_pins_exact_text_for_both_tray_states() {
+        // With a tray, the hint points at the tray menu.
+        assert_eq!(
+            update_notification_body(&esphome_wording().subject("2025.1.0"), "2024.12.2", true),
+            "ESPHome 2025.1.0 (stable) is available (you have 2024.12.2). \
+             Open the tray menu and choose \"Check for Updates...\" to update."
+        );
+        assert_eq!(
+            update_notification_body(&DEVICE_BUILDER_WORDING.subject("1.2.3"), "1.2.2", true),
+            "ESPHome Device Builder 1.2.3 is available (you have 1.2.2). \
+             Open the tray menu and choose \"Check for Updates...\" to update."
+        );
+        // Without a tray, the hint falls back to the CLI.
+        assert_eq!(
+            update_notification_body(&esphome_wording().subject("2025.1.0"), "2024.12.2", false),
+            "ESPHome 2025.1.0 (stable) is available (you have 2024.12.2). \
+             No system tray was detected. Run `esphome-desktop update` from a \
+             terminal to update."
+        );
+        assert_eq!(
+            update_notification_body(&DEVICE_BUILDER_WORDING.subject("1.2.3"), "1.2.2", false),
+            "ESPHome Device Builder 1.2.3 is available (you have 1.2.2). \
+             No system tray was detected. Run `esphome-desktop update` from a \
+             terminal to update."
         );
     }
 

--- a/src-tauri/src/update/mod.rs
+++ b/src-tauri/src/update/mod.rs
@@ -12,6 +12,7 @@ use tauri_plugin_dialog::MessageDialogKind;
 use tauri_plugin_notification::NotificationExt;
 use tracing::{debug, error, info, warn};
 
+use crate::control::protocol::channel_name;
 use crate::platform;
 use crate::settings::{Backend, ReleaseChannel};
 
@@ -193,44 +194,21 @@ impl UpdateChecker {
             }
         };
 
-        // Compare versions
-        if is_newer_version(&latest, &installed) {
-            info!(
-                "Update available: {} -> {} (installed: {})",
-                installed, latest, installed
-            );
-
-            let channel_label = match channel {
-                ReleaseChannel::Stable => "stable",
-                ReleaseChannel::Beta => "beta",
-                ReleaseChannel::Dev => unreachable!(),
-            };
-
-            // Ask user if they want to update
-            let msg = format!(
-                "ESPHome {} ({}) is available.\n\nYou currently have version {}.\n\nWould you like to update now?",
-                latest, channel_label, installed
-            );
-            let should_update =
-                crate::dialog::confirm(app_handle, "Update Available", msg, "Update Now", "Later")
-                    .await;
-
-            if should_update {
-                return Some(latest);
-            }
-        } else {
-            info!("ESPHome is up to date ({})", installed);
-
-            crate::dialog::notice(
-                app_handle,
-                "No Updates Available",
-                format!("ESPHome {} is the latest version.", installed),
-                MessageDialogKind::Info,
-            )
-            .await;
-        }
-
-        None
+        // Compare versions and ask the user (dev never reaches here, so
+        // channel_name only ever yields "stable" or "beta")
+        prompt_if_newer(
+            app_handle,
+            &UpdateWording {
+                component: "ESPHome",
+                log_prefix: "Update",
+                channel_label: Some(channel_name(channel)),
+            },
+            "Update Available",
+            latest,
+            &installed,
+            true,
+        )
+        .await
     }
 
     /// Check for updates and notify the user if one is available (background check).
@@ -269,38 +247,19 @@ impl UpdateChecker {
             }
         };
 
-        // Compare versions
-        if is_newer_version(&latest, &installed) {
-            info!(
-                "Update available: {} -> {} (installed: {})",
-                installed, latest, installed
-            );
-
-            let channel_label = match channel {
-                ReleaseChannel::Stable => "stable",
-                ReleaseChannel::Beta => "beta",
-                ReleaseChannel::Dev => unreachable!(),
-            };
-
-            // Show notification
-            if let Err(e) = app_handle
-                .notification()
-                .builder()
-                .title("ESPHome Update Available")
-                .body(format!(
-                    "ESPHome {} ({}) is available (you have {}). {}",
-                    latest,
-                    channel_label,
-                    installed,
-                    crate::updates_menu_hint(tray_available)
-                ))
-                .show()
-            {
-                error!("Failed to show notification: {}", e);
-            }
-        } else {
-            debug!("ESPHome is up to date ({})", installed);
-        }
+        // Compare versions and notify (dev never reaches here, so
+        // channel_name only ever yields "stable" or "beta")
+        notify_if_newer(
+            app_handle,
+            &UpdateWording {
+                component: "ESPHome",
+                log_prefix: "Update",
+                channel_label: Some(channel_name(channel)),
+            },
+            &latest,
+            &installed,
+            tray_available,
+        );
     }
 
     /// Perform an update to the specified version, or install from git for dev channel.
@@ -468,29 +427,13 @@ impl UpdateChecker {
             }
         };
 
-        if is_newer_version(&latest, &installed) {
-            info!(
-                "Device-builder update available: {} -> {} (installed: {})",
-                installed, latest, installed
-            );
-
-            if let Err(e) = app_handle
-                .notification()
-                .builder()
-                .title("ESPHome Device Builder Update Available")
-                .body(format!(
-                    "ESPHome Device Builder {} is available (you have {}). {}",
-                    latest,
-                    installed,
-                    crate::updates_menu_hint(tray_available)
-                ))
-                .show()
-            {
-                error!("Failed to show notification: {}", e);
-            }
-        } else {
-            debug!("ESPHome Device Builder is up to date ({})", installed);
-        }
+        notify_if_newer(
+            app_handle,
+            &DEVICE_BUILDER_WORDING,
+            &latest,
+            &installed,
+            tray_available,
+        );
     }
 
     /// User-initiated check for esphome-device-builder updates. Returns
@@ -525,34 +468,15 @@ impl UpdateChecker {
             }
         };
 
-        if !is_newer_version(&latest, &installed) {
-            info!("ESPHome Device Builder is up to date ({})", installed);
-            return None;
-        }
-
-        info!(
-            "Device-builder update available: {} -> {} (installed: {})",
-            installed, latest, installed
-        );
-
-        let msg = format!(
-            "ESPHome Device Builder {} is available.\n\nYou currently have version {}.\n\nWould you like to update now?",
-            latest, installed
-        );
-        let should_update = crate::dialog::confirm(
+        prompt_if_newer(
             app_handle,
+            &DEVICE_BUILDER_WORDING,
             "Device Builder Update Available",
-            msg,
-            "Update Now",
-            "Later",
+            latest,
+            &installed,
+            false,
         )
-        .await;
-
-        if should_update {
-            Some(latest)
-        } else {
-            None
-        }
+        .await
     }
 
     /// Switch to a new release channel by installing the appropriate version.
@@ -587,6 +511,136 @@ impl UpdateChecker {
             }
         }
     }
+}
+
+/// Per-component wording shared by the user-prompt and background-notify
+/// update-check tails, so the strings cannot drift between the two flows.
+struct UpdateWording<'a> {
+    /// Component display name, e.g. "ESPHome" or "ESPHome Device Builder".
+    component: &'a str,
+    /// Leading words of the "<log_prefix> available: a -> b" info log.
+    log_prefix: &'a str,
+    /// Release-channel label appended to the offered version, when shown.
+    channel_label: Option<&'a str>,
+}
+
+/// Wording for the `esphome-device-builder` check tails (no channel label;
+/// the backend channel is implied by which backend is configured).
+const DEVICE_BUILDER_WORDING: UpdateWording<'static> = UpdateWording {
+    component: "ESPHome Device Builder",
+    log_prefix: "Device-builder update",
+    channel_label: None,
+};
+
+impl UpdateWording<'_> {
+    /// "<component> <version>" with the channel label appended when present,
+    /// e.g. "ESPHome 2025.1.0 (stable)" or "ESPHome Device Builder 1.2.3".
+    fn subject(&self, version: &str) -> String {
+        match self.channel_label {
+            Some(label) => format!("{} {} ({})", self.component, version, label),
+            None => format!("{} {}", self.component, version),
+        }
+    }
+}
+
+/// Shared tail of the user-initiated update checks: compare versions and, when
+/// `latest` is newer, log it and ask the user whether to update now. Returns
+/// `Some(latest)` only when an update is available and the user confirms.
+/// When already up to date, logs that at info level and, if
+/// `dialog_when_up_to_date` is set, also shows the "No Updates Available"
+/// notice (the device-builder flow stays silent; its caller owns that UX).
+async fn prompt_if_newer(
+    app_handle: &AppHandle,
+    wording: &UpdateWording<'_>,
+    title: &str,
+    latest: String,
+    installed: &str,
+    dialog_when_up_to_date: bool,
+) -> Option<String> {
+    if !is_newer_version(&latest, installed) {
+        info!("{} is up to date ({})", wording.component, installed);
+        if dialog_when_up_to_date {
+            crate::dialog::notice(
+                app_handle,
+                "No Updates Available",
+                format!("{} {} is the latest version.", wording.component, installed),
+                MessageDialogKind::Info,
+            )
+            .await;
+        }
+        return None;
+    }
+
+    info!(
+        "{} available: {} -> {} (installed: {})",
+        wording.log_prefix, installed, latest, installed
+    );
+
+    let msg = format!(
+        "{} is available.\n\nYou currently have version {}.\n\nWould you like to update now?",
+        wording.subject(&latest),
+        installed
+    );
+    if crate::dialog::confirm(app_handle, title, msg, "Update Now", "Later").await {
+        Some(latest)
+    } else {
+        None
+    }
+}
+
+/// Shared tail of the background update checks: compare versions and, when
+/// `latest` is newer, log it and show the "<component> Update Available"
+/// notification pointing at the updates menu. Logs the up-to-date state at
+/// debug level otherwise.
+fn notify_if_newer(
+    app_handle: &AppHandle,
+    wording: &UpdateWording<'_>,
+    latest: &str,
+    installed: &str,
+    tray_available: bool,
+) {
+    if !is_newer_version(latest, installed) {
+        debug!("{} is up to date ({})", wording.component, installed);
+        return;
+    }
+
+    info!(
+        "{} available: {} -> {} (installed: {})",
+        wording.log_prefix, installed, latest, installed
+    );
+
+    if let Err(e) = notify_update_available(
+        app_handle,
+        &format!("{} Update Available", wording.component),
+        &wording.subject(latest),
+        installed,
+        tray_available,
+    ) {
+        error!("Failed to show notification: {}", e);
+    }
+}
+
+/// Build and show the standard "update available" notification:
+/// "<subject> is available (you have <installed>). <updates menu hint>".
+/// Returns the show error so each caller keeps its own failure log wording.
+pub(crate) fn notify_update_available(
+    app_handle: &AppHandle,
+    title: &str,
+    subject: &str,
+    installed: &str,
+    tray_available: bool,
+) -> tauri_plugin_notification::Result<()> {
+    app_handle
+        .notification()
+        .builder()
+        .title(title)
+        .body(format!(
+            "{} is available (you have {}). {}",
+            subject,
+            installed,
+            crate::updates_menu_hint(tray_available)
+        ))
+        .show()
 }
 
 /// Choose the version to offer on the beta channel.

--- a/src-tauri/src/update/mod.rs
+++ b/src-tauri/src/update/mod.rs
@@ -1170,6 +1170,20 @@ mod tests {
         args.iter().any(|a| a == flag)
     }
 
+    #[test]
+    fn subject_appends_channel_label_when_present() {
+        let esphome = UpdateWording {
+            component: "ESPHome",
+            log_prefix: "Update",
+            channel_label: Some("stable"),
+        };
+        assert_eq!(esphome.subject("2025.1.0"), "ESPHome 2025.1.0 (stable)");
+        assert_eq!(
+            DEVICE_BUILDER_WORDING.subject("1.2.3"),
+            "ESPHome Device Builder 1.2.3"
+        );
+    }
+
     /// One non-yanked file — a normally installable release.
     fn active() -> Vec<PyPIRelease> {
         vec![PyPIRelease { yanked: false }]


### PR DESCRIPTION
# What does this implement/fix?

Extracts private prompt_if_newer and notify_if_newer helpers in update/mod.rs so the ESPHome and device builder check flows share the compare, log, and prompt or notify tail, with an UpdateWording struct carrying the per component strings. The notification builder plus updates_menu_hint tail now lives in one notify_update_available helper that app_update/mod.rs reuses, and the two local stable or beta label matches are replaced with protocol::channel_name. The esphome dev channel branch in check_for_user is untouched; all dialog, notification, and log output stays byte identical, no behavior change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- closes #257

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).

Stacked on #276; merge that first.

