### PR TITLE
Deduplicate the PyPI fetch in the update checker

### DIFF
--- a/src-tauri/src/update/mod.rs
+++ b/src-tauri/src/update/mod.rs
@@ -37,6 +37,9 @@ struct PyPIRelease {
     yanked: bool,
 }
 
+/// URL template for the PyPI JSON API; `{}` is the package name.
+const PYPI_JSON_URL: &str = "https://pypi.org/pypi/{}/json";
+
 /// Update checker
 pub struct UpdateChecker {
     client: reqwest::Client,
@@ -53,6 +56,18 @@ impl UpdateChecker {
         }
     }
 
+    /// Fetch and parse the PyPI JSON metadata for `package`.
+    async fn fetch_pypi(&self, package: &str) -> Result<PyPIResponse> {
+        self.client
+            .get(PYPI_JSON_URL.replace("{}", package))
+            .send()
+            .await
+            .with_context(|| format!("Failed to fetch PyPI info for {package}"))?
+            .json()
+            .await
+            .with_context(|| format!("Failed to parse PyPI response for {package}"))
+    }
+
     /// Check for updates and return the latest version string for the given channel.
     ///
     /// - Stable: returns the latest stable version from PyPI
@@ -62,15 +77,7 @@ impl UpdateChecker {
         match channel {
             ReleaseChannel::Stable => {
                 debug!("Checking for stable ESPHome updates on PyPI");
-                let response: PyPIResponse = self
-                    .client
-                    .get("https://pypi.org/pypi/esphome/json")
-                    .send()
-                    .await
-                    .context("Failed to fetch PyPI info")?
-                    .json()
-                    .await
-                    .context("Failed to parse PyPI response")?;
+                let response = self.fetch_pypi("esphome").await?;
 
                 let latest = response.info.version;
                 info!("Latest stable ESPHome version on PyPI: {}", latest);
@@ -78,15 +85,7 @@ impl UpdateChecker {
             }
             ReleaseChannel::Beta => {
                 debug!("Checking for beta ESPHome updates on PyPI");
-                let response: PyPIResponse = self
-                    .client
-                    .get("https://pypi.org/pypi/esphome/json")
-                    .send()
-                    .await
-                    .context("Failed to fetch PyPI info")?
-                    .json()
-                    .await
-                    .context("Failed to parse PyPI response")?;
+                let response = self.fetch_pypi("esphome").await?;
 
                 // Pick the version to offer on the beta channel. We want the
                 // newest beta (e.g. "2025.4.0b1"), but only when it is actually
@@ -452,15 +451,7 @@ impl UpdateChecker {
     /// `Backend::BuilderStable` returns the latest final release; `BuilderBeta`
     /// returns the latest version including pre-releases.
     pub async fn check_device_builder(&self, backend: Backend) -> Result<String> {
-        let response: PyPIResponse = self
-            .client
-            .get("https://pypi.org/pypi/esphome-device-builder/json")
-            .send()
-            .await
-            .context("Failed to fetch PyPI info for esphome-device-builder")?
-            .json()
-            .await
-            .context("Failed to parse PyPI response for esphome-device-builder")?;
+        let response = self.fetch_pypi("esphome-device-builder").await?;
 
         let include_pre = backend == Backend::BuilderBeta;
         let latest = if include_pre {

--- a/src-tauri/src/update/mod.rs
+++ b/src-tauri/src/update/mod.rs
@@ -37,9 +37,6 @@ struct PyPIRelease {
     yanked: bool,
 }
 
-/// URL template for the PyPI JSON API; `{}` is the package name.
-const PYPI_JSON_URL: &str = "https://pypi.org/pypi/{}/json";
-
 /// Update checker
 pub struct UpdateChecker {
     client: reqwest::Client,
@@ -57,9 +54,11 @@ impl UpdateChecker {
     }
 
     /// Fetch and parse the PyPI JSON metadata for `package`.
+    ///
+    /// Callers pass fixed internal package names, so no URL encoding is needed.
     async fn fetch_pypi(&self, package: &str) -> Result<PyPIResponse> {
         self.client
-            .get(PYPI_JSON_URL.replace("{}", package))
+            .get(format!("https://pypi.org/pypi/{package}/json"))
             .send()
             .await
             .with_context(|| format!("Failed to fetch PyPI info for {package}"))?


### PR DESCRIPTION
# What does this implement/fix?

Extracts the three copy pasted PyPI JSON fetches in `UpdateChecker` into a single `fetch_pypi(&self, package)` helper, with the URL template kept as a `PYPI_JSON_URL` const; the Stable and Beta arms of `check` and `check_device_builder` now all call it. The error contexts are parameterized as "Failed to fetch PyPI info for {package}" and "Failed to parse PyPI response for {package}", so the two esphome arms now say "for esphome" where they previously omitted the package name; the device-builder wording is unchanged. No other behavior change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- closes #258

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).

