### PR TITLE
Limit build parallelism to 2 for pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       contents: read
     strategy:
       fail-fast: false
-      max-parallel: 4
+      max-parallel: ${{ github.event_name == 'pull_request' && 2 || 4 }}
       matrix:
         include:
           - platform: windows


### PR DESCRIPTION
# What does this implement/fix?

Makes the build job's `max-parallel` conditional on the trigger: pull requests run at most 2 matrix jobs at a time, while `workflow_dispatch` and `workflow_run` (release) builds keep 4. This frees up runners for other work during routine PR CI without slowing down releases.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue (if applicable):**

- fixes <link to issue>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).