### PR TITLE
Share the unique temp dir test helper

### DIFF
--- a/src-tauri/src/git_check/mod.rs
+++ b/src-tauri/src/git_check/mod.rs
@@ -371,21 +371,9 @@ pub fn notify_if_config_dir_in_git_repo(app_handle: &AppHandle, config_dir: &Pat
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::util::unique_temp_dir;
     use std::fs;
     use std::path::{Path, PathBuf};
-
-    /// Create a unique, empty temp directory for a test and return its path.
-    /// The process id plus a per-test tag keeps both intra-process parallelism
-    /// and two concurrent `cargo test` binaries on the same host from
-    /// colliding.
-    fn unique_temp_dir(tag: &str) -> PathBuf {
-        let dir =
-            std::env::temp_dir().join(format!("esphome_git_check_{}_{tag}", std::process::id()));
-        // Start from a clean slate in case a previous run left it behind.
-        let _ = fs::remove_dir_all(&dir);
-        fs::create_dir_all(&dir).expect("create temp dir");
-        dir
-    }
 
     fn touch_git_executable(dir: &Path) -> PathBuf {
         let path = dir.join(GIT_EXECUTABLES[0]);

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -1454,17 +1454,9 @@ mod macos {
     #[cfg(test)]
     mod tests {
         use super::*;
+        use crate::util::unique_temp_dir;
         use std::fs;
         use std::path::Path;
-
-        /// Fresh temp dir per test; process id + tag avoids collisions.
-        fn unique_temp_dir(tag: &str) -> PathBuf {
-            let dir =
-                std::env::temp_dir().join(format!("esphome_cli_cmd_{}_{tag}", std::process::id()));
-            let _ = fs::remove_dir_all(&dir);
-            fs::create_dir_all(&dir).expect("create temp dir");
-            dir
-        }
 
         fn bin_dir(dir: &Path) -> PathBuf {
             let bin = dir.join("bin");
@@ -1842,20 +1834,8 @@ mod linux {
     #[cfg(test)]
     mod tests {
         use super::*;
+        use crate::util::unique_temp_dir;
         use std::fs;
-        use std::sync::atomic::{AtomicU64, Ordering};
-
-        /// Unique temp dir per call so parallel tests never collide.
-        fn unique_temp_dir(tag: &str) -> PathBuf {
-            static COUNTER: AtomicU64 = AtomicU64::new(0);
-            let n = COUNTER.fetch_add(1, Ordering::Relaxed);
-            std::env::temp_dir().join(format!(
-                "koan-appindicator-{}-{}-{}",
-                tag,
-                std::process::id(),
-                n
-            ))
-        }
 
         #[test]
         fn candidate_paths_are_all_rooted_in_appdir() {
@@ -2037,6 +2017,8 @@ pub fn is_tray_supported() -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(unix)]
+    use crate::util::unique_temp_dir;
 
     #[test]
     fn path_with_prepended_puts_dir_first() {
@@ -2155,22 +2137,6 @@ mod tests {
         let entries: Vec<PathBuf> = std::env::split_paths(&joined).collect();
         assert_eq!(entries[0].as_os_str().as_bytes(), b"/weird\xffdir");
         assert_eq!(entries[1], PathBuf::from("/opt/homebrew/bin"));
-    }
-
-    /// Unique temp dir per call. Combines the process id with a monotonic
-    /// counter so tests running in parallel within the same process can never
-    /// collide on (or delete) each other's directories.
-    #[cfg(unix)]
-    fn unique_temp_dir(tag: &str) -> std::path::PathBuf {
-        use std::sync::atomic::{AtomicU64, Ordering};
-        static COUNTER: AtomicU64 = AtomicU64::new(0);
-        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
-        std::env::temp_dir().join(format!(
-            "koan-copytest-{}-{}-{}",
-            tag,
-            std::process::id(),
-            n
-        ))
     }
 
     #[cfg(unix)]

--- a/src-tauri/src/settings/mod.rs
+++ b/src-tauri/src/settings/mod.rs
@@ -367,20 +367,8 @@ fn detect_installed_version(app_handle: &AppHandle) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::util::unique_temp_dir;
     use std::fs;
-    use std::path::PathBuf;
-
-    /// Create a unique, empty temp directory for a test and return its path.
-    /// The process id plus a per-test tag keeps both intra-process parallelism
-    /// and two concurrent `cargo test` binaries on the same host from
-    /// colliding.
-    fn unique_temp_dir(tag: &str) -> PathBuf {
-        let dir =
-            std::env::temp_dir().join(format!("esphome_settings_{}_{tag}", std::process::id()));
-        let _ = fs::remove_dir_all(&dir);
-        fs::create_dir_all(&dir).expect("create temp dir");
-        dir
-    }
 
     #[test]
     fn default_backend_matches_stable_release_channel() {

--- a/src-tauri/src/util/mod.rs
+++ b/src-tauri/src/util/mod.rs
@@ -111,7 +111,8 @@ pub(crate) fn unique_temp_dir(tag: &str) -> PathBuf {
         std::process::id()
     ));
     let _ = std::fs::remove_dir_all(&dir);
-    std::fs::create_dir_all(&dir).expect("create temp dir");
+    std::fs::create_dir_all(&dir)
+        .unwrap_or_else(|e| panic!("failed to create temp dir {}: {e}", dir.display()));
     dir
 }
 

--- a/src-tauri/src/util/mod.rs
+++ b/src-tauri/src/util/mod.rs
@@ -97,6 +97,24 @@ fn rename_replacing(from: &Path, to: &Path) -> std::io::Result<()> {
     std::fs::rename(from, to)
 }
 
+/// Create a unique, empty temp directory for a test and return its path.
+/// The process id plus a per-test tag and a monotonic counter keep both
+/// intra-process parallelism and two concurrent `cargo test` binaries on the
+/// same host from colliding. Callers clean up after themselves (or wrap the
+/// path in a guard like the `TmpDir` in this module's tests); leftovers from a
+/// crashed run with a recycled pid are wiped before the directory is recreated.
+#[cfg(test)]
+pub(crate) fn unique_temp_dir(tag: &str) -> PathBuf {
+    let seq = TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!(
+        "esphome-desktop-test-{}-{tag}-{seq}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+    dir
+}
+
 /// Rotate `path` before a fresh run, keeping up to `keep` previous copies.
 ///
 /// The launcher redirects the dashboard child's stdout/stderr into a single
@@ -140,14 +158,7 @@ mod tests {
 
     impl TmpDir {
         fn new(tag: &str) -> Self {
-            let seq = TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
-            let dir = std::env::temp_dir().join(format!(
-                "esphome-desktop-test-{}-{}-{seq}",
-                std::process::id(),
-                tag
-            ));
-            std::fs::create_dir_all(&dir).unwrap();
-            Self(dir)
+            Self(unique_temp_dir(tag))
         }
 
         fn path(&self) -> &Path {


### PR DESCRIPTION
# What does this implement/fix?

Consolidates the five near identical unique temp dir test helpers (three in platform/mod.rs test modules, one each in git_check and settings) into a single `#[cfg(test)] util::unique_temp_dir` that combines the process id, a per test tag, and a monotonic counter, and creates the directory after wiping any stale leftover. The `util::TmpDir` RAII guard now delegates to the shared helper for naming and creation; each test's own cleanup calls are untouched. Test only change. One semantic difference worth noting: some of the replaced helpers (the Linux tray tests and the unix copy_dir tests) only returned a unique path without touching the filesystem, while the shared helper always wipes any leftover and creates the directory; those call sites were checked and tolerate a pre-created empty directory (they either create files under it or recreate it themselves).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- closes #265

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).


