### PR TITLE
Emit tray status from the daemon stop and start paths

### DIFF
--- a/src-tauri/src/app_update/mod.rs
+++ b/src-tauri/src/app_update/mod.rs
@@ -244,10 +244,6 @@ async fn download_update_bytes(update: &tauri_plugin_updater::Update) -> Result<
 async fn stop_backend_for_install(app_handle: &AppHandle) {
     if let Some(state) = app_handle.try_state::<std::sync::Arc<crate::AppState>>() {
         info!("Stopping ESPHome backend before installing desktop update");
-        // Reflect the stop in the tray immediately; `stop()` only flips the
-        // daemon's internal flag, so the tray would otherwise stay on
-        // "Running" (matches the package-update path in `tray`).
-        crate::tray::update_status(app_handle, false);
         if let Err(e) = state.daemon.stop().await {
             warn!("Error stopping backend before update: {}", e);
         }
@@ -274,14 +270,12 @@ async fn install_update_bytes(
 /// it before installing, so on a failed install — where the bundle was not
 /// replaced and the running process is still valid — without this the running
 /// app would be left with no dashboard. (A successful install always relaunches,
-/// so it never takes this path.) Best-effort: restart it and restore the tray
-/// status.
+/// so it never takes this path.) Best-effort.
 async fn restore_backend(app_handle: &AppHandle) {
     if let Some(state) = app_handle.try_state::<std::sync::Arc<crate::AppState>>() {
         info!("Restarting ESPHome backend after desktop update");
-        match state.daemon.start().await {
-            Ok(()) => crate::tray::update_status(app_handle, true),
-            Err(e) => warn!("Failed to restart backend after update: {}", e),
+        if let Err(e) = state.daemon.start().await {
+            warn!("Failed to restart backend after update: {}", e);
         }
     }
 }

--- a/src-tauri/src/control/ops.rs
+++ b/src-tauri/src/control/ops.rs
@@ -83,13 +83,6 @@ pub(crate) fn not_ready_note() -> String {
     format!("did not become ready within {READY_TIMEOUT_SECS}s; check the logs")
 }
 
-/// Show the daemon's actual state in the tray. The switch/restart sequences
-/// optimistically set "stopped" before stopping; after a failed stop the
-/// backend may well still be running, so the optimistic label must not stand.
-fn show_actual_status(app: &AppHandle, state: &AppState) {
-    tray::update_status(app, state.daemon.is_running());
-}
-
 /// How a channel/backend switch ended. The tray maps these onto dialogs, the
 /// control server onto terminal replies.
 pub(crate) enum SwitchOutcome {
@@ -108,13 +101,12 @@ pub(crate) enum SwitchOutcome {
     StartFailed(String),
 }
 
-/// Stop prologue shared by the switch flows: report progress, optimistically
-/// show "stopped", and stop the daemon. On failure run `revert` (restores the
-/// tray radio checks), show the daemon's actual state, and hand back the
+/// Stop prologue shared by the switch flows: report progress and stop the
+/// daemon (which reflects the stop in the tray status line itself). On
+/// failure run `revert` (restores the tray radio checks) and hand back the
 /// [`SwitchOutcome::StopFailed`] for the caller to return. `stop_what` names
 /// what failed to stop in the log line.
 async fn stop_or_revert(
-    app: &AppHandle,
     state: &Arc<AppState>,
     progress: Progress<'_>,
     detail: &str,
@@ -122,11 +114,9 @@ async fn stop_or_revert(
     revert: impl FnOnce(),
 ) -> Result<(), SwitchOutcome> {
     progress("stop", detail);
-    tray::update_status(app, false);
     if let Err(e) = state.daemon.stop().await {
         error!("Failed to stop {}: {}", stop_what, e);
         revert();
-        show_actual_status(app, state);
         return Err(SwitchOutcome::StopFailed(e.to_string()));
     }
     Ok(())
@@ -138,14 +128,13 @@ async fn stop_or_revert(
 /// into [`SwitchOutcome::InstallFailed`]. Callers log their flow-specific
 /// error line before calling.
 async fn install_failed(
-    app: &AppHandle,
     state: &Arc<AppState>,
     error: String,
     context: &str,
     revert: impl FnOnce(),
 ) -> SwitchOutcome {
     revert();
-    let restarted = restart_after_failure(app, state, context).await;
+    let restarted = restart_after_failure(state, context).await;
     SwitchOutcome::InstallFailed { error, restarted }
 }
 
@@ -184,7 +173,6 @@ pub(crate) async fn switch_release_channel(
     tray::update_channel_checks(new_channel);
 
     if let Err(outcome) = stop_or_revert(
-        app,
         state,
         progress,
         "stopping the dashboard",
@@ -217,12 +205,11 @@ pub(crate) async fn switch_release_channel(
                 error!("Failed to restart backend after channel switch: {}", e);
                 return SwitchOutcome::StartFailed(e.to_string());
             }
-            tray::update_status(app, true);
             SwitchOutcome::Success { ready: true }
         }
         Err(e) => {
             error!("Channel switch failed: {}", e);
-            install_failed(app, state, e.to_string(), "failed channel switch", || {
+            install_failed(state, e.to_string(), "failed channel switch", || {
                 tray::update_channel_checks(old_channel)
             })
             .await
@@ -248,7 +235,6 @@ pub(crate) async fn switch_backend(
     tray::update_backend_checks(new_backend);
 
     if let Err(outcome) = stop_or_revert(
-        app,
         state,
         progress,
         "stopping the backend",
@@ -271,7 +257,7 @@ pub(crate) async fn switch_backend(
         .await
     {
         error!("Failed to install esphome-device-builder: {}", e);
-        return install_failed(app, state, e.to_string(), "failed backend switch", || {
+        return install_failed(state, e.to_string(), "failed backend switch", || {
             tray::update_backend_checks(old_backend)
         })
         .await;
@@ -291,7 +277,6 @@ pub(crate) async fn switch_backend(
         error!("Failed to start daemon after backend switch: {}", e);
         return SwitchOutcome::StartFailed(e.to_string());
     }
-    tray::update_status(app, true);
     info!("Switched backend to {}", new_backend);
 
     progress("wait", "waiting for the backend to become ready");
@@ -303,19 +288,15 @@ pub(crate) async fn switch_backend(
 /// Restart the dashboard backend. With `wait_ready` the call also polls the
 /// dashboard's readiness probe and returns whether it came up within 60s.
 pub(crate) async fn restart_daemon(
-    app: &AppHandle,
     state: &Arc<AppState>,
     wait_ready: bool,
     _guard: &UpdateGuard,
     progress: Progress<'_>,
 ) -> Result<bool, String> {
     progress("restart", "restarting the dashboard");
-    tray::update_status(app, false);
     if let Err(e) = state.daemon.restart().await {
-        show_actual_status(app, state);
         return Err(e.to_string());
     }
-    tray::update_status(app, true);
     if !wait_ready {
         return Ok(true);
     }
@@ -666,7 +647,6 @@ async fn update_esphome_package(
     progress("esphome", "checking for an ESPHome update");
     let check = esphome_update_available(app, state, channel).await;
     run_package_phase(
-        app,
         state,
         progress,
         report,
@@ -706,7 +686,6 @@ async fn update_device_builder_package(
     progress("device-builder", "checking for a device builder update");
     let check = device_builder_update_available(app, state, backend).await;
     run_package_phase(
-        app,
         state,
         progress,
         report,
@@ -757,7 +736,6 @@ struct PackagePhase<D, F, R> {
 /// on success, and record the outcome. Everything component-specific comes
 /// bundled in the [`PackagePhase`].
 async fn run_package_phase<D, F, Fut, R, RFut>(
-    app: &AppHandle,
     state: &Arc<AppState>,
     progress: Progress<'_>,
     report: &mut UpdateReport,
@@ -802,7 +780,7 @@ async fn run_package_phase<D, F, Fut, R, RFut>(
         labels.step,
         &format!("updating {} {installed} to {label}", labels.display_name),
     );
-    let result = stop_install_start(app, state, || install(target)).await;
+    let result = stop_install_start(state, || install(target)).await;
     match result {
         Ok(()) => {
             refresh().await;
@@ -815,25 +793,16 @@ async fn run_package_phase<D, F, Fut, R, RFut>(
 /// Stop the dashboard, run `install`, then start the dashboard again. The
 /// start is attempted even after a failed install so the user isn't left
 /// without a dashboard.
-async fn stop_install_start<F, Fut>(
-    app: &AppHandle,
-    state: &Arc<AppState>,
-    install: F,
-) -> Result<(), String>
+async fn stop_install_start<F, Fut>(state: &Arc<AppState>, install: F) -> Result<(), String>
 where
     F: FnOnce() -> Fut,
     Fut: std::future::Future<Output = anyhow::Result<()>>,
 {
-    tray::update_status(app, false);
     if let Err(e) = state.daemon.stop().await {
-        show_actual_status(app, state);
         return Err(format!("failed to stop the dashboard: {e}"));
     }
     let install_result = install().await;
     let start_result = state.daemon.start().await;
-    if start_result.is_ok() {
-        tray::update_status(app, true);
-    }
     match (install_result, start_result) {
         (Ok(()), Ok(())) => Ok(()),
         (Ok(()), Err(e)) => Err(format!("updated, but the dashboard failed to start: {e}")),
@@ -846,12 +815,9 @@ where
 
 /// Best-effort dashboard restart after a failed install, so the user isn't
 /// left without a backend. Returns whether the restart succeeded.
-async fn restart_after_failure(app: &AppHandle, state: &Arc<AppState>, context: &str) -> bool {
+async fn restart_after_failure(state: &Arc<AppState>, context: &str) -> bool {
     match state.daemon.start().await {
-        Ok(()) => {
-            tray::update_status(app, true);
-            true
-        }
+        Ok(()) => true,
         Err(e) => {
             error!("Failed to restart backend after {}: {}", context, e);
             false

--- a/src-tauri/src/control/server.rs
+++ b/src-tauri/src/control/server.rs
@@ -381,7 +381,7 @@ async fn dispatch(
         }
         Request::Restart => {
             let guard = guard_or_busy!();
-            match ops::restart_daemon(app, &state, true, &guard, &progress).await {
+            match ops::restart_daemon(&state, true, &guard, &progress).await {
                 Ok(true) => {
                     let _ = tx.send(Reply::ok("dashboard restarted and ready"));
                 }

--- a/src-tauri/src/daemon/mod.rs
+++ b/src-tauri/src/daemon/mod.rs
@@ -105,8 +105,21 @@ impl DaemonManager {
         })
     }
 
-    /// Start the ESPHome device builder
+    /// Start the ESPHome device builder.
+    ///
+    /// Emits the tray status itself — "Running" on success, "Stopped" on
+    /// failure — so callers don't have to pair every start with a
+    /// `tray::update_status` call (a forgotten pairing leaves the tray
+    /// stale). The status reflects the actual post-call state, not the
+    /// intent.
     pub async fn start(&self) -> Result<()> {
+        let result = self.start_inner().await;
+        crate::tray::update_status(&self.app_handle, self.is_running());
+        result
+    }
+
+    /// The start sequence proper; see [`Self::start`] for the tray wrapper.
+    async fn start_inner(&self) -> Result<()> {
         // Hold the process lock for the entire start sequence (check ->
         // spawn -> store) so two concurrent start() calls can't both pass
         // the running check and each spawn a child. Without this, the
@@ -376,8 +389,24 @@ impl DaemonManager {
         Ok(())
     }
 
-    /// Stop the ESPHome dashboard
+    /// Stop the ESPHome dashboard.
+    ///
+    /// Emits the tray status itself: "Stopped" optimistically up front (the
+    /// graceful drain below can take up to 30s, during which the tray should
+    /// not claim the backend is running), restored to the actual state if the
+    /// stop fails — after a failed stop the backend may well still be
+    /// running, so the optimistic label must not stand.
     pub async fn stop(&self) -> Result<()> {
+        crate::tray::update_status(&self.app_handle, false);
+        let result = self.stop_inner().await;
+        if result.is_err() {
+            crate::tray::update_status(&self.app_handle, self.is_running());
+        }
+        result
+    }
+
+    /// The stop sequence proper; see [`Self::stop`] for the tray wrapper.
+    async fn stop_inner(&self) -> Result<()> {
         // Acquire the process lock *before* reading/mutating `running` so the
         // check-and-act is fully atomic against start(), which also reads
         // `running` under this lock. The check is done post-lock (no lockless

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -612,9 +612,6 @@ pub fn run(cli: Cli) {
                 drop(startup_guard);
                 match start_result {
                     Ok(()) => {
-                        // Update tray status to show running
-                        tray::update_status(&daemon_app, true);
-
                         // Warn (non-blocking) if git is missing. ESPHome needs
                         // it for external components, remote packages, and other
                         // deps, so many configs won't compile without it; absent
@@ -637,7 +634,6 @@ pub fn run(cli: Cli) {
                     }
                     Err(e) => {
                         error!("Failed to start ESPHome daemon: {}", e);
-                        tray::update_status(&daemon_app, false);
                     }
                 }
             });

--- a/src-tauri/src/tray/mod.rs
+++ b/src-tauri/src/tray/mod.rs
@@ -443,7 +443,6 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>) {
                     info!("User requested update to version {}", version);
 
                     // Stop the dashboard
-                    update_status(&app, false);
                     if let Err(e) = state.daemon.stop().await {
                         error!("Failed to stop backend for update: {}", e);
                         crate::dialog::notice(
@@ -482,7 +481,6 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>) {
                                 )
                                 .await;
                             } else {
-                                update_status(&app, true);
                                 let msg = if channel == ReleaseChannel::Dev {
                                     "ESPHome has been updated to the latest dev version."
                                         .to_string()
@@ -514,8 +512,6 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>) {
                                     "Failed to restart backend after failed update: {}",
                                     restart_err
                                 );
-                            } else {
-                                update_status(&app, true);
                             }
                         }
                     }
@@ -535,7 +531,6 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>) {
                     builder_version
                 );
 
-                update_status(&app, false);
                 if let Err(e) = state.daemon.stop().await {
                     error!("Failed to stop backend for device-builder update: {}", e);
                     crate::dialog::notice(
@@ -575,7 +570,6 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>) {
                             )
                             .await;
                         } else {
-                            update_status(&app, true);
                             crate::dialog::notice(
                                 &app,
                                 "Update Complete",
@@ -604,8 +598,6 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>) {
                                 "Failed to restart backend after failed device-builder update: {}",
                                 restart_err
                             );
-                        } else {
-                            update_status(&app, true);
                         }
                     }
                 }
@@ -811,7 +803,6 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>) {
         }
         ids::RESTART => {
             let state = state.clone();
-            let app = app_handle.clone();
             async_runtime::spawn(async move {
                 // restart() is a stop()->start() sequence, so it must hold the
                 // same re-entrancy guard as the channel/backend switch arms.
@@ -821,7 +812,7 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>) {
                 // saved settings and tray radio state.
                 let guard = guard_or_return!(state, "restart");
                 info!("Restarting ESPHome backend");
-                if let Err(e) = ops::restart_daemon(&app, &state, false, &guard, &|_, _| {}).await {
+                if let Err(e) = ops::restart_daemon(&state, false, &guard, &|_, _| {}).await {
                     error!("Failed to restart daemon: {}", e);
                 }
             });


### PR DESCRIPTION
# What does this implement/fix?

Moves the tray status emission into `DaemonManager::start` and `stop` themselves (the manager already holds the `AppHandle` for its exit watcher), so every stop and start path updates the tray and new call sites cannot forget the pairing. `stop` sets "Stopped" optimistically up front and restores the actual state if the stop fails; `start` reflects the actual post-call state, so a failed start shows "Stopped". The roughly fifteen manual `tray::update_status` pairings in control/ops.rs, app_update/mod.rs, tray/mod.rs, and lib.rs are removed, along with the now unused `show_actual_status` helper and the unused `app` parameters that only fed it. The one behavior change is that the quit path's daemon stop now also updates the status line during teardown, which is harmless.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- closes #264

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).

Stacked on #287; merge that first.

