### PR TITLE
Deduplicate the loopback URL helper

### DIFF
--- a/src-tauri/src/daemon/mod.rs
+++ b/src-tauri/src/daemon/mod.rs
@@ -598,15 +598,16 @@ impl DaemonManager {
     }
 }
 
-/// Build the health-check URL for the dashboard.
+/// Build the loopback URL used to probe the dashboard (both the startup
+/// readiness poll and the periodic health check).
 ///
 /// The backend is spawned with `--address 127.0.0.1` / `--host 127.0.0.1`
-/// (see `start()`), so it only listens on the IPv4 loopback. Probing the
-/// literal `127.0.0.1` rather than the `localhost` hostname avoids a
-/// resolver detour: on IPv6-first hosts `localhost` resolves to `::1`
-/// first, where nothing is listening, producing spurious health-check
-/// failures (and a 5s connect stall per cycle before the IPv4 fallback).
-fn health_check_url(port: u16) -> String {
+/// (see `DaemonManager::start()`), so it only listens on the IPv4 loopback.
+/// Probing the literal `127.0.0.1` rather than the `localhost` hostname
+/// avoids a resolver detour: on IPv6-first hosts `localhost` resolves to
+/// `::1` first, where nothing is listening, producing spurious probe
+/// failures (and a connect stall per attempt before the IPv4 fallback).
+pub(crate) fn loopback_url(port: u16) -> String {
     format!("http://127.0.0.1:{}/", port)
 }
 
@@ -617,7 +618,7 @@ pub(crate) async fn health_check(port: u16) -> Result<bool> {
         .timeout(std::time::Duration::from_secs(5))
         .build()?;
 
-    let url = health_check_url(port);
+    let url = loopback_url(port);
     match client.get(&url).send().await {
         Ok(response) => Ok(response.status().is_success()),
         Err(_) => Ok(false),
@@ -626,14 +627,14 @@ pub(crate) async fn health_check(port: u16) -> Result<bool> {
 
 #[cfg(test)]
 mod tests {
-    use super::health_check_url;
+    use super::loopback_url;
 
     #[test]
-    fn health_check_url_targets_ipv4_loopback() {
+    fn loopback_url_targets_ipv4_loopback() {
         // Must match the address the backend binds (`127.0.0.1`), not the
         // `localhost` hostname, so the probe doesn't get steered to `::1`
         // on IPv6-first hosts where the daemon isn't listening.
-        assert_eq!(health_check_url(6052), "http://127.0.0.1:6052/");
-        assert!(!health_check_url(6052).contains("localhost"));
+        assert_eq!(loopback_url(6052), "http://127.0.0.1:6052/");
+        assert!(!loopback_url(6052).contains("localhost"));
     }
 }

--- a/src-tauri/src/daemon/mod.rs
+++ b/src-tauri/src/daemon/mod.rs
@@ -634,7 +634,8 @@ mod tests {
         // Must match the address the backend binds (`127.0.0.1`), not the
         // `localhost` hostname, so the probe doesn't get steered to `::1`
         // on IPv6-first hosts where the daemon isn't listening.
-        assert_eq!(loopback_url(6052), "http://127.0.0.1:6052/");
-        assert!(!loopback_url(6052).contains("localhost"));
+        let url = loopback_url(6052);
+        assert_eq!(url, "http://127.0.0.1:6052/");
+        assert!(!url.contains("localhost"));
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -277,20 +277,6 @@ pub(crate) fn open_dashboard(port: u16) {
     }
 }
 
-/// Build the URL the startup readiness probe should poll.
-///
-/// The daemon is spawned with `--host 127.0.0.1` / `--address 127.0.0.1`
-/// (see `DaemonManager::start()`), so it only listens on the IPv4 loopback.
-/// We probe the literal `127.0.0.1` rather than the `localhost` hostname to
-/// avoid a resolver detour: on IPv6-first hosts `localhost` resolves to
-/// `::1` first, where nothing is listening, so each poll can stall on the
-/// `::1` connect attempt before falling back to IPv4 — delaying the
-/// browser-open on startup. The periodic health check should probe
-/// `127.0.0.1` for the same reason.
-fn dashboard_ready_url(port: u16) -> String {
-    format!("http://127.0.0.1:{}/", port)
-}
-
 /// Wait for the dashboard to be ready by polling the health endpoint
 pub(crate) async fn wait_for_dashboard_ready(port: u16, timeout_secs: u64) -> bool {
     let client = match reqwest::Client::builder()
@@ -301,7 +287,7 @@ pub(crate) async fn wait_for_dashboard_ready(port: u16, timeout_secs: u64) -> bo
         Err(_) => return false,
     };
 
-    let url = dashboard_ready_url(port);
+    let url = daemon::loopback_url(port);
     let start = std::time::Instant::now();
     let timeout = std::time::Duration::from_secs(timeout_secs);
 
@@ -814,7 +800,6 @@ pub fn run(cli: Cli) {
 
 #[cfg(test)]
 mod tests {
-    use super::dashboard_ready_url;
     use super::is_bare_terminal_launch;
     use super::updates_menu_hint;
 
@@ -836,17 +821,6 @@ mod tests {
         // is a deliberate invocation: arg_count > 1, so never bare.
         assert!(!is_bare_terminal_launch(true, 2)); // e.g. --no-open-dashboard
         assert!(!is_bare_terminal_launch(true, 3)); // e.g. --builder-channel stable
-    }
-
-    #[test]
-    fn dashboard_ready_url_targets_ipv4_loopback() {
-        // The daemon binds `127.0.0.1` only, so the readiness probe must
-        // target the IPv4 literal rather than the `localhost` hostname —
-        // otherwise IPv6-first hosts steer the connect to `::1`, where
-        // nothing is listening, stalling each poll before the IPv4 fallback.
-        let url = dashboard_ready_url(6052);
-        assert_eq!(url, "http://127.0.0.1:6052/");
-        assert!(!url.contains("localhost"));
     }
 
     #[test]

--- a/src-tauri/src/settings/mod.rs
+++ b/src-tauri/src/settings/mod.rs
@@ -102,8 +102,8 @@ where
 ///
 /// Port `0` is the dangerous case: a server reads it as "pick any free
 /// ephemeral port," but this app uses the configured value verbatim for the
-/// health check (`health_check_url`) and the dashboard URL it opens, never the
-/// port the backend actually bound. A persisted `{"port": 0}` (hand-edited
+/// health check (`daemon::loopback_url`) and the dashboard URL it opens, never
+/// the port the backend actually bound. A persisted `{"port": 0}` (hand-edited
 /// file) would therefore leave the dashboard permanently unreachable with no
 /// visible error. A non-number (null, string, bool from a hand-edited or future
 /// file) likewise falls back here rather than failing the whole parse and


### PR DESCRIPTION
# What does this implement/fix?

`daemon::health_check_url` and `dashboard_ready_url` in lib.rs were byte identical, each with its own copy of the comment explaining why the probe must target `127.0.0.1` instead of `localhost`, plus a duplicated unit test. They are now consolidated into a single `pub(crate) daemon::loopback_url` used by both the startup readiness poll and the periodic health check, with one copy of the rationale comment and one test. The browser facing `http://localhost:{}` in `open_dashboard` is deliberately unchanged; no behavior change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- closes #253

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).

