### PR TITLE
Remove backend switching entirely

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ Right-click (or left-click on some platforms) the tray icon to access:
 - **Open Dashboard** - Open the dashboard in your browser
 - **Status** - Shows if the daemon is running
 - **Port** - Shows the configured port
-- **Backend** - Choose the ESPHome Device Builder channel (stable or beta)
 - **Release Channel** - Choose the update channel (Stable, Beta, Dev)
 - **Startup** - Choose whether the app launches automatically at login (on by default; see [Running as a remote builder](#running-as-a-remote-builder))
 - **Check for Updates** - Check for a new ESPHome Device Builder desktop release, then new ESPHome (Python) and device-builder versions
@@ -72,7 +71,6 @@ esphome-desktop update           # update the desktop app, ESPHome, and the devi
 esphome-desktop restart          # restart the dashboard backend
 esphome-desktop logs             # show recent dashboard log output (-f to follow)
 esphome-desktop release-channel  # show the ESPHome channel; pass stable|beta|dev to switch
-esphome-desktop backend          # show the device-builder channel; pass stable|beta to switch
 esphome-desktop startup          # show launch-at-login; pass on|off to change
 esphome-desktop quit             # quit the running app
 ```

--- a/src-tauri/src/control/client.rs
+++ b/src-tauri/src/control/client.rs
@@ -10,7 +10,7 @@ use std::process::ExitCode;
 use std::time::Duration;
 
 use super::protocol::{
-    self, backend_name, channel_name, ErrCode, Reply, Request, StatusReply, STEP_APP_RESTARTING,
+    self, channel_name, ErrCode, Reply, Request, StatusReply, STEP_APP_RESTARTING,
 };
 use crate::{ApiMethod, CliCommand, OnOff};
 
@@ -43,15 +43,6 @@ const TAIL_WINDOW_BYTES: u64 = 64 * 1024;
 pub(crate) fn run(command: CliCommand) -> ExitCode {
     match command {
         CliCommand::Open => open_cmd(),
-        CliCommand::Backend { channel } => match channel {
-            None => simple(Request::GetBackend, DEFAULT_TIMEOUT),
-            Some(channel) => simple(
-                Request::SetBackend {
-                    backend: channel.into(),
-                },
-                UPDATE_TIMEOUT,
-            ),
-        },
         CliCommand::ReleaseChannel { channel } => match channel {
             None => simple(Request::GetChannel, DEFAULT_TIMEOUT),
             Some(channel) => simple(
@@ -505,12 +496,11 @@ fn print_status(status: &StatusReply) {
         channel_name(status.release_channel)
     );
     println!(
-        "Device builder:  {} ({} channel)",
+        "Device builder:  {}",
         status
             .device_builder_version
             .as_deref()
-            .unwrap_or("not installed"),
-        backend_name(status.backend)
+            .unwrap_or("not installed")
     );
     println!(
         "Launch at login: {}",
@@ -544,7 +534,6 @@ fn offline_status(json: bool) -> ExitCode {
                     "app_running": false,
                     "port": settings.port,
                     "release_channel": settings.release_channel,
-                    "backend": settings.backend,
                     "config_dir": config_dir,
                     "logs_dir": data_dir.join("logs"),
                 })
@@ -561,10 +550,6 @@ fn offline_status(json: bool) -> ExitCode {
         println!(
             "Release channel: {}",
             channel_name(settings.release_channel)
-        );
-        println!(
-            "Backend:         {} channel",
-            backend_name(settings.backend)
         );
         let config_dir = settings
             .config_dir
@@ -849,7 +834,7 @@ fn file_identity(_meta: &std::fs::Metadata) -> Option<(u64, u64)> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::settings::{Backend, ReleaseChannel};
+    use crate::settings::ReleaseChannel;
     use std::io::Cursor;
     use std::path::PathBuf;
 
@@ -1012,7 +997,6 @@ mod tests {
             esphome_version: None,
             device_builder_version: None,
             release_channel: ReleaseChannel::Stable,
-            backend: Backend::BuilderBeta,
             launch_at_startup: false,
             config_dir: PathBuf::from("/tmp/esphome"),
             logs_dir: PathBuf::from("/tmp/logs"),

--- a/src-tauri/src/control/ops.rs
+++ b/src-tauri/src/control/ops.rs
@@ -622,7 +622,15 @@ async fn update_device_builder_package(
                 display_name: "device builder",
             },
             display_target: |latest: &str| latest.to_string(),
-            install: |_target| async move { state.update_checker.install_device_builder(app).await },
+            // Reuse the version the availability check just resolved: no
+            // second PyPI query, and the "updating … to X" progress line can't
+            // disagree with what actually gets installed.
+            install: |target: String| async move {
+                state
+                    .update_checker
+                    .install_device_builder(app, &target)
+                    .await
+            },
             refresh: || tray::refresh_builder_version_display(app),
         },
     )

--- a/src-tauri/src/control/ops.rs
+++ b/src-tauri/src/control/ops.rs
@@ -1,7 +1,7 @@
 //! Shared control operations.
 //!
 //! The multi-step stop→install→start sequences behind the tray's Switch
-//! Channel / Switch Backend / Restart Dashboard items and their CLI
+//! Channel / Restart Dashboard items and their CLI
 //! equivalents. The tray arms wrap these with confirmation dialogs; the
 //! control server wraps them with streamed progress replies. Keeping the
 //! sequences here means both surfaces stay in lockstep, including the tray
@@ -26,7 +26,7 @@ pub(crate) type Progress<'a> = &'a (dyn Fn(&str, &str) + Send + Sync);
 
 /// RAII guard ensuring only one update/switch sequence runs at a time.
 ///
-/// The "Check for Updates", "Switch Channel", and "Switch Backend" tray arms —
+/// The "Check for Updates" and "Switch Channel" tray arms —
 /// and their CLI counterparts — each perform a multi-step
 /// stop→install/update→start sequence. `DaemonManager::start()`/`stop()` are
 /// individually mutex-serialized, but those *sequences* are not mutually
@@ -90,15 +90,13 @@ fn show_actual_status(app: &AppHandle, state: &AppState) {
     tray::update_status(app, state.daemon.is_running());
 }
 
-/// How a channel/backend switch ended. The tray maps these onto dialogs, the
+/// How a channel switch ended. The tray maps these onto dialogs, the
 /// control server onto terminal replies.
 pub(crate) enum SwitchOutcome {
     /// The requested value was already active; nothing was done.
     Unchanged,
-    /// Switched and restarted. `ready` is whether the dashboard answered the
-    /// readiness probe (only probed by the backend switch; the channel switch
-    /// reports `true` without probing, matching the previous tray behavior).
-    Success { ready: bool },
+    /// Switched and restarted.
+    Success,
     /// The dashboard could not be stopped; nothing was installed.
     StopFailed(String),
     /// The install failed; `restarted` is whether the previous version's
@@ -159,7 +157,7 @@ pub(crate) async fn switch_release_channel(
                 return SwitchOutcome::StartFailed(e.to_string());
             }
             tray::update_status(app, true);
-            SwitchOutcome::Success { ready: true }
+            SwitchOutcome::Success
         }
         Err(e) => {
             error!("Channel switch failed: {}", e);
@@ -171,76 +169,6 @@ pub(crate) async fn switch_release_channel(
             }
         }
     }
-}
-
-/// Switch the device-builder backend channel: stop the dashboard, install the
-/// package for the new channel, persist the setting, restart, and wait for the
-/// dashboard to become reachable.
-pub(crate) async fn switch_backend(
-    app: &AppHandle,
-    state: &Arc<AppState>,
-    new_backend: crate::settings::Backend,
-    _guard: &UpdateGuard,
-    progress: Progress<'_>,
-) -> SwitchOutcome {
-    let old_backend = state.settings.read().await.backend;
-    if new_backend == old_backend {
-        return SwitchOutcome::Unchanged;
-    }
-
-    tray::update_backend_checks(new_backend);
-
-    progress("stop", "stopping the backend");
-    tray::update_status(app, false);
-    if let Err(e) = state.daemon.stop().await {
-        error!("Failed to stop daemon for backend switch: {}", e);
-        tray::update_backend_checks(old_backend);
-        show_actual_status(app, state);
-        return SwitchOutcome::StopFailed(e.to_string());
-    }
-
-    // Install/upgrade the package for the selected channel first.
-    progress(
-        "install",
-        &format!("installing esphome-device-builder ({new_backend})"),
-    );
-    if let Err(e) = state
-        .update_checker
-        .install_device_builder(app, new_backend)
-        .await
-    {
-        error!("Failed to install esphome-device-builder: {}", e);
-        tray::update_backend_checks(old_backend);
-        let restarted = restart_after_failure(app, state, "failed backend switch").await;
-        return SwitchOutcome::InstallFailed {
-            error: e.to_string(),
-            restarted,
-        };
-    }
-    // Install succeeded — refresh the tray version display.
-    tray::refresh_builder_version_display(app).await;
-
-    // Persist the new backend channel.
-    {
-        let mut settings = state.settings.write().await;
-        settings.backend = new_backend;
-        if let Err(e) = settings.save(app) {
-            warn!("Failed to save settings: {}", e);
-        }
-    }
-
-    progress("start", "starting the backend");
-    if let Err(e) = state.daemon.start().await {
-        error!("Failed to start daemon after backend switch: {}", e);
-        return SwitchOutcome::StartFailed(e.to_string());
-    }
-    tray::update_status(app, true);
-    info!("Switched backend to {}", new_backend);
-
-    progress("wait", "waiting for the backend to become ready");
-    let port = state.daemon.port();
-    let ready = crate::wait_for_dashboard_ready(port, READY_TIMEOUT_SECS).await;
-    SwitchOutcome::Success { ready }
 }
 
 /// Restart the dashboard backend. With `wait_ready` the call also polls the
@@ -423,7 +351,6 @@ pub(crate) async fn esphome_update_available(
 pub(crate) async fn device_builder_update_available(
     app: &AppHandle,
     state: &Arc<AppState>,
-    backend: crate::settings::Backend,
 ) -> ComponentUpdate {
     let installed =
         match detect_installed_or_report(app, crate::update::get_installed_device_builder_version)
@@ -432,7 +359,7 @@ pub(crate) async fn device_builder_update_available(
             Ok(v) => v,
             Err(early) => return early,
         };
-    match state.update_checker.check_device_builder(backend).await {
+    match state.update_checker.check_device_builder().await {
         Ok(latest) => compare(installed, latest),
         Err(e) => ComponentUpdate::errored(Some(installed), e.to_string()),
     }
@@ -587,13 +514,10 @@ pub(crate) async fn run_full_update(
         Err(e) => report.fail(format!("desktop updater not available: {e}")),
     }
 
-    let (channel, backend) = {
-        let settings = state.settings.read().await;
-        (settings.release_channel, settings.backend)
-    };
+    let channel = state.settings.read().await.release_channel;
 
     update_esphome_package(app, state, channel, progress, &mut report).await;
-    update_device_builder_package(app, state, backend, progress, &mut report).await;
+    update_device_builder_package(app, state, progress, &mut report).await;
 
     report
 }
@@ -642,12 +566,11 @@ async fn update_esphome_package(
 async fn update_device_builder_package(
     app: &AppHandle,
     state: &Arc<AppState>,
-    backend: crate::settings::Backend,
     progress: Progress<'_>,
     report: &mut UpdateReport,
 ) {
     progress("device-builder", "checking for a device builder update");
-    let check = device_builder_update_available(app, state, backend).await;
+    let check = device_builder_update_available(app, state).await;
     run_package_phase(
         app,
         state,
@@ -661,12 +584,7 @@ async fn update_device_builder_package(
                 display_name: "device builder",
             },
             display_target: |latest: &str| latest.to_string(),
-            install: |_target| async move {
-                state
-                    .update_checker
-                    .install_device_builder(app, backend)
-                    .await
-            },
+            install: |_target| async move { state.update_checker.install_device_builder(app).await },
             refresh: || tray::refresh_builder_version_display(app),
         },
     )

--- a/src-tauri/src/control/protocol.rs
+++ b/src-tauri/src/control/protocol.rs
@@ -10,7 +10,7 @@
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
-use crate::settings::{Backend, ReleaseChannel};
+use crate::settings::ReleaseChannel;
 
 /// Upper bound on a single protocol line. Requests and replies are tiny; a
 /// line this long means a confused peer, not a real client.
@@ -26,7 +26,12 @@ pub const MAX_LINE_BYTES: usize = 64 * 1024;
 /// fields — ARE this public contract, not merely internal types.
 /// Renaming/removing a field or changing a tag on them is a breaking change to
 /// the dashboard and must bump this version. Do not refactor them casually.
-pub const API_SCHEMA_VERSION: u32 = 1;
+///
+/// Version history:
+/// - 2: removed the `backend` field from [`StatusReply`] along with the
+///   device-builder backend channel switching feature.
+/// - 1: initial contract.
+pub const API_SCHEMA_VERSION: u32 = 2;
 
 /// Name of the control pipe on Windows, where unix sockets are unavailable.
 #[cfg(windows)]
@@ -43,10 +48,6 @@ pub const STEP_APP_RESTARTING: &str = "app_restarting";
 pub enum Request {
     /// Open the dashboard in the default browser.
     Open,
-    /// Report the active device-builder backend channel.
-    GetBackend,
-    /// Switch the device-builder backend channel.
-    SetBackend { backend: Backend },
     /// Report the ESPHome release channel.
     GetChannel,
     /// Switch the ESPHome release channel.
@@ -122,7 +123,6 @@ pub struct StatusReply {
     pub esphome_version: Option<String>,
     pub device_builder_version: Option<String>,
     pub release_channel: ReleaseChannel,
-    pub backend: Backend,
     pub launch_at_startup: bool,
     pub config_dir: PathBuf,
     pub logs_dir: PathBuf,
@@ -214,15 +214,6 @@ pub fn channel_name(channel: ReleaseChannel) -> &'static str {
     }
 }
 
-/// Short lowercase backend channel name used on the CLI surface (matches the
-/// `backend` argument values).
-pub fn backend_name(backend: Backend) -> &'static str {
-    match backend {
-        Backend::BuilderStable => "stable",
-        Backend::BuilderBeta => "beta",
-    }
-}
-
 /// Path of the control socket, resolvable from both the app and the CLI
 /// client (no `AppHandle`).
 #[cfg(unix)]
@@ -281,10 +272,6 @@ mod tests {
     fn request_round_trips() {
         let requests = vec![
             Request::Open,
-            Request::GetBackend,
-            Request::SetBackend {
-                backend: Backend::BuilderStable,
-            },
             Request::GetChannel,
             Request::SetChannel {
                 channel: ReleaseChannel::Dev,
@@ -330,7 +317,6 @@ mod tests {
                 esphome_version: Some("2026.6.2".into()),
                 device_builder_version: None,
                 release_channel: ReleaseChannel::Beta,
-                backend: Backend::BuilderBeta,
                 launch_at_startup: true,
                 config_dir: PathBuf::from("/home/x/esphome"),
                 logs_dir: PathBuf::from("/home/x/.local/share/io.esphome.builder/logs"),

--- a/src-tauri/src/control/server.rs
+++ b/src-tauri/src/control/server.rs
@@ -12,9 +12,7 @@ use tokio::sync::mpsc;
 use tracing::{info, warn};
 
 use super::ops::{self, SwitchOutcome, UpdateGuard};
-use super::protocol::{
-    self, backend_name, channel_name, ErrCode, Reply, Request, StatusReply, UpdateCheckReply,
-};
+use super::protocol::{self, channel_name, ErrCode, Reply, Request, StatusReply, UpdateCheckReply};
 use crate::AppState;
 
 /// Backoff before retrying a failed accept or pipe re-create, so a
@@ -325,19 +323,6 @@ async fn dispatch(
                 format!("switched to the {} release channel", channel_name(channel)),
             ));
         }
-        Request::GetBackend => {
-            let backend = state.settings.read().await.backend;
-            let _ = tx.send(Reply::ok(backend_name(backend)));
-        }
-        Request::SetBackend { backend } => {
-            let guard = guard_or_busy!();
-            let outcome = ops::switch_backend(app, &state, backend, &guard, &progress).await;
-            let _ = tx.send(switch_reply(
-                outcome,
-                format!("backend is already {}", backend_name(backend)),
-                format!("switched to the {} device builder", backend_name(backend)),
-            ));
-        }
         Request::GetStartup => {
             let fallback = state.settings.read().await.launch_at_startup;
             let enabled = ops::startup_enabled(app, fallback).await;
@@ -424,16 +409,11 @@ async fn dispatch(
     None
 }
 
-/// Map a [`SwitchOutcome`] onto the terminal reply for a set-channel or
-/// set-backend request.
+/// Map a [`SwitchOutcome`] onto the terminal reply for a set-channel request.
 fn switch_reply(outcome: SwitchOutcome, unchanged_msg: String, success_msg: String) -> Reply {
     match outcome {
         SwitchOutcome::Unchanged => Reply::ok(unchanged_msg),
-        SwitchOutcome::Success { ready: true } => Reply::ok(success_msg),
-        SwitchOutcome::Success { ready: false } => Reply::failed(format!(
-            "{success_msg}, but the dashboard {}",
-            ops::not_ready_note()
-        )),
+        SwitchOutcome::Success => Reply::ok(success_msg),
         SwitchOutcome::StopFailed(e) => Reply::failed(format!("failed to stop the dashboard: {e}")),
         SwitchOutcome::InstallFailed { error, restarted } => Reply::failed(if restarted {
             format!("install failed: {error}; the previous version was restarted")
@@ -449,12 +429,11 @@ fn switch_reply(outcome: SwitchOutcome, unchanged_msg: String, success_msg: Stri
 /// Assemble the full status snapshot. Version detection spawns Python
 /// subprocesses, so it runs on blocking threads.
 async fn build_status(app: &AppHandle, state: &Arc<AppState>) -> StatusReply {
-    let (port, release_channel, backend, launch_fallback) = {
+    let (port, release_channel, launch_fallback) = {
         let settings = state.settings.read().await;
         (
             settings.port,
             settings.release_channel,
-            settings.backend,
             settings.launch_at_startup,
         )
     };
@@ -478,7 +457,6 @@ async fn build_status(app: &AppHandle, state: &Arc<AppState>) -> StatusReply {
         esphome_version,
         device_builder_version,
         release_channel,
-        backend,
         launch_at_startup,
         config_dir: state.daemon.config_dir().clone(),
         logs_dir: state.daemon.logs_dir().clone(),
@@ -490,14 +468,11 @@ async fn build_status(app: &AppHandle, state: &Arc<AppState>) -> StatusReply {
 /// update is in flight. The three checks hit the network (GitHub, PyPI) and
 /// spawn Python for the installed versions, so run them concurrently.
 async fn build_update_check(app: &AppHandle, state: &Arc<AppState>) -> UpdateCheckReply {
-    let (channel, backend) = {
-        let settings = state.settings.read().await;
-        (settings.release_channel, settings.backend)
-    };
+    let channel = state.settings.read().await.release_channel;
     let (app_update, esphome, device_builder) = tokio::join!(
         ops::desktop_update_available(app),
         ops::esphome_update_available(app, state, channel),
-        ops::device_builder_update_available(app, state, backend),
+        ops::device_builder_update_available(app, state),
     );
     UpdateCheckReply {
         any_available: app_update.available || esphome.available || device_builder.available,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -28,27 +28,9 @@ use tracing::{error, info, warn};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 use daemon::DaemonManager;
-use settings::{Backend, Settings};
+use settings::Settings;
 use tray::build_tray_menu;
 use update::UpdateChecker;
-
-/// CLI selector for the device-builder channel.
-/// Maps onto [`Backend::BuilderStable`]/[`Backend::BuilderBeta`].
-#[derive(clap::ValueEnum, Clone, Copy, Debug)]
-#[value(rename_all = "lowercase")]
-pub enum BuilderChannelArg {
-    Stable,
-    Beta,
-}
-
-impl From<BuilderChannelArg> for Backend {
-    fn from(arg: BuilderChannelArg) -> Self {
-        match arg {
-            BuilderChannelArg::Stable => Backend::BuilderStable,
-            BuilderChannelArg::Beta => Backend::BuilderBeta,
-        }
-    }
-}
 
 /// CLI selector for the ESPHome release channel.
 /// Maps onto [`settings::ReleaseChannel`].
@@ -86,12 +68,6 @@ pub enum OnOff {
 pub enum CliCommand {
     /// Open the dashboard in the default browser (starts the app if needed)
     Open,
-    /// Show or switch the device-builder backend channel
-    Backend {
-        /// New backend channel; omit to show the current one
-        #[arg(value_enum)]
-        channel: Option<BuilderChannelArg>,
-    },
     /// Show or switch the ESPHome release channel
     ReleaseChannel {
         /// New release channel; omit to show the current one
@@ -166,17 +142,6 @@ pub struct Cli {
     /// Don't open the dashboard in browser on startup
     #[arg(long = "no-open-dashboard")]
     pub no_open_dashboard: bool,
-
-    /// Apply the `--builder-channel` selection (stable or beta) to the device
-    /// builder. Persists to settings — useful as a fallback when the tray menu
-    /// is unavailable.
-    #[arg(long = "use-builder")]
-    pub use_builder: bool,
-
-    /// Channel for the ESPHome Device Builder backend.
-    /// Only takes effect together with `--use-builder`.
-    #[arg(long = "builder-channel", value_enum, default_value_t = BuilderChannelArg::Beta)]
-    pub builder_channel: BuilderChannelArg,
 }
 
 /// Run a control subcommand as a short-lived CLI client and return its exit
@@ -188,8 +153,8 @@ pub fn run_cli(command: CliCommand) -> std::process::ExitCode {
 /// Whether this is a bare `esphome-desktop` run from a terminal — no
 /// subcommand and no flags at all, just the program name — which should print
 /// the command list instead of launching another app instance. Any explicit
-/// argument is a deliberate invocation and launches as before: a launch flag
-/// like `--no-open-dashboard`, or even the no-op `--builder-channel`, so the
+/// argument is a deliberate invocation and launches as before (e.g. the
+/// `--no-open-dashboard` launch flag), so the
 /// rule needs no per-flag list and stays correct as flags are added.
 /// Non-terminal launches (Finder, the applications menu, a `.desktop` file,
 /// autostart, `open`'s detached spawn) also take the normal app-start path.
@@ -224,7 +189,7 @@ pub struct AppState {
     pub settings: RwLock<Settings>,
     pub update_checker: UpdateChecker,
     /// Guards the multi-step stop→install→start sequences — the tray's
-    /// Check for Updates / Switch Channel / Switch Backend arms, their CLI
+    /// Check for Updates / Switch Channel arms, their CLI
     /// counterparts, and the initial daemon start — so only one runs at a
     /// time. Each runs as an independent async task; while
     /// `daemon.start()`/`stop()` are individually mutex-serialized, the
@@ -365,11 +330,6 @@ pub fn run(cli: Cli) {
 
     // Capture CLI flags before closure
     let no_open_dashboard = cli.no_open_dashboard;
-    let cli_backend_override = if cli.use_builder {
-        Some(Backend::from(cli.builder_channel))
-    } else {
-        None
-    };
 
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
@@ -466,30 +426,6 @@ pub fn run(cli: Cli) {
                     warn!("Failed to persist backend migration: {}", e);
                 }
             }
-
-            // Apply CLI backend override (persists to settings).
-            // This runs before the daemon starts so the new backend takes
-            // effect immediately, and before the tray menu is built so the
-            // radio buttons reflect the override.
-            let cli_override_needs_install = if let Some(new_backend) = cli_backend_override {
-                let mut settings = async_runtime::block_on(state.settings.write());
-                if settings.backend != new_backend {
-                    info!(
-                        "CLI override: switching backend from {} to {}",
-                        settings.backend, new_backend
-                    );
-                    settings.backend = new_backend;
-                    if let Err(e) = settings.save(app.handle()) {
-                        warn!("Failed to save settings after CLI override: {}", e);
-                    }
-                    // Changing the channel needs a (re)install of the package.
-                    true
-                } else {
-                    false
-                }
-            } else {
-                false
-            };
 
             // Reconcile the OS login item to the persisted preference. This
             // applies the on-by-default on first run and re-asserts a user's
@@ -594,20 +530,6 @@ pub fn run(cli: Cli) {
                     control::ops::UpdateGuard::acquire_wait(daemon_state.update_in_flight.clone())
                         .await;
 
-                // If a CLI override switched us into a builder backend, ensure
-                // the package is installed/upgraded before starting the daemon.
-                if cli_override_needs_install {
-                    let backend = daemon_state.settings.read().await.backend;
-                    info!("Installing/upgrading esphome-device-builder for CLI override");
-                    if let Err(e) = daemon_state
-                        .update_checker
-                        .install_device_builder(&daemon_app, backend)
-                        .await
-                    {
-                        error!("Failed to install esphome-device-builder: {}", e);
-                    }
-                }
-
                 let start_result = daemon_state.daemon.start().await;
                 drop(startup_guard);
                 match start_result {
@@ -648,8 +570,7 @@ pub fn run(cli: Cli) {
             // directory, so any pip-installed ESPHome / device-builder bump
             // we'd do now would be wiped by the next launch. Skip the Python
             // checks while an app update is pending.
-            // The dev channel skips automatic update checks entirely. When
-            // the active backend is a builder variant, the
+            // The dev channel skips automatic update checks entirely. The
             // `esphome-device-builder` package is checked on the same schedule.
             let update_state = state.clone();
             let update_app = app.handle().clone();
@@ -668,21 +589,14 @@ pub fn run(cli: Cli) {
                         // App update pending — leave the Python packages alone.
                         continue;
                     }
-                    let (channel, backend) = {
-                        let settings = update_state.settings.read().await;
-                        (settings.release_channel, settings.backend)
-                    };
+                    let channel = update_state.settings.read().await.release_channel;
                     update_state
                         .update_checker
                         .check_and_notify(&update_app, channel, update_tray_available)
                         .await;
                     update_state
                         .update_checker
-                        .check_and_notify_device_builder(
-                            &update_app,
-                            backend,
-                            update_tray_available,
-                        )
+                        .check_and_notify_device_builder(&update_app, update_tray_available)
                         .await;
                 }
             });
@@ -817,10 +731,10 @@ mod tests {
 
     #[test]
     fn any_argument_launches_even_in_a_terminal() {
-        // A launch flag, a subcommand, or even the no-op `--builder-channel`
-        // is a deliberate invocation: arg_count > 1, so never bare.
+        // A launch flag or a subcommand is a deliberate invocation:
+        // arg_count > 1, so never bare.
         assert!(!is_bare_terminal_launch(true, 2)); // e.g. --no-open-dashboard
-        assert!(!is_bare_terminal_launch(true, 3)); // e.g. --builder-channel stable
+        assert!(!is_bare_terminal_launch(true, 3)); // e.g. release-channel stable
     }
 
     #[test]

--- a/src-tauri/src/settings/mod.rs
+++ b/src-tauri/src/settings/mod.rs
@@ -49,54 +49,6 @@ impl fmt::Display for ReleaseChannel {
     }
 }
 
-/// Which device-builder channel the daemon should run. The classic ESPHome
-/// dashboard backend was removed in line with ESPHome 2026.6.0 retiring the
-/// legacy in-tree dashboard; the daemon now always launches the device builder.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "snake_case")]
-pub enum Backend {
-    /// ESPHome device builder, stable release from PyPI.
-    ///
-    /// This is the default so a fresh install (and any legacy/unknown/corrupt
-    /// settings that fall back here) matches the stable-by-default
-    /// [`ReleaseChannel`]: a user on the stable channel must not be silently
-    /// offered a beta device-builder update (#241). Beta is opt-in via the tray
-    /// or the `backend beta` CLI subcommand.
-    #[default]
-    BuilderStable,
-    /// ESPHome device builder, beta/pre-release from PyPI
-    BuilderBeta,
-}
-
-impl fmt::Display for Backend {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::BuilderStable => write!(f, "ESPHome Device Builder (stable)"),
-            Self::BuilderBeta => write!(f, "ESPHome Device Builder (beta)"),
-        }
-    }
-}
-
-/// Deserialize the backend, tolerating legacy or unknown values by falling back
-/// to the default. An old settings file selecting the removed classic dashboard
-/// (`"backend": "classic"`) must migrate to the default device builder rather
-/// than failing the whole parse, which would discard every other preference via
-/// the corrupt-file recovery path.
-fn deserialize_backend<'de, D>(deserializer: D) -> Result<Backend, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    // Deserialize into a generic value so a non-string `backend` (null, number,
-    // bool from a hand-edited or future file) falls back to the default too,
-    // rather than failing the whole parse and discarding every other preference.
-    let raw = serde_json::Value::deserialize(deserializer)?;
-    Ok(match raw.as_str() {
-        Some("builder_stable") => Backend::BuilderStable,
-        Some("builder_beta") => Backend::BuilderBeta,
-        _ => Backend::default(),
-    })
-}
-
 /// Deserialize the dashboard port, falling back to the default for a zero,
 /// out-of-range, or non-numeric value.
 ///
@@ -169,10 +121,6 @@ pub struct Settings {
     #[serde(default)]
     pub release_channel: ReleaseChannel,
 
-    /// Active device-builder channel (stable or beta)
-    #[serde(default, deserialize_with = "deserialize_backend")]
-    pub backend: Backend,
-
     /// Installed ESPHome version (detected from venv)
     #[serde(skip)]
     pub installed_version: Option<String>,
@@ -195,7 +143,6 @@ impl Default for Settings {
             launch_at_startup: true,
             check_updates: true,
             release_channel: ReleaseChannel::default(),
-            backend: Backend::default(),
             installed_version: None,
         }
     }
@@ -354,16 +301,6 @@ mod tests {
     use std::fs;
 
     #[test]
-    fn default_backend_matches_stable_release_channel() {
-        // The device-builder backend must default to stable so it agrees with
-        // the stable-by-default release channel; a stable-channel user must not
-        // be silently offered a beta device-builder update (#241).
-        assert_eq!(Backend::default(), Backend::BuilderStable);
-        assert_eq!(ReleaseChannel::default(), ReleaseChannel::Stable);
-        assert_eq!(Settings::default().backend, Backend::BuilderStable);
-    }
-
-    #[test]
     fn missing_file_yields_defaults() {
         let dir = unique_temp_dir("missing");
         let path = dir.join("settings.json");
@@ -371,7 +308,6 @@ mod tests {
         let settings = load_settings_file(&path);
 
         assert_eq!(settings.port, DEFAULT_PORT);
-        assert_eq!(settings.backend, Backend::default());
         assert!(!path.exists());
 
         let _ = fs::remove_dir_all(&dir);
@@ -386,7 +322,6 @@ mod tests {
             port: 1234,
             open_on_start: false,
             release_channel: ReleaseChannel::Beta,
-            backend: Backend::BuilderStable,
             ..Default::default()
         };
         let content = serde_json::to_string_pretty(&original).expect("serialize");
@@ -397,7 +332,6 @@ mod tests {
         assert_eq!(loaded.port, 1234);
         assert!(!loaded.open_on_start);
         assert_eq!(loaded.release_channel, ReleaseChannel::Beta);
-        assert_eq!(loaded.backend, Backend::BuilderStable);
         // A successful parse must not move the file aside.
         assert!(path.exists());
         assert!(!path.with_extension("json.corrupt").exists());
@@ -406,23 +340,33 @@ mod tests {
     }
 
     #[test]
-    fn legacy_classic_backend_migrates_to_default() {
-        // An old settings file selecting the removed classic dashboard backend
-        // must migrate to the default device builder (stable), keep its other
-        // fields, and NOT be treated as corrupt (which would discard every
-        // other preference).
-        let dir = unique_temp_dir("classic");
-        let path = dir.join("settings.json");
-        fs::write(&path, r#"{"port":1234,"backend":"classic"}"#).expect("write settings");
+    fn legacy_backend_key_is_ignored() {
+        // Settings files written before the backend setting was removed still
+        // carry a `backend` key (as do older files with the removed classic
+        // dashboard, or hand-edited files with a malformed value). The unknown
+        // key must be ignored — of any JSON type — keeping every other field,
+        // and must NOT be treated as corrupt (which would discard every other
+        // preference).
+        for body in [
+            r#"{"port":1234,"backend":"classic"}"#,
+            r#"{"port":1234,"backend":"builder_beta"}"#,
+            r#"{"port":1234,"backend":null}"#,
+        ] {
+            let dir = unique_temp_dir("legacy_backend");
+            let path = dir.join("settings.json");
+            fs::write(&path, body).expect("write settings");
 
-        let settings = load_settings_file(&path);
+            let settings = load_settings_file(&path);
 
-        assert_eq!(settings.backend, Backend::BuilderStable);
-        assert_eq!(settings.port, 1234);
-        assert!(path.exists());
-        assert!(!path.with_extension("json.corrupt").exists());
+            assert_eq!(settings.port, 1234, "body: {body}");
+            assert!(path.exists(), "body: {body}");
+            assert!(
+                !path.with_extension("json.corrupt").exists(),
+                "body: {body}"
+            );
 
-        let _ = fs::remove_dir_all(&dir);
+            let _ = fs::remove_dir_all(&dir);
+        }
     }
 
     #[test]
@@ -438,7 +382,6 @@ mod tests {
         let settings = load_settings_file(&path);
 
         assert_eq!(settings.port, DEFAULT_PORT);
-        assert_eq!(settings.backend, Backend::BuilderStable);
         assert!(!path.with_extension("json.corrupt").exists());
 
         let _ = fs::remove_dir_all(&dir);
@@ -470,25 +413,6 @@ mod tests {
 
             let _ = fs::remove_dir_all(&dir);
         }
-    }
-
-    #[test]
-    fn non_string_backend_value_falls_back_to_default() {
-        // A malformed (non-string) backend value must fall back to the default
-        // instead of failing the whole parse, which would discard every other
-        // preference via corrupt-file recovery.
-        let dir = unique_temp_dir("bad_backend");
-        let path = dir.join("settings.json");
-        fs::write(&path, r#"{"port":1234,"backend":null}"#).expect("write settings");
-
-        let settings = load_settings_file(&path);
-
-        assert_eq!(settings.backend, Backend::BuilderStable);
-        assert_eq!(settings.port, 1234);
-        assert!(path.exists());
-        assert!(!path.with_extension("json.corrupt").exists());
-
-        let _ = fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/src-tauri/src/tray/mod.rs
+++ b/src-tauri/src/tray/mod.rs
@@ -484,7 +484,11 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>) {
                     return;
                 }
 
-                match state.update_checker.install_device_builder(&app).await {
+                match state
+                    .update_checker
+                    .install_device_builder(&app, &builder_version)
+                    .await
+                {
                     Ok(()) => {
                         info!("Device builder updated successfully to {}", builder_version);
 
@@ -652,11 +656,12 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>) {
             let state = state.clone();
             async_runtime::spawn(async move {
                 // restart() is a stop()->start() sequence, so it must hold the
-                // same re-entrancy guard as the channel switch arm.
-                // Without it a Restart click during an in-flight switch can run
-                // start() with the OLD version before the switch persists the
-                // new one, leaving the running process out of sync with the
-                // saved settings and tray radio state.
+                // same re-entrancy guard as the release-channel switch arm.
+                // Without it a Restart click during an in-flight channel
+                // switch can run start() with the old channel's ESPHome
+                // install before the switch persists the new selection,
+                // leaving the running process out of sync with the saved
+                // settings and tray radio state.
                 let guard = guard_or_return!(state, "restart");
                 info!("Restarting ESPHome backend");
                 if let Err(e) = ops::restart_daemon(&state, false, &guard, &|_, _| {}).await {

--- a/src-tauri/src/tray/mod.rs
+++ b/src-tauri/src/tray/mod.rs
@@ -11,11 +11,10 @@ use tauri::{
 };
 use tauri_plugin_autostart::ManagerExt;
 use tauri_plugin_dialog::MessageDialogKind;
-use tauri_plugin_notification::NotificationExt;
 use tracing::{error, info, warn};
 
 use crate::control::ops::{self, SwitchOutcome, UpdateGuard};
-use crate::settings::{Backend, ReleaseChannel};
+use crate::settings::ReleaseChannel;
 use crate::AppState;
 
 /// Menu item IDs
@@ -36,10 +35,6 @@ mod ids {
     pub const CHANNEL_STABLE: &str = "channel_stable";
     pub const CHANNEL_BETA: &str = "channel_beta";
     pub const CHANNEL_DEV: &str = "channel_dev";
-
-    // Backend submenu items
-    pub const BACKEND_BUILDER_STABLE: &str = "backend_builder_stable";
-    pub const BACKEND_BUILDER_BETA: &str = "backend_builder_beta";
 
     // Startup submenu items
     pub const STARTUP_ENABLE: &str = "startup_enable";
@@ -123,28 +118,10 @@ pub fn build_tray_menu(app_handle: &AppHandle, state: &Arc<AppState>) -> Result<
         .item(&channel_dev)
         .build()?;
 
-    // Backend submenu items
-    let current_backend = settings.backend;
-    // TODO: use `build` once a stable release of esphome-device-builder is out
-    let backend_builder_stable = BACKEND_BUILDER_STABLE_ITEM.build_disabled(
-        app_handle,
-        ids::BACKEND_BUILDER_STABLE,
-        current_backend == Backend::BuilderStable,
-    )?;
-    let backend_builder_beta = BACKEND_BUILDER_BETA_ITEM.build(
-        app_handle,
-        ids::BACKEND_BUILDER_BETA,
-        current_backend == Backend::BuilderBeta,
-    )?;
-
-    let backend_submenu = SubmenuBuilder::with_id(app_handle, "backend", "Backend")
-        .item(&backend_builder_stable)
-        .item(&backend_builder_beta)
-        .build()?;
-
-    // Startup submenu items (radio group, mirroring Backend). Label from the
-    // actual OS login-item state so a failed startup reconcile doesn't show a
-    // lie; fall back to the persisted intent only if the query itself errors.
+    // Startup submenu items (radio group, mirroring Release Channel). Label
+    // from the actual OS login-item state so a failed startup reconcile
+    // doesn't show a lie; fall back to the persisted intent only if the query
+    // itself errors.
     let launch_at_startup = app_handle
         .autolaunch()
         .is_enabled()
@@ -176,7 +153,6 @@ pub fn build_tray_menu(app_handle: &AppHandle, state: &Arc<AppState>) -> Result<
                 .build(app_handle)?,
         )
         .separator()
-        .item(&backend_submenu)
         .item(&channel_submenu)
         .item(&startup_submenu)
         .item(
@@ -236,36 +212,14 @@ impl RadioItem {
         id: &str,
         selected: bool,
     ) -> Result<MenuItem<tauri::Wry>> {
-        self.build_impl(app_handle, id, selected, true)
-    }
-
-    /// Like [`RadioItem::build`], but the item is greyed out.
-    fn build_disabled(
-        &self,
-        app_handle: &AppHandle,
-        id: &str,
-        selected: bool,
-    ) -> Result<MenuItem<tauri::Wry>> {
-        self.build_impl(app_handle, id, selected, false)
-    }
-
-    fn build_impl(
-        &self,
-        app_handle: &AppHandle,
-        id: &str,
-        selected: bool,
-        enabled: bool,
-    ) -> Result<MenuItem<tauri::Wry>> {
         // If a previous build already registered an item, reuse it so
         // `refresh` keeps targeting the item that is live in the menu.
         if let Some(item) = self.item.get() {
             item.set_text(radio_label(self.label, selected))?;
-            item.set_enabled(enabled)?;
             return Ok(item.clone());
         }
-        let item = MenuItemBuilder::with_id(id, radio_label(self.label, selected))
-            .enabled(enabled)
-            .build(app_handle)?;
+        let item =
+            MenuItemBuilder::with_id(id, radio_label(self.label, selected)).build(app_handle)?;
         let _ = self.item.set(item.clone());
         Ok(item)
     }
@@ -284,10 +238,6 @@ impl RadioItem {
 static CHANNEL_STABLE_ITEM: RadioItem = RadioItem::new("Stable");
 static CHANNEL_BETA_ITEM: RadioItem = RadioItem::new("Beta");
 static CHANNEL_DEV_ITEM: RadioItem = RadioItem::new("Dev");
-
-/// Backend menu items stored globally for radio-button behavior
-static BACKEND_BUILDER_STABLE_ITEM: RadioItem = RadioItem::new("ESPHome Device Builder (stable)");
-static BACKEND_BUILDER_BETA_ITEM: RadioItem = RadioItem::new("ESPHome Device Builder (beta)");
 
 /// Startup menu items stored globally for radio-button behavior
 static STARTUP_ENABLE_ITEM: RadioItem = RadioItem::new("Launch at Login");
@@ -334,12 +284,6 @@ pub(crate) fn update_channel_checks(channel: ReleaseChannel) {
     CHANNEL_STABLE_ITEM.refresh(channel == ReleaseChannel::Stable);
     CHANNEL_BETA_ITEM.refresh(channel == ReleaseChannel::Beta);
     CHANNEL_DEV_ITEM.refresh(channel == ReleaseChannel::Dev);
-}
-
-/// Update the backend menu item labels to reflect the given backend.
-pub(crate) fn update_backend_checks(backend: Backend) {
-    BACKEND_BUILDER_STABLE_ITEM.refresh(backend == Backend::BuilderStable);
-    BACKEND_BUILDER_BETA_ITEM.refresh(backend == Backend::BuilderBeta);
 }
 
 /// Update the startup menu item labels to reflect whether autostart is enabled.
@@ -433,10 +377,7 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>) {
                     return;
                 }
 
-                let (channel, backend) = {
-                    let settings = state.settings.read().await;
-                    (settings.release_channel, settings.backend)
-                };
+                let channel = state.settings.read().await.release_channel;
 
                 // Check for updates and get version if user wants to update
                 if let Some(version) = state.update_checker.check_for_user(&app, channel).await {
@@ -525,7 +466,7 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>) {
                 // ESPHome release channel.
                 let Some(builder_version) = state
                     .update_checker
-                    .check_device_builder_for_user(&app, backend)
+                    .check_device_builder_for_user(&app)
                     .await
                 else {
                     return;
@@ -548,11 +489,7 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>) {
                     return;
                 }
 
-                match state
-                    .update_checker
-                    .install_device_builder(&app, backend)
-                    .await
-                {
+                match state.update_checker.install_device_builder(&app).await {
                     Ok(()) => {
                         info!("Device builder updated successfully to {}", builder_version);
 
@@ -661,7 +598,7 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>) {
                     .await
                 {
                     SwitchOutcome::Unchanged => {}
-                    SwitchOutcome::Success { .. } => {
+                    SwitchOutcome::Success => {
                         let msg = format!(
                             "Successfully switched to the {} release channel.",
                             new_channel
@@ -707,96 +644,6 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>) {
                 }
             });
         }
-        ids::BACKEND_BUILDER_STABLE | ids::BACKEND_BUILDER_BETA => {
-            let new_backend = match id {
-                ids::BACKEND_BUILDER_STABLE => Backend::BuilderStable,
-                ids::BACKEND_BUILDER_BETA => Backend::BuilderBeta,
-                _ => unreachable!(),
-            };
-
-            let state = state.clone();
-            let app = app_handle.clone();
-            async_runtime::spawn(async move {
-                let guard = guard_or_return!(state, "backend switch");
-                let old_backend = {
-                    let settings = state.settings.read().await;
-                    settings.backend
-                };
-
-                if new_backend == old_backend {
-                    return;
-                }
-
-                // Confirm the switch with the user.
-                let msg = format!(
-                    "Switch to {}?\n\n\
-                     This will install the `esphome-device-builder` Python package, \
-                     stop the current backend, and restart with the new one.",
-                    new_backend
-                );
-                let confirmed =
-                    crate::dialog::confirm(&app, "Switch Backend", msg, "Switch", "Cancel").await;
-
-                if !confirmed {
-                    update_backend_checks(old_backend);
-                    return;
-                }
-
-                // The stop→install→persist→start→wait sequence (including
-                // label updates and their failure-path reverts) lives in ops
-                // so the CLI drives the exact same code; the tray adds the
-                // dialogs and the readiness notification.
-                match ops::switch_backend(&app, &state, new_backend, &guard, &|_, _| {}).await {
-                    SwitchOutcome::Unchanged => {}
-                    SwitchOutcome::Success { ready } => {
-                        let body = if ready {
-                            format!("{} is ready.", new_backend)
-                        } else {
-                            format!(
-                                "Switched to {}, but it didn't become ready in time. Check the logs.",
-                                new_backend
-                            )
-                        };
-                        if let Err(e) = app
-                            .notification()
-                            .builder()
-                            .title("Backend Switched")
-                            .body(body)
-                            .show()
-                        {
-                            warn!("Failed to show backend-switch notification: {}", e);
-                        }
-                    }
-                    SwitchOutcome::StopFailed(e) => {
-                        crate::dialog::notice(
-                            &app,
-                            "Backend Switch Failed",
-                            format!("Failed to stop backend: {}", e),
-                            MessageDialogKind::Error,
-                        )
-                        .await;
-                    }
-                    SwitchOutcome::InstallFailed { error, .. } => {
-                        crate::dialog::notice(
-                            &app,
-                            "Backend Switch Failed",
-                            format!("Failed to install esphome-device-builder: {}", error),
-                            MessageDialogKind::Error,
-                        )
-                        .await;
-                    }
-                    SwitchOutcome::StartFailed(e) => {
-                        crate::dialog::notice(
-                            &app,
-                            "Backend Switch Failed",
-                            format!("Failed to start backend: {}", e),
-                            MessageDialogKind::Error,
-                        )
-                        .await;
-                    }
-                }
-            });
-        }
         ids::VIEW_LOGS => {
             let logs_dir = state.daemon.logs_dir();
             if let Err(e) = open::that_detached(logs_dir) {
@@ -814,9 +661,9 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>) {
             let app = app_handle.clone();
             async_runtime::spawn(async move {
                 // restart() is a stop()->start() sequence, so it must hold the
-                // same re-entrancy guard as the channel/backend switch arms.
+                // same re-entrancy guard as the channel switch arm.
                 // Without it a Restart click during an in-flight switch can run
-                // start() with the OLD backend before the switch persists the
+                // start() with the OLD version before the switch persists the
                 // new one, leaving the running process out of sync with the
                 // saved settings and tray radio state.
                 let guard = guard_or_return!(state, "restart");

--- a/src-tauri/src/update/mod.rs
+++ b/src-tauri/src/update/mod.rs
@@ -319,41 +319,32 @@ impl UpdateChecker {
         }
     }
 
-    /// Install or upgrade the `esphome-device-builder` package from PyPI
-    /// (stable releases only).
-    pub async fn install_device_builder(&self, app_handle: &AppHandle) -> Result<()> {
+    /// Install or upgrade the `esphome-device-builder` package from PyPI,
+    /// pinned to `version` — the release the caller already resolved via
+    /// [`Self::check_device_builder`] (stable releases only). Taking the
+    /// resolved version avoids a second PyPI query here and guarantees the
+    /// version the caller reported is exactly the one that gets installed,
+    /// even if a new release lands between check and install.
+    pub async fn install_device_builder(
+        &self,
+        app_handle: &AppHandle,
+        version: &str,
+    ) -> Result<()> {
         let python_path = platform::get_python_path(app_handle)?;
 
-        info!("Installing/upgrading esphome-device-builder");
-
-        // Resolve the concrete latest stable version and pin it so pip will
-        // *downgrade* off a newer installed pre-release. A plain `--upgrade`
-        // without a pin never downgrades, so an install that previously
-        // tracked the removed beta channel would otherwise stay on its beta
-        // forever (#200). If the PyPI lookup fails we fall back to the
-        // unpinned upgrade rather than block the install entirely.
-        let version = match self.check_device_builder().await {
-            Ok(v) => Some(v),
-            Err(e) => {
-                warn!(
-                    "Could not resolve latest stable device-builder version; \
-                     falling back to unpinned upgrade (may not downgrade a pre-release): {}",
-                    e
-                );
-                None
-            }
-        };
+        info!("Installing/upgrading esphome-device-builder=={version}");
 
         // Try a clean upgrade first (attempts a normal uninstall of the old
         // copy). Only if pip aborts on a missing RECORD file (#155) do we retry
         // with --ignore-installed, which skips the uninstall but orphans stale
         // files — so we limit that trade-off to the broken-RECORD case.
         let pp = python_path.clone();
+        let version = version.to_string();
         let result = install_with_record_retry(
             move |ignore| {
                 let pp = pp.clone();
                 let version = version.clone();
-                async move { run_device_builder_install(&pp, ignore, version.as_deref()).await }
+                async move { run_device_builder_install(&pp, ignore, &version).await }
             },
             "esphome-device-builder installed/upgraded successfully",
             "esphome-device-builder upgrade hit missing RECORD file; retrying with --ignore-installed",
@@ -376,7 +367,13 @@ impl UpdateChecker {
     pub async fn check_device_builder(&self) -> Result<String> {
         let response = self.fetch_pypi("esphome-device-builder").await?;
 
-        let latest = response.info.version;
+        // Don't trust `info.version` blindly: PyPI reports the newest upload
+        // there, which can be a pre-release when the project's finals lag its
+        // betas — and the install path pins `==X` exactly, so a pre-release
+        // here would actually get installed. Select the highest non-yanked
+        // *final* release ourselves; `info.version` is only the fallback when
+        // no installable final release exists at all.
+        let latest = find_latest_final(&response.releases).unwrap_or(response.info.version);
         info!("Latest esphome-device-builder version on PyPI: {}", latest);
         Ok(latest)
     }
@@ -707,6 +704,21 @@ fn find_latest_beta(releases: &HashMap<String, Vec<PyPIRelease>>) -> Option<Stri
     highest_version(releases, has_beta_suffix)
 }
 
+/// Find the latest final (non-pre-release) version from PyPI releases,
+/// skipping yanked/removed versions. Used for the device builder, which only
+/// ever tracks final releases.
+fn find_latest_final(releases: &HashMap<String, Vec<PyPIRelease>>) -> Option<String> {
+    highest_version(releases, is_final_release)
+}
+
+/// Whether a version string is a final release: parseable, with no
+/// pre-release tag (alpha/beta/rc/dev/…) on any segment. [`parse_version`]
+/// marks final segments with the `255` sentinel tier.
+fn is_final_release(version: &str) -> bool {
+    let parts = parse_version(version);
+    !parts.is_empty() && parts.iter().all(|(_, tier, _)| *tier == 255)
+}
+
 /// Check whether a version string has a beta suffix like "b1", "b2", etc.
 /// Matches patterns where a 'b' immediately follows a digit and is followed by
 /// one or more digits (e.g. "2025.4.0b1"), which distinguishes it from versions
@@ -878,19 +890,14 @@ fn detect_device_builder_version_with_heal(app_handle: &AppHandle) -> Result<Opt
 /// `version` pins the package to an exact release (`esphome-device-builder==X`).
 /// A plain `--upgrade` never *downgrades*, so an install still carrying a newer
 /// pre-release from the removed beta channel would otherwise never move to the
-/// older stable (#200). Passing the resolved stable version forces pip to
-/// install exactly that release, downgrading off the newer pre-release. Pass
-/// `None` only when the PyPI lookup failed and an unpinned upgrade is the best
-/// remaining option.
-fn device_builder_install_args(ignore_installed: bool, version: Option<&str>) -> Vec<String> {
+/// older stable (#200). Pinning the resolved stable version forces pip to
+/// install exactly that release, downgrading off the newer pre-release.
+fn device_builder_install_args(ignore_installed: bool, version: &str) -> Vec<String> {
     let mut args: Vec<String> = vec!["--upgrade".to_string()];
     if ignore_installed {
         args.push("--ignore-installed".to_string());
     }
-    match version {
-        Some(v) => args.push(format!("esphome-device-builder=={v}")),
-        None => args.push("esphome-device-builder".to_string()),
-    }
+    args.push(format!("esphome-device-builder=={version}"));
     args
 }
 
@@ -898,7 +905,7 @@ fn device_builder_install_args(ignore_installed: bool, version: Option<&str>) ->
 async fn run_device_builder_install(
     python_path: &std::path::Path,
     ignore_installed: bool,
-    version: Option<&str>,
+    version: &str,
 ) -> Result<std::process::Output> {
     let args = device_builder_install_args(ignore_installed, version);
     let mut cmd = platform::pip_command(python_path);
@@ -1324,13 +1331,13 @@ mod tests {
         // The default (first-attempt) upgrade must NOT pass --ignore-installed,
         // so normal installs still get a clean uninstall of the old copy. The
         // beta channel is gone, so --pre must never appear.
-        let args = device_builder_install_args(false, None);
+        let args = device_builder_install_args(false, "1.2.3");
         assert!(!has(&args, "--ignore-installed"));
         assert!(!has(&args, "--pre"));
         assert!(has(&args, "--upgrade"));
         assert_eq!(
             args.last().map(String::as_str),
-            Some("esphome-device-builder")
+            Some("esphome-device-builder==1.2.3")
         );
     }
 
@@ -1338,24 +1345,24 @@ mod tests {
     fn test_device_builder_install_args_ignore_installed_fallback() {
         // The fallback path adds --ignore-installed so a missing RECORD file in
         // the bundled install can't abort the retry (issue #155).
-        let args = device_builder_install_args(true, None);
+        let args = device_builder_install_args(true, "1.2.3");
         assert!(has(&args, "--ignore-installed"));
         assert!(!has(&args, "--pre"));
         assert!(has(&args, "--upgrade"));
         assert_eq!(
             args.last().map(String::as_str),
-            Some("esphome-device-builder")
+            Some("esphome-device-builder==1.2.3")
         );
     }
 
     #[test]
-    fn test_device_builder_install_args_pins_version_for_downgrade() {
-        // The #200 fix: passing an explicit version pins the package to that
-        // exact release (`==X`). A plain `--upgrade` never downgrades, so the
-        // pin is what forces pip off a newer installed pre-release (from the
-        // removed beta channel) onto the older stable.
+    fn test_device_builder_install_args_always_pin_version() {
+        // The #200 fix: the version pins the package to that exact release
+        // (`==X`). A plain `--upgrade` never downgrades, so the pin is what
+        // forces pip off a newer installed pre-release (from the removed beta
+        // channel) onto the older stable.
         for ignore_installed in [false, true] {
-            let args = device_builder_install_args(ignore_installed, Some("1.2.3"));
+            let args = device_builder_install_args(ignore_installed, "1.2.3");
             assert!(has(&args, "--upgrade"));
             assert!(!has(&args, "--pre"));
             assert_eq!(
@@ -1552,6 +1559,58 @@ mod tests {
 
         let latest = find_latest_beta(&releases);
         assert_eq!(latest, Some("2025.4.0b1".to_string()));
+    }
+
+    #[test]
+    fn test_is_final_release() {
+        assert!(is_final_release("1.1.0"));
+        assert!(is_final_release("2025.4.0"));
+        // Every pre-release kind is non-final, including the PEP 440
+        // dot-separated dev form PyPI reports.
+        assert!(!is_final_release("1.2.0b1"));
+        assert!(!is_final_release("1.2.0a1"));
+        assert!(!is_final_release("1.2.0rc1"));
+        assert!(!is_final_release("1.2.0.dev3"));
+        assert!(!is_final_release("1.2.0-dev"));
+        // Unparseable strings are never offered as a final release.
+        assert!(!is_final_release("abc"));
+        assert!(!is_final_release(""));
+    }
+
+    #[test]
+    fn test_find_latest_final_ignores_prereleases_and_yanked() {
+        // The device builder only ever tracks final releases: a newer beta or
+        // dev upload must not win (the install path pins `==X` exactly, so a
+        // pre-release picked here would actually get installed), and a newer
+        // final whose files were all yanked is not installable.
+        let mut releases = HashMap::new();
+        releases.insert("1.1.0".to_string(), active());
+        releases.insert("1.2.0b1".to_string(), active());
+        releases.insert("1.2.0.dev1".to_string(), active());
+        releases.insert("1.1.1".to_string(), yanked());
+
+        assert_eq!(find_latest_final(&releases), Some("1.1.0".to_string()));
+    }
+
+    #[test]
+    fn test_find_latest_final_picks_highest_final() {
+        let mut releases = HashMap::new();
+        releases.insert("1.0.9".to_string(), active());
+        releases.insert("1.1.0".to_string(), active());
+        releases.insert("1.0.30b7".to_string(), active());
+
+        assert_eq!(find_latest_final(&releases), Some("1.1.0".to_string()));
+    }
+
+    #[test]
+    fn test_find_latest_final_none_when_only_prereleases() {
+        // No installable final release at all — the caller falls back to
+        // PyPI's `info.version` rather than failing the check.
+        let mut releases = HashMap::new();
+        releases.insert("1.0.0b1".to_string(), active());
+        releases.insert("1.0.0".to_string(), yanked());
+
+        assert_eq!(find_latest_final(&releases), None);
     }
 
     #[test]

--- a/src-tauri/src/update/mod.rs
+++ b/src-tauri/src/update/mod.rs
@@ -13,7 +13,7 @@ use tauri_plugin_notification::NotificationExt;
 use tracing::{debug, error, info, warn};
 
 use crate::platform;
-use crate::settings::{Backend, ReleaseChannel};
+use crate::settings::ReleaseChannel;
 
 /// PyPI package info response (used for stable channel)
 #[derive(Debug, Deserialize)]
@@ -346,39 +346,29 @@ impl UpdateChecker {
         }
     }
 
-    /// Install or upgrade the `esphome-device-builder` package from PyPI.
-    /// Pass `Backend::BuilderBeta` to allow pre-releases (`pip install --pre`),
-    /// `Backend::BuilderStable` for stable-only.
-    pub async fn install_device_builder(
-        &self,
-        app_handle: &AppHandle,
-        backend: Backend,
-    ) -> Result<()> {
+    /// Install or upgrade the `esphome-device-builder` package from PyPI
+    /// (stable releases only).
+    pub async fn install_device_builder(&self, app_handle: &AppHandle) -> Result<()> {
         let python_path = platform::get_python_path(app_handle)?;
 
-        info!("Installing/upgrading esphome-device-builder ({})", backend);
+        info!("Installing/upgrading esphome-device-builder");
 
-        // For the stable channel, resolve the concrete latest stable version and
-        // pin it so pip will *downgrade* off a newer installed beta. A plain
-        // `--upgrade` without a pin never downgrades, so a beta->stable switch
-        // would otherwise be a silent no-op (#200). Beta stays unpinned
-        // (`--pre --upgrade`), which already moves forward to the latest
-        // pre-release. If the PyPI lookup fails we fall back to the unpinned
-        // upgrade rather than block the install entirely.
-        let version = if backend == Backend::BuilderStable {
-            match self.check_device_builder(Backend::BuilderStable).await {
-                Ok(v) => Some(v),
-                Err(e) => {
-                    warn!(
-                        "Could not resolve latest stable device-builder version; \
-                         falling back to unpinned upgrade (may not downgrade a beta): {}",
-                        e
-                    );
-                    None
-                }
+        // Resolve the concrete latest stable version and pin it so pip will
+        // *downgrade* off a newer installed pre-release. A plain `--upgrade`
+        // without a pin never downgrades, so an install that previously
+        // tracked the removed beta channel would otherwise stay on its beta
+        // forever (#200). If the PyPI lookup fails we fall back to the
+        // unpinned upgrade rather than block the install entirely.
+        let version = match self.check_device_builder().await {
+            Ok(v) => Some(v),
+            Err(e) => {
+                warn!(
+                    "Could not resolve latest stable device-builder version; \
+                     falling back to unpinned upgrade (may not downgrade a pre-release): {}",
+                    e
+                );
+                None
             }
-        } else {
-            None
         };
 
         // Try a clean upgrade first (attempts a normal uninstall of the old
@@ -390,9 +380,7 @@ impl UpdateChecker {
             move |ignore| {
                 let pp = pp.clone();
                 let version = version.clone();
-                async move {
-                    run_device_builder_install(&pp, backend, ignore, version.as_deref()).await
-                }
+                async move { run_device_builder_install(&pp, ignore, version.as_deref()).await }
             },
             "esphome-device-builder installed/upgraded successfully",
             "esphome-device-builder upgrade hit missing RECORD file; retrying with --ignore-installed",
@@ -410,22 +398,13 @@ impl UpdateChecker {
         result
     }
 
-    /// Query PyPI for the latest available `esphome-device-builder` version.
-    /// `Backend::BuilderStable` returns the latest final release; `BuilderBeta`
-    /// returns the latest version including pre-releases.
-    pub async fn check_device_builder(&self, backend: Backend) -> Result<String> {
+    /// Query PyPI for the latest available `esphome-device-builder` version
+    /// (the latest final release; pre-releases are never offered).
+    pub async fn check_device_builder(&self) -> Result<String> {
         let response = self.fetch_pypi("esphome-device-builder").await?;
 
-        let include_pre = backend == Backend::BuilderBeta;
-        let latest = if include_pre {
-            find_latest_any(&response.releases).unwrap_or(response.info.version)
-        } else {
-            response.info.version
-        };
-        info!(
-            "Latest esphome-device-builder version on PyPI ({}): {}",
-            backend, latest
-        );
+        let latest = response.info.version;
+        info!("Latest esphome-device-builder version on PyPI: {}", latest);
         Ok(latest)
     }
 
@@ -434,7 +413,6 @@ impl UpdateChecker {
     pub async fn check_and_notify_device_builder(
         &self,
         app_handle: &AppHandle,
-        backend: Backend,
         tray_available: bool,
     ) {
         let installed = match detect_device_builder_version_with_heal(app_handle) {
@@ -449,7 +427,7 @@ impl UpdateChecker {
             }
         };
 
-        let latest = match self.check_device_builder(backend).await {
+        let latest = match self.check_device_builder().await {
             Ok(v) => v,
             Err(e) => {
                 warn!("Device-builder update check failed: {}", e);
@@ -486,11 +464,7 @@ impl UpdateChecker {
     /// `Some(version)` if the user wants to update, `None` otherwise.
     /// Stays silent when there is no update — the caller is responsible
     /// for the "everything is up to date" UX.
-    pub async fn check_device_builder_for_user(
-        &self,
-        app_handle: &AppHandle,
-        backend: Backend,
-    ) -> Option<String> {
+    pub async fn check_device_builder_for_user(&self, app_handle: &AppHandle) -> Option<String> {
         let installed = match detect_device_builder_version_with_heal(app_handle) {
             Ok(Some(v)) => v,
             Ok(None) => {
@@ -506,7 +480,7 @@ impl UpdateChecker {
             }
         };
 
-        let latest = match self.check_device_builder(backend).await {
+        let latest = match self.check_device_builder().await {
             Ok(v) => v,
             Err(e) => {
                 warn!("Device-builder update check failed: {}", e);
@@ -671,13 +645,6 @@ fn has_active_files(files: &[PyPIRelease]) -> bool {
     files.iter().any(|f| !f.yanked)
 }
 
-/// Find the highest version across all releases on PyPI, including
-/// pre-releases. Used for the "beta" device-builder channel where any
-/// pre-release counts (a/b/rc/dev), not just `bN` like ESPHome itself.
-fn find_latest_any(releases: &HashMap<String, Vec<PyPIRelease>>) -> Option<String> {
-    highest_version(releases, |_| true)
-}
-
 /// Maintenance helper run with the bundled interpreter as `python -c <src>
 /// <mode>`. `detect` prints the highest installed device-builder version (empty
 /// if undeterminable); `dedupe` removes orphaned duplicate `.dist-info` dirs and
@@ -823,22 +790,16 @@ fn detect_device_builder_version_with_heal(app_handle: &AppHandle) -> Result<Opt
 /// trade-off to the genuinely-broken RECORD case instead of every upgrade.
 ///
 /// `version` pins the package to an exact release (`esphome-device-builder==X`).
-/// A plain `--upgrade` never *downgrades*, so switching the device builder from
-/// a newer beta to an older stable would otherwise be a silent no-op (#200).
-/// Passing the resolved stable version forces pip to install exactly that
-/// release, downgrading off the newer beta. Pass `None` to keep the package
-/// unpinned (the beta channel, which only ever moves forward).
-fn device_builder_install_args(
-    backend: Backend,
-    ignore_installed: bool,
-    version: Option<&str>,
-) -> Vec<String> {
+/// A plain `--upgrade` never *downgrades*, so an install still carrying a newer
+/// pre-release from the removed beta channel would otherwise never move to the
+/// older stable (#200). Passing the resolved stable version forces pip to
+/// install exactly that release, downgrading off the newer pre-release. Pass
+/// `None` only when the PyPI lookup failed and an unpinned upgrade is the best
+/// remaining option.
+fn device_builder_install_args(ignore_installed: bool, version: Option<&str>) -> Vec<String> {
     let mut args: Vec<String> = vec!["--upgrade".to_string()];
     if ignore_installed {
         args.push("--ignore-installed".to_string());
-    }
-    if backend == Backend::BuilderBeta {
-        args.push("--pre".to_string());
     }
     match version {
         Some(v) => args.push(format!("esphome-device-builder=={v}")),
@@ -850,11 +811,10 @@ fn device_builder_install_args(
 /// Run `pip install` for `esphome-device-builder` with the given flags.
 async fn run_device_builder_install(
     python_path: &std::path::Path,
-    backend: Backend,
     ignore_installed: bool,
     version: Option<&str>,
 ) -> Result<std::process::Output> {
-    let args = device_builder_install_args(backend, ignore_installed, version);
+    let args = device_builder_install_args(ignore_installed, version);
     let mut cmd = platform::pip_command(python_path);
     cmd.args(&args);
     cmd.output().await.context("Failed to run pip install")
@@ -972,11 +932,11 @@ pub fn installed_esphome_version(app_handle: &AppHandle) -> Result<Option<String
 /// `dev < alpha < beta < rc < release`.
 ///
 /// ESPHome itself only ships `bN` betas (e.g. "2025.4.0b1") and `-dev`
-/// builds (e.g. "2026.5.0-dev"), but `esphome-device-builder` is compared
-/// with [`find_latest_any`], which can surface any pre-release kind. Ranking
-/// them all explicitly avoids mis-selecting an alpha over a beta (both used to
-/// share rank 1) or treating a dev build as equal to a beta (both used to be
-/// rank 0).
+/// builds (e.g. "2026.5.0-dev"), but an installed `esphome-device-builder`
+/// can carry any pre-release kind (a leftover from the removed beta channel).
+/// Ranking them all explicitly avoids mis-selecting an alpha over a beta
+/// (both used to share rank 1) or treating a dev build as equal to a beta
+/// (both used to be rank 0).
 ///
 /// A bare stable segment never reaches this function — [`parse_version`]
 /// assigns it the `255` sentinel directly, so every pre-release tier here
@@ -1004,11 +964,9 @@ fn prerelease_ord(tag: &str) -> u8 {
 /// parser handles. Without this, `parse_version` splits `"dev3"` off as its own
 /// dot-segment, finds no leading digit, and drops it entirely — so the dev
 /// build parses identically to the stable `"2025.5.0"`. That silently breaks
-/// the device-builder beta channel: a user on one `.devN` build is never
-/// notified of a newer `.devN` build of the same base (they compare equal), and
-/// `find_latest_any` ranks a dev equal-to-stable / above a beta of the same
-/// base, inverting the PEP 440 ordering that [`prerelease_ord`] is meant to
-/// enforce.
+/// version comparison for an installed `.devN` device builder: it would rank
+/// equal to the stable of the same base instead of below it, inverting the
+/// PEP 440 ordering that [`prerelease_ord`] is meant to enforce.
 ///
 /// Converting `".dev"` → `"-dev"` routes the dev tag through the hyphenated path
 /// the tier logic already ranks correctly. Only `.dev` is normalized: among PEP
@@ -1205,59 +1163,40 @@ mod tests {
     #[test]
     fn test_device_builder_install_args_default_no_ignore_installed() {
         // The default (first-attempt) upgrade must NOT pass --ignore-installed,
-        // so normal installs still get a clean uninstall of the old copy.
-        for backend in [Backend::BuilderStable, Backend::BuilderBeta] {
-            let args = device_builder_install_args(backend, false, None);
-            assert!(!has(&args, "--ignore-installed"), "backend {backend:?}");
-            assert!(has(&args, "--upgrade"), "backend {backend:?}");
-            assert_eq!(
-                args.last().map(String::as_str),
-                Some("esphome-device-builder")
-            );
-        }
+        // so normal installs still get a clean uninstall of the old copy. The
+        // beta channel is gone, so --pre must never appear.
+        let args = device_builder_install_args(false, None);
+        assert!(!has(&args, "--ignore-installed"));
+        assert!(!has(&args, "--pre"));
+        assert!(has(&args, "--upgrade"));
+        assert_eq!(
+            args.last().map(String::as_str),
+            Some("esphome-device-builder")
+        );
     }
 
     #[test]
     fn test_device_builder_install_args_ignore_installed_fallback() {
         // The fallback path adds --ignore-installed so a missing RECORD file in
         // the bundled install can't abort the retry (issue #155).
-        for backend in [Backend::BuilderStable, Backend::BuilderBeta] {
-            let args = device_builder_install_args(backend, true, None);
-            assert!(has(&args, "--ignore-installed"), "backend {backend:?}");
-            assert!(has(&args, "--upgrade"), "backend {backend:?}");
-            assert_eq!(
-                args.last().map(String::as_str),
-                Some("esphome-device-builder")
-            );
-        }
-    }
-
-    #[test]
-    fn test_device_builder_install_args_pre_only_for_beta() {
-        for ignore_installed in [false, true] {
-            assert!(has(
-                &device_builder_install_args(Backend::BuilderBeta, ignore_installed, None),
-                "--pre"
-            ));
-            assert!(!has(
-                &device_builder_install_args(Backend::BuilderStable, ignore_installed, None),
-                "--pre"
-            ));
-        }
+        let args = device_builder_install_args(true, None);
+        assert!(has(&args, "--ignore-installed"));
+        assert!(!has(&args, "--pre"));
+        assert!(has(&args, "--upgrade"));
+        assert_eq!(
+            args.last().map(String::as_str),
+            Some("esphome-device-builder")
+        );
     }
 
     #[test]
     fn test_device_builder_install_args_pins_version_for_downgrade() {
         // The #200 fix: passing an explicit version pins the package to that
         // exact release (`==X`). A plain `--upgrade` never downgrades, so the
-        // pin is what forces pip off a newer installed beta onto the older
-        // stable when switching channels.
+        // pin is what forces pip off a newer installed pre-release (from the
+        // removed beta channel) onto the older stable.
         for ignore_installed in [false, true] {
-            let args = device_builder_install_args(
-                Backend::BuilderStable,
-                ignore_installed,
-                Some("1.2.3"),
-            );
+            let args = device_builder_install_args(ignore_installed, Some("1.2.3"));
             assert!(has(&args, "--upgrade"));
             assert!(!has(&args, "--pre"));
             assert_eq!(
@@ -1454,17 +1393,6 @@ mod tests {
 
         let latest = find_latest_beta(&releases);
         assert_eq!(latest, Some("2025.4.0b1".to_string()));
-    }
-
-    #[test]
-    fn test_find_latest_any_skips_yanked() {
-        let mut releases = HashMap::new();
-        releases.insert("2025.4.0".to_string(), active());
-        releases.insert("2025.5.0b1".to_string(), yanked());
-
-        // The only newer candidate is yanked, so the highest installable
-        // version wins.
-        assert_eq!(find_latest_any(&releases), Some("2025.4.0".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
# What does this implement/fix?

Removes the device-builder backend channel switching feature entirely. The device builder now always tracks the latest stable `esphome-device-builder` release on PyPI (stable was already the default since #241, and a stable release now exists).

Removed surfaces:

- The `Backend` enum and `backend` settings field. Old settings files carrying a `backend` key (including the legacy `"classic"` value or malformed values) parse fine — the unknown key is ignored, and the classic-migration startup check is retained.
- The tray **Backend** submenu (including the disabled-stable TODO item) and its radio plumbing; `RadioItem::build_disabled` lost its only caller and was folded back into `build`.
- The `esphome-desktop backend` CLI subcommand and the `--use-builder`/`--builder-channel` launch flags, plus the CLI-override install path at startup.
- The `GetBackend`/`SetBackend` control requests and `ops::switch_backend`; `SwitchOutcome::Success { ready }` collapsed to a unit variant since only the backend switch ever probed readiness.

The install path still resolves and pins the exact stable version (`==X`), which is what migrates any install left on a beta from the old channel down to stable on its next update — a plain `--upgrade` never downgrades (#200).

Breaking changes to coordinate:

- `api status` no longer carries the `backend` field, so `API_SCHEMA_VERSION` is bumped from 1 to 2 per the contract note in `protocol.rs`. A dashboard gating on `schema_version == 1` or reading `.backend` needs a matching update.
- Scripts passing `--use-builder`/`--builder-channel` or calling `esphome-desktop backend` will now fail argument parsing. The app's own autostart registration only ever used `--no-open-dashboard`, so stock installs are unaffected.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).