### PR TITLE
Deduplicate the control client send prologue

### DIFF
--- a/src-tauri/src/control/client.rs
+++ b/src-tauri/src/control/client.rs
@@ -155,18 +155,35 @@ fn fail(message: impl std::fmt::Display) -> ExitCode {
 /// An `Err` means the connection could not be established.
 fn exchange(request: &Request, timeout: Duration) -> Result<Outcome, ConnectError> {
     let mut stream = connect()?;
-    let mut line = match serde_json::to_string(request) {
-        Ok(line) => line,
-        Err(e) => return Ok(Outcome::Failed(format!("could not encode request: {e}"))),
-    };
-    line.push('\n');
-    if let Err(e) = stream
-        .write_all(line.as_bytes())
-        .and_then(|()| stream.flush())
-    {
-        return Ok(Outcome::Failed(format!("error sending request: {e}")));
+    if let Err(e) = send_request(&mut stream, request) {
+        return Ok(Outcome::Failed(match e {
+            SendError::Encode(e) => format!("could not encode request: {e}"),
+            SendError::Send(e) => format!("error sending request: {e}"),
+        }));
     }
     Ok(read_replies(reply_reader(stream, timeout)))
+}
+
+/// Why [`send_request`] failed. The mapping to an error surface stays in each
+/// caller ([`exchange`] formats an [`Outcome::Failed`] message for the human
+/// CLI, `api_stream` emits an NDJSON error line); only the encode-and-write
+/// skeleton is shared.
+enum SendError {
+    /// The request could not be encoded as JSON.
+    Encode(serde_json::Error),
+    /// The encoded request line could not be written to the stream.
+    Send(std::io::Error),
+}
+
+/// Encode `request` as one newline-terminated JSON line and write it to
+/// `stream`, flushing afterwards.
+fn send_request<W: Write>(stream: &mut W, request: &Request) -> Result<(), SendError> {
+    let mut line = serde_json::to_string(request).map_err(SendError::Encode)?;
+    line.push('\n');
+    stream
+        .write_all(line.as_bytes())
+        .and_then(|()| stream.flush())
+        .map_err(SendError::Send)
 }
 
 /// One step of a reply read loop: what `read_line` produced, classified the
@@ -606,16 +623,11 @@ fn api_stream(request: &Request, timeout: Duration) -> u8 {
             return api_err_line("bad_path", &message, EXIT_FAILED)
         }
     };
-    let mut line = match serde_json::to_string(request) {
-        Ok(line) => line,
-        Err(e) => return api_err_line("encode_failed", &e.to_string(), EXIT_FAILED),
-    };
-    line.push('\n');
-    if let Err(e) = stream
-        .write_all(line.as_bytes())
-        .and_then(|()| stream.flush())
-    {
-        return api_err_line("send_failed", &e.to_string(), EXIT_FAILED);
+    if let Err(e) = send_request(&mut stream, request) {
+        return match e {
+            SendError::Encode(e) => api_err_line("encode_failed", &e.to_string(), EXIT_FAILED),
+            SendError::Send(e) => api_err_line("send_failed", &e.to_string(), EXIT_FAILED),
+        };
     }
     api_read(reply_reader(stream, timeout))
 }
@@ -889,6 +901,37 @@ mod tests {
         assert!(matches!(
             read_reply_line(&mut broken, &mut line),
             LineStep::ReadErr(_)
+        ));
+    }
+
+    /// A writer whose next write or flush fails with the given error, for
+    /// exercising the send arm of [`send_request`].
+    struct ErrWriter(Option<std::io::Error>);
+
+    impl Write for ErrWriter {
+        fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+            Err(self.0.take().expect("write called more than once"))
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Err(self.0.take().expect("flush called more than once"))
+        }
+    }
+
+    #[test]
+    fn send_request_writes_one_line_and_classifies_send_failures() {
+        // Success: exactly the encoded request plus a trailing newline.
+        let mut sink = Vec::new();
+        assert!(send_request(&mut sink, &Request::Status).is_ok());
+        let expected = format!("{}\n", serde_json::to_string(&Request::Status).unwrap());
+        assert_eq!(sink, expected.as_bytes());
+
+        // A write failure surfaces as SendError::Send. (Encoding a Request
+        // cannot fail, so that arm has no unit test.)
+        let mut broken = ErrWriter(Some(std::io::Error::other("boom")));
+        assert!(matches!(
+            send_request(&mut broken, &Request::Status),
+            Err(SendError::Send(_))
         ));
     }
 

--- a/src-tauri/src/control/client.rs
+++ b/src-tauri/src/control/client.rs
@@ -904,13 +904,27 @@ mod tests {
         ));
     }
 
-    /// A writer whose next write or flush fails with the given error, for
-    /// exercising the send arm of [`send_request`].
-    struct ErrWriter(Option<std::io::Error>);
+    /// A writer whose next `write` fails with the given error (`flush`
+    /// always succeeds), for exercising the write half of [`send_request`].
+    struct WriteErrWriter(Option<std::io::Error>);
 
-    impl Write for ErrWriter {
+    impl Write for WriteErrWriter {
         fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
             Err(self.0.take().expect("write called more than once"))
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// A writer that accepts every `write` but whose next `flush` fails with
+    /// the given error, for exercising the flush half of [`send_request`].
+    struct FlushErrWriter(Option<std::io::Error>);
+
+    impl Write for FlushErrWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            Ok(buf.len())
         }
 
         fn flush(&mut self) -> std::io::Result<()> {
@@ -928,9 +942,17 @@ mod tests {
 
         // A write failure surfaces as SendError::Send. (Encoding a Request
         // cannot fail, so that arm has no unit test.)
-        let mut broken = ErrWriter(Some(std::io::Error::other("boom")));
+        let mut broken_write = WriteErrWriter(Some(std::io::Error::other("boom")));
         assert!(matches!(
-            send_request(&mut broken, &Request::Status),
+            send_request(&mut broken_write, &Request::Status),
+            Err(SendError::Send(_))
+        ));
+
+        // A flush failure after a successful write also surfaces as
+        // SendError::Send.
+        let mut broken_flush = FlushErrWriter(Some(std::io::Error::other("boom")));
+        assert!(matches!(
+            send_request(&mut broken_flush, &Request::Status),
             Err(SendError::Send(_))
         ));
     }


### PR DESCRIPTION
# What does this implement/fix?

Extracts the duplicated send half of the control client into a `send_request` helper in src-tauri/src/control/client.rs; it encodes the request as one newline terminated JSON line, writes and flushes it, and returns a small `SendError` enum (encode vs send). `exchange` and `api_stream` now share it and each maps the error to its own surface, `Outcome::Failed` messages for the human CLI and `api_err_line` NDJSON for the api; all error strings and codes are byte identical, so no behavior change. Adds a unit test for the helper, mirroring the read half dedup from #248.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- closes #261

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).

