### PR TITLE
Merge the find latest release helpers

### DIFF
--- a/src-tauri/src/update/mod.rs
+++ b/src-tauri/src/update/mod.rs
@@ -645,17 +645,21 @@ fn select_beta_target(releases: &HashMap<String, Vec<PyPIRelease>>, stable: &str
     }
 }
 
-/// Find the latest beta/pre-release version from PyPI releases.
+/// Find the highest version among PyPI releases whose version string matches
+/// `predicate`.
 ///
-/// Beta versions on PyPI look like "2025.4.0b1", "2025.4.0b2", etc.
-/// We find the highest version that contains a beta suffix.
-fn find_latest_beta(releases: &HashMap<String, Vec<PyPIRelease>>) -> Option<String> {
+/// Skips version strings that don't start with a digit (not a valid-looking
+/// version) and versions with no installable files (fully yanked or files
+/// removed): PyPI keeps the version key with an empty/all-yanked file list,
+/// and offering it would download nothing or install a pulled release.
+fn highest_version(
+    releases: &HashMap<String, Vec<PyPIRelease>>,
+    predicate: impl Fn(&str) -> bool,
+) -> Option<String> {
     let mut best: Option<String> = None;
 
     for (version_str, files) in releases {
-        // Only consider versions with a beta suffix (e.g. "2025.4.0b1").
-        // ESPHome beta releases always use bN naming.
-        if !has_beta_suffix(version_str) {
+        if !predicate(version_str) {
             continue;
         }
 
@@ -668,10 +672,7 @@ fn find_latest_beta(releases: &HashMap<String, Vec<PyPIRelease>>) -> Option<Stri
             continue;
         }
 
-        // Skip versions with no installable files (fully yanked or files
-        // removed). PyPI keeps the version key with an empty/all-yanked
-        // file list; offering it would download nothing or install a
-        // pulled release.
+        // Skip versions with no installable files (fully yanked or removed).
         if !has_active_files(files) {
             continue;
         }
@@ -687,6 +688,15 @@ fn find_latest_beta(releases: &HashMap<String, Vec<PyPIRelease>>) -> Option<Stri
     }
 
     best
+}
+
+/// Find the latest beta/pre-release version from PyPI releases.
+///
+/// Beta versions on PyPI look like "2025.4.0b1", "2025.4.0b2", etc.
+/// We find the highest version that contains a beta suffix; ESPHome beta
+/// releases always use bN naming.
+fn find_latest_beta(releases: &HashMap<String, Vec<PyPIRelease>>) -> Option<String> {
+    highest_version(releases, has_beta_suffix)
 }
 
 /// Check whether a version string has a beta suffix like "b1", "b2", etc.
@@ -717,25 +727,7 @@ fn has_active_files(files: &[PyPIRelease]) -> bool {
 /// pre-releases. Used for the "beta" device-builder channel where any
 /// pre-release counts (a/b/rc/dev), not just `bN` like ESPHome itself.
 fn find_latest_any(releases: &HashMap<String, Vec<PyPIRelease>>) -> Option<String> {
-    let mut best: Option<String> = None;
-    for (v, files) in releases {
-        if !v.chars().next().is_some_and(|c| c.is_ascii_digit()) {
-            continue;
-        }
-        // Skip versions with no installable files (fully yanked or removed).
-        if !has_active_files(files) {
-            continue;
-        }
-        match &best {
-            None => best = Some(v.clone()),
-            Some(curr) => {
-                if is_newer_version(v, curr) {
-                    best = Some(v.clone());
-                }
-            }
-        }
-    }
-    best
+    highest_version(releases, |_| true)
 }
 
 /// Maintenance helper run with the bundled interpreter as `python -c <src>


### PR DESCRIPTION
# What does this implement/fix?

Merges the duplicated release scanning loops in find_latest_beta and find_latest_any into a shared highest_version helper that takes a version predicate; the skip non digit and skip yanked/empty file list invariants now live in one place. find_latest_beta passes has_beta_suffix and find_latest_any passes an always true predicate, both kept as thin wrappers so call sites and tests stay unchanged. No behavior change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- closes #259

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).

