### PR TITLE
Share the pip install command construction

### DIFF
--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -1047,6 +1047,16 @@ pub fn configure_no_window_tokio_command(cmd: &mut tokio::process::Command) {
     }
 }
 
+/// Build a tokio `pip install` command for the given Python interpreter,
+/// prefilled with `-m pip install` and the Windows no-window flag. Callers
+/// append their own package specs and flags before running it.
+pub fn pip_command(python: &Path) -> tokio::process::Command {
+    let mut cmd = tokio::process::Command::new(python);
+    cmd.args(["-m", "pip", "install"]);
+    configure_no_window_tokio_command(&mut cmd);
+    cmd
+}
+
 /// Configure the daemon child's creation flags on Windows: no console window
 /// AND a new process group. The new process group makes the child its own
 /// group leader (pgid == pid) so we can later deliver a graceful

--- a/src-tauri/src/update/mod.rs
+++ b/src-tauri/src/update/mod.rs
@@ -860,7 +860,7 @@ fn detect_device_builder_version_with_heal(app_handle: &AppHandle) -> Result<Opt
 }
 
 /// Build the `pip install` argument list (appended after the `-m pip install`
-/// prefix supplied by [`platform::pip_command`]) for installing/upgrading
+/// prefix supplied by [`crate::platform::pip_command`]) for installing/upgrading
 /// `esphome-device-builder`.
 ///
 /// When `ignore_installed` is false this is a plain `pip install --upgrade`,
@@ -923,7 +923,7 @@ async fn run_device_builder_install(
 const ESPHOME_DEV_ZIP_URL: &str = "https://github.com/esphome/esphome/archive/dev.zip";
 
 /// Build the `pip install` argument list (appended after the `-m pip install`
-/// prefix supplied by [`platform::pip_command`]) for installing ESPHome from
+/// prefix supplied by [`crate::platform::pip_command`]) for installing ESPHome from
 /// the dev GitHub zip.
 ///
 /// When `ignore_installed` is false this is a plain `--force-reinstall`, which

--- a/src-tauri/src/update/mod.rs
+++ b/src-tauri/src/update/mod.rs
@@ -368,9 +368,8 @@ impl UpdateChecker {
         } else {
             info!("Updating ESPHome to version {}", version);
 
-            let mut cmd = tokio::process::Command::new(&python_path);
-            cmd.args(["-m", "pip", "install", &format!("esphome=={}", version)]);
-            platform::configure_no_window_tokio_command(&mut cmd);
+            let mut cmd = platform::pip_command(&python_path);
+            cmd.arg(format!("esphome=={}", version));
 
             let output = cmd.output().await.context("Failed to run pip install")?;
 
@@ -860,7 +859,8 @@ fn detect_device_builder_version_with_heal(app_handle: &AppHandle) -> Result<Opt
     get_installed_device_builder_version(app_handle)
 }
 
-/// Build the `pip` argument list for installing/upgrading
+/// Build the `pip install` argument list (appended after the `-m pip install`
+/// prefix supplied by [`platform::pip_command`]) for installing/upgrading
 /// `esphome-device-builder`.
 ///
 /// When `ignore_installed` is false this is a plain `pip install --upgrade`,
@@ -892,12 +892,7 @@ fn device_builder_install_args(
     ignore_installed: bool,
     version: Option<&str>,
 ) -> Vec<String> {
-    let mut args: Vec<String> = vec![
-        "-m".to_string(),
-        "pip".to_string(),
-        "install".to_string(),
-        "--upgrade".to_string(),
-    ];
+    let mut args: Vec<String> = vec!["--upgrade".to_string()];
     if ignore_installed {
         args.push("--ignore-installed".to_string());
     }
@@ -919,16 +914,17 @@ async fn run_device_builder_install(
     version: Option<&str>,
 ) -> Result<std::process::Output> {
     let args = device_builder_install_args(backend, ignore_installed, version);
-    let mut cmd = tokio::process::Command::new(python_path);
+    let mut cmd = platform::pip_command(python_path);
     cmd.args(&args);
-    platform::configure_no_window_tokio_command(&mut cmd);
     cmd.output().await.context("Failed to run pip install")
 }
 
 /// URL of the ESPHome dev-branch source archive installed on the Dev channel.
 const ESPHOME_DEV_ZIP_URL: &str = "https://github.com/esphome/esphome/archive/dev.zip";
 
-/// Build the `pip` argument list for installing ESPHome from the dev GitHub zip.
+/// Build the `pip install` argument list (appended after the `-m pip install`
+/// prefix supplied by [`platform::pip_command`]) for installing ESPHome from
+/// the dev GitHub zip.
 ///
 /// When `ignore_installed` is false this is a plain `--force-reinstall`, which
 /// uninstalls the existing copy of each affected package first. Pass `true`
@@ -939,7 +935,7 @@ const ESPHOME_DEV_ZIP_URL: &str = "https://github.com/esphome/esphome/archive/de
 /// over the top — pip's own documented recovery — at the cost of leaving stale
 /// files orphaned, so it is limited to the genuinely-broken RECORD case.
 fn dev_install_args(ignore_installed: bool) -> Vec<&'static str> {
-    let mut args: Vec<&'static str> = vec!["-m", "pip", "install", "--force-reinstall"];
+    let mut args: Vec<&'static str> = vec!["--force-reinstall"];
     if ignore_installed {
         args.push("--ignore-installed");
     }
@@ -953,9 +949,8 @@ async fn run_dev_install(
     ignore_installed: bool,
 ) -> Result<std::process::Output> {
     let args = dev_install_args(ignore_installed);
-    let mut cmd = tokio::process::Command::new(python_path);
+    let mut cmd = platform::pip_command(python_path);
     cmd.args(&args);
-    platform::configure_no_window_tokio_command(&mut cmd);
     cmd.output().await.context("Failed to run pip install")
 }
 


### PR DESCRIPTION
# What does this implement/fix?

Adds a `platform::pip_command(python)` helper that returns a tokio Command prefilled with `-m pip install` and the Windows no-window flag; the three async pip install call sites in update/mod.rs (`update_to`, `run_device_builder_install`, `run_dev_install`) now use it, and the arg builders return only the flags appended after that prefix. The std `pip_install_blocking` variant keeps its own construction; it pipes stderr and spawns instead of running to completion, so folding it in would cost more than the three shared literals it saves. No behavior change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- closes #263

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).

