### PR TITLE
Guard the Linux deps composite action to Linux runners

### DIFF
--- a/.github/actions/linux-tauri-deps/action.yml
+++ b/.github/actions/linux-tauri-deps/action.yml
@@ -9,6 +9,7 @@ runs:
   using: composite
   steps:
     - name: Install Linux dependencies
+      if: runner.os == 'Linux'
       shell: bash
       run: |
         sudo apt-get update


### PR DESCRIPTION
# What does this implement/fix?

Follow up to #278, which merged while review feedback was still being addressed; this adds the `if: runner.os == 'Linux'` guard to the composite step so accidental reuse from a non Linux runner skips cleanly instead of failing on apt-get.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- follow up to #278 for #267

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).
