### PR TITLE
Make the tray/dialog UI translatable via Lokalise

### DIFF
--- a/.github/scripts/translations.py
+++ b/.github/scripts/translations.py
@@ -143,6 +143,10 @@ class LokaliseClient:
             raise LokaliseError(
                 f"Lokalise {method} {path} failed: HTTP {exc.code} {detail}"
             ) from exc
+        except (urllib.error.URLError, TimeoutError) as exc:
+            # Network-level failures (DNS, refused connection, timeout) must
+            # surface as a single ::error:: CI line, not a stack trace.
+            raise LokaliseError(f"Lokalise {method} {path} failed: {exc}") from exc
 
     def upload_base_file(self, data_b64: str, *, cleanup_mode: bool) -> dict[str, Any]:
         """Upload the base-language file and wait for processing to finish."""
@@ -234,8 +238,13 @@ class LokaliseClient:
 def fetch_bytes(url: str) -> bytes:
     """GET a URL (the signed bundle blob) and return the raw bytes."""
     req = urllib.request.Request(url, headers={"Accept": "application/octet-stream"})
-    with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:  # noqa: S310
-        return resp.read()
+    try:
+        with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:  # noqa: S310
+            return resp.read()
+    except (urllib.error.URLError, TimeoutError) as exc:
+        # HTTPError is a URLError subclass, so an expired/403 signed URL lands
+        # here too — surface one ::error:: CI line instead of a stack trace.
+        raise LokaliseError(f"Failed to download bundle: {exc}") from exc
 
 
 def write_locale_bundle(zip_bytes: bytes, dest_dir: Path) -> list[str]:
@@ -247,12 +256,23 @@ def write_locale_bundle(zip_bytes: bytes, dest_dir: Path) -> list[str]:
     sorted locales written.
     """
     written: list[str] = []
-    with zipfile.ZipFile(io.BytesIO(zip_bytes)) as bundle:
+    try:
+        bundle = zipfile.ZipFile(io.BytesIO(zip_bytes))
+    except zipfile.BadZipFile as exc:
+        raise LokaliseError(f"Bundle is not a valid zip archive: {exc}") from exc
+    with bundle:
         for info in bundle.infolist():
             locale = locale_from_zip_entry(info.filename)
             if locale is None or locale == BASE_LANGUAGE:
                 continue
-            data = json.loads(bundle.read(info))
+            try:
+                data = json.loads(bundle.read(info))
+            except json.JSONDecodeError as exc:
+                # A corrupt/partial export must fail as a single ::error:: CI
+                # line, not a stack trace.
+                raise LokaliseError(
+                    f"Bundle entry '{info.filename}' is not valid JSON: {exc}"
+                ) from exc
             path = dest_dir / f"{locale}.json"
             # Re-serialize with the repo's JSON conventions (2-space indent,
             # raw unicode, trailing newline) so a diff only carries genuine

--- a/.github/scripts/translations.py
+++ b/.github/scripts/translations.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""Sync UI translations with Lokalise.
+
+    python3 .github/scripts/translations.py upload [--cleanup]
+    python3 .github/scripts/translations.py download
+
+The base language file (src-tauri/translations/en.json) is the in-repo
+source of truth: ``upload`` pushes its keys to Lokalise, adding new keys and
+updating the English copy of existing keys (other locales are untouched);
+``download`` writes every other locale back into src-tauri/translations/ and
+never touches en.json. Non-English locales are gitignored — they only exist
+in a checkout when this script downloads them (the release build embeds
+whatever is present, see src-tauri/build.rs).
+
+Automated uploads never prune: keys removed from en.json are left in the
+Lokalise project so a moved key keeps its translations for reuse. To delete
+stale keys, run ``upload --cleanup`` (exposed as a manual input on the
+upload workflow).
+
+Credentials come from the environment:
+
+    LOKALISE_API_TOKEN   API token with read/write file permissions
+    LOKALISE_PROJECT_ID  target project id
+    LOKALISE_API_BASE    optional API base URL override (used by the tests)
+
+The script fails loudly (non-zero exit) when credentials are missing, the
+API errors, or a download yields no translated locales — a silent no-op
+would let a release quietly ship English-only. Mirrors
+device-builder-frontend's build-scripts/translations.ts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import io
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+import zipfile
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+API_BASE = "https://api.lokalise.com/api2"
+
+# Base language. Its file (en.json) is the only committed translation file
+# and is never overwritten by a download.
+BASE_LANGUAGE = "en"
+
+HTTP_TIMEOUT = 30.0
+
+# File upload and export are both asynchronous on Lokalise's side: the
+# endpoint returns a process id and the work happens in the background.
+# Poll the process until it leaves the queued/running state, with a ceiling
+# so a stuck process can't hang CI.
+POLL_INTERVAL = 2.0
+POLL_TIMEOUT = 300.0
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TRANSLATIONS_DIR = REPO_ROOT / "src-tauri" / "translations"
+
+
+class LokaliseError(RuntimeError):
+    """A Lokalise API call failed or returned an unusable payload."""
+
+
+def to_bcp47(stem: str) -> str:
+    """Canonicalize a locale stem to a BCP 47 tag.
+
+    Lokalise emits underscore-separated ISO codes (``zh_CN``, ``pt_BR``);
+    normalize the separator and per-subtag case so the written filename is a
+    valid tag (``zh-CN``, ``pt-BR``, ``sr-Latn-RS``) regardless of what the
+    export used.
+    """
+    parts = stem.replace("_", "-").split("-")
+    out: list[str] = [parts[0].lower()]
+    for part in parts[1:]:
+        if len(part) == 4 and part.isalpha():
+            out.append(part.title())  # script subtag, e.g. Latn
+        elif (len(part) == 2 and part.isalpha()) or (len(part) == 3 and part.isdigit()):
+            out.append(part.upper())  # region subtag, e.g. CN / 419
+        else:
+            out.append(part.lower())
+    return "-".join(out)
+
+
+def locale_from_zip_entry(name: str) -> str | None:
+    """Canonical locale code for a zip entry (``fr.json``, ``x/zh_CN.json``),
+    or None when the entry isn't a JSON file."""
+    if not name.endswith(".json"):
+        return None
+    stem = name.rsplit("/", 1)[-1].removesuffix(".json")
+    return to_bcp47(stem)
+
+
+class LokaliseClient:
+    """Minimal Lokalise REST API v2 client (stdlib urllib only)."""
+
+    def __init__(
+        self,
+        token: str,
+        project_id: str,
+        api_base: str = API_BASE,
+        poll_interval: float = POLL_INTERVAL,
+        poll_timeout: float = POLL_TIMEOUT,
+        sleep: Callable[[float], None] = time.sleep,
+    ) -> None:
+        if not token:
+            raise LokaliseError(
+                "Lokalise API token is required (set LOKALISE_API_TOKEN)."
+            )
+        if not project_id:
+            raise LokaliseError(
+                "Lokalise project id is required (set LOKALISE_PROJECT_ID)."
+            )
+        self.token = token
+        self.project_id = project_id
+        self.api_base = api_base
+        self.poll_interval = poll_interval
+        self.poll_timeout = poll_timeout
+        self.sleep = sleep
+
+    def _request(
+        self, method: str, path: str, body: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        url = f"{self.api_base}/projects/{self.project_id}/{path}"
+        headers = {"X-Api-Token": self.token, "Accept": "application/json"}
+        data: bytes | None = None
+        if body is not None:
+            headers["Content-Type"] = "application/json"
+            data = json.dumps(body).encode()
+        req = urllib.request.Request(url, data=data, headers=headers, method=method)
+        try:
+            with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:  # noqa: S310
+                payload: dict[str, Any] = json.load(resp)
+                return payload
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode(errors="replace")
+            raise LokaliseError(
+                f"Lokalise {method} {path} failed: HTTP {exc.code} {detail}"
+            ) from exc
+
+    def upload_base_file(self, data_b64: str, *, cleanup_mode: bool) -> dict[str, Any]:
+        """Upload the base-language file and wait for processing to finish."""
+        payload = {
+            "data": data_b64,
+            "filename": f"{BASE_LANGUAGE}.json",
+            "lang_iso": BASE_LANGUAGE,
+            # The strings use `{placeholder}` tokens the Rust runtime fills
+            # verbatim; don't let Lokalise rewrite them into its universal
+            # placeholder format.
+            "convert_placeholders": False,
+            # The Rust runtime does plain token replacement, not ICU — don't
+            # let Lokalise split plural-looking strings into per-form keys
+            # that would re-export as ICU syntax the app can't render.
+            "detect_icu_plurals": False,
+            # Push reworded English copy for existing keys, not just new
+            # keys — en.json is the source of truth for the base language.
+            # Only the English file is uploaded, so this never clobbers
+            # translator edits in other locales.
+            "replace_modified": True,
+            # When set, keys absent from the uploaded base file are deleted
+            # from the project. Off by default; opt in via `upload --cleanup`.
+            "cleanup_mode": cleanup_mode,
+        }
+        result = self._request("POST", "files/upload", payload)
+        process_id = (result.get("process") or {}).get("process_id")
+        if not process_id:
+            raise LokaliseError(f"Upload did not return a process id: {result}")
+        return self.wait_for_process(process_id)
+
+    def wait_for_process(self, process_id: str) -> dict[str, Any]:
+        """Poll a queued process (upload or async export) until it finishes."""
+        deadline = time.monotonic() + self.poll_timeout
+        while True:
+            result = self._request("GET", f"processes/{process_id}")
+            process: dict[str, Any] = result.get("process") or {}
+            status = process.get("status")
+            if status == "finished":
+                return process
+            if status in ("failed", "cancelled"):
+                raise LokaliseError(
+                    f"Lokalise process {process_id} {status}: {process}"
+                )
+            if time.monotonic() > deadline:
+                raise LokaliseError(
+                    f"Lokalise process {process_id} timed out (last status: {status})."
+                )
+            self.sleep(self.poll_interval)
+
+    def download_bundle_url(self) -> str:
+        """Request an export bundle for every project language and return its
+        download URL.
+
+        Uses the async export endpoint (files/async-download): it returns a
+        process id, and the bundle URL lands in the finished process's
+        ``details.download_url`` — same poller as upload.
+        """
+        payload = {
+            "format": "json",
+            "original_filenames": False,
+            "bundle_structure": "%LANG_ISO%.json",
+            # Omit untranslated keys so the app's per-key English fallback
+            # kicks in (src-tauri/src/i18n) instead of shipping English
+            # strings inside non-English files.
+            "export_empty_as": "skip",
+            "export_sort": "first_added",
+            "json_unescaped_slashes": True,
+            "replace_breaks": False,
+            "indentation": "2sp",
+            # Keep `{name}` token style on export to match the runtime.
+            "placeholder_format": "icu",
+            # No filter_langs: export whatever languages the project has, so
+            # adding a locale in Lokalise round-trips with no code change.
+        }
+        result = self._request("POST", "files/async-download", payload)
+        process_id = result.get("process_id")
+        if not process_id:
+            raise LokaliseError(f"Async download did not return a process id: {result}")
+        process = self.wait_for_process(process_id)
+        bundle_url = (process.get("details") or {}).get("download_url")
+        if not bundle_url:
+            raise LokaliseError(
+                f"Async download process {process_id} finished without a "
+                f"download_url: {process}"
+            )
+        return str(bundle_url)
+
+
+def fetch_bytes(url: str) -> bytes:
+    """GET a URL (the signed bundle blob) and return the raw bytes."""
+    req = urllib.request.Request(url, headers={"Accept": "application/octet-stream"})
+    with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:  # noqa: S310
+        return resp.read()
+
+
+def write_locale_bundle(zip_bytes: bytes, dest_dir: Path) -> list[str]:
+    """Unpack a zip of ``<locale>.json`` files into ``dest_dir``.
+
+    Writes each locale except the base — en.json is the in-repo source of
+    truth and is never overwritten by a download. Stems are canonicalized to
+    BCP 47 so a Lokalise ``zh_CN.json`` lands as ``zh-CN.json``. Returns the
+    sorted locales written.
+    """
+    written: list[str] = []
+    with zipfile.ZipFile(io.BytesIO(zip_bytes)) as bundle:
+        for info in bundle.infolist():
+            locale = locale_from_zip_entry(info.filename)
+            if locale is None or locale == BASE_LANGUAGE:
+                continue
+            data = json.loads(bundle.read(info))
+            path = dest_dir / f"{locale}.json"
+            # Re-serialize with the repo's JSON conventions (2-space indent,
+            # raw unicode, trailing newline) so a diff only carries genuine
+            # translation changes.
+            path.write_text(
+                json.dumps(data, ensure_ascii=False, indent=2) + "\n",
+                encoding="utf-8",
+            )
+            try:
+                display = path.relative_to(REPO_ROOT)
+            except ValueError:  # dest outside the repo (tests)
+                display = path
+            print(f"  {display}")
+            written.append(locale)
+    return sorted(written)
+
+
+def run_upload(client: LokaliseClient, *, cleanup: bool) -> int:
+    data_b64 = base64.b64encode(
+        (TRANSLATIONS_DIR / f"{BASE_LANGUAGE}.json").read_bytes()
+    ).decode()
+
+    suffix = " (cleanup: removing keys absent from en.json)" if cleanup else ""
+    print(f"Uploading {BASE_LANGUAGE}.json as base language '{BASE_LANGUAGE}'{suffix}")
+
+    process = client.upload_base_file(data_b64, cleanup_mode=cleanup)
+    print(f"Upload finished (status: {process.get('status', 'unknown')}).")
+    return 0
+
+
+def run_download(client: LokaliseClient, dest_dir: Path) -> int:
+    print("Requesting bundle for all project languages from Lokalise")
+    bundle_url = client.download_bundle_url()
+    written = write_locale_bundle(fetch_bytes(bundle_url), dest_dir)
+
+    if not written:
+        # A download that yields no locales is a real failure (wrong project
+        # id, empty/corrupt bundle, API hiccup) — fail loudly so a release
+        # can't silently ship English-only. The legitimate English-only case
+        # is the unset-secrets guard in the workflow, which never gets here.
+        raise LokaliseError("Lokalise returned no non-base translation files.")
+    print(f"Wrote {len(written)} file(s): {', '.join(written)}")
+    return 0
+
+
+def client_from_env() -> LokaliseClient:
+    return LokaliseClient(
+        os.environ.get("LOKALISE_API_TOKEN", ""),
+        os.environ.get("LOKALISE_PROJECT_ID", ""),
+        api_base=os.environ.get("LOKALISE_API_BASE", API_BASE),
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    upload = sub.add_parser("upload", help="Push en.json keys to Lokalise")
+    upload.add_argument(
+        "--cleanup",
+        action="store_true",
+        help="Delete Lokalise keys no longer in en.json (prunes stale keys)",
+    )
+    sub.add_parser("download", help="Pull translated locales from Lokalise")
+    args = parser.parse_args(argv)
+
+    try:
+        client = client_from_env()
+        if args.command == "upload":
+            return run_upload(client, cleanup=args.cleanup)
+        return run_download(client, TRANSLATIONS_DIR)
+    except LokaliseError as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,11 +20,72 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-    # Only run release builds when the Release Drafter workflow succeeded.
+  # Release builds embed every translated locale (src-tauri/build.rs picks up
+  # whatever JSON files sit in src-tauri/translations/ at compile time). The
+  # download runs in its own small job so the Lokalise API token is only ever
+  # exposed here — never to the build matrix, which runs pip installs and the
+  # full bundler. PR builds skip this and build English-only.
+  translations:
+    name: Download translations from Lokalise
     if: >-
-      github.event_name != 'workflow_run' ||
+      github.event_name == 'workflow_run' &&
       github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-22.04
+    # The Lokalise credentials live in the `lokalise` environment.
+    environment: lokalise
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.13"
+
+      - name: Download from Lokalise
+        # Non-English locales are gitignored, so pull them before building to
+        # ship fully-translated binaries. Unset secrets downgrade the release
+        # to English-only with a warning rather than failing it, so releases
+        # keep flowing while the Lokalise project is being bootstrapped (and
+        # on forks, where the secrets are unreachable). Once translations are
+        # established, tighten this to a hard failure on the canonical repo
+        # like device-builder-frontend does.
+        env:
+          LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
+          LOKALISE_PROJECT_ID: ${{ secrets.LOKALISE_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+          if [ -z "${LOKALISE_API_TOKEN}" ] || [ -z "${LOKALISE_PROJECT_ID}" ]; then
+            echo "::warning::Lokalise secrets unset; building English-only."
+            exit 0
+          fi
+          python3 .github/scripts/translations.py download
+
+      - name: Upload translations artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: translations
+          # en.json is always present, so the artifact stays non-empty even
+          # when no locales were downloaded — the build job's restore step
+          # then never fails on a missing artifact.
+          path: src-tauri/translations/
+
+  build:
+    # Only run release builds when the Release Drafter workflow succeeded AND
+    # the translations job delivered its artifact — a failed Lokalise download
+    # must block the release rather than silently shipping English-only
+    # binaries. PR/dispatch builds run regardless (translations is skipped
+    # there, hence the `always()`).
+    needs: translations
+    if: >-
+      always() && (
+        (github.event_name != 'workflow_run' && needs.translations.result == 'skipped') ||
+        (github.event.workflow_run.conclusion == 'success' && needs.translations.result == 'success')
+      )
     permissions:
       contents: read
     strategy:
@@ -85,6 +146,19 @@ jobs:
           # For workflow_run events, check out the commit that triggered the
           # Release Drafter workflow (the latest push to main).
           ref: ${{ github.event.workflow_run.head_sha || github.ref }}
+
+      # Locale files come from the `translations` job (which holds the
+      # Lokalise credentials); this job never sees the API token. The
+      # artifact always carries en.json, so this overwrites the checked-out
+      # copy with itself and adds any downloaded locales, which
+      # src-tauri/build.rs then embeds into the binary. PR builds skip this
+      # and build English-only.
+      - name: Restore translations
+        if: github.event_name == 'workflow_run'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: translations
+          path: src-tauri/translations/
 
       # Linux-specific dependencies
       - name: Install Linux dependencies

--- a/.github/workflows/translations-upload.yml
+++ b/.github/workflows/translations-upload.yml
@@ -1,0 +1,58 @@
+name: Upload translations
+
+# Push the English source strings to Lokalise whenever en.json lands on
+# main, so translators always see the latest keys. New keys are added and
+# the English copy of existing keys is updated; keys removed from en.json
+# are left in the project (so a moved key keeps its translations for reuse)
+# and translated locales are left untouched (see
+# .github/scripts/translations.py).
+#
+# Automated pushes never prune. To delete keys no longer in en.json (stale
+# keys orphaned by a rename or migration), run this workflow manually from
+# the Actions tab with the `cleanup` input checked.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src-tauri/translations/en.json"
+      - ".github/scripts/translations.py"
+      - ".github/workflows/translations-upload.yml"
+  workflow_dispatch:
+    inputs:
+      cleanup:
+        description: "Delete Lokalise keys no longer in en.json (prunes stale keys)"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+# Serialize uploads so two quick pushes can't race the same project.
+concurrency:
+  group: lokalise-upload
+  cancel-in-progress: false
+
+jobs:
+  upload:
+    name: Upload base strings to Lokalise
+    runs-on: ubuntu-22.04
+    # The Lokalise credentials live in the `lokalise` environment.
+    environment: lokalise
+    # Forks can't read the secret; skip there so the job doesn't fail noisily.
+    if: github.repository == 'esphome/esphome-desktop'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.13"
+
+      - name: Upload to Lokalise
+        env:
+          LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
+          LOKALISE_PROJECT_ID: ${{ secrets.LOKALISE_PROJECT_ID }}
+          CLEANUP: ${{ inputs.cleanup && '--cleanup' || '' }}
+        run: python3 .github/scripts/translations.py upload $CLEANUP

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,12 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 
+# Translations: en.json is the committed source of truth; every other locale
+# is downloaded from Lokalise by CI at release time (see
+# .github/scripts/translations.py) and must not be committed.
+src-tauri/translations/*.json
+!src-tauri/translations/en.json
+
 # Python bundles (downloaded by build scripts)
 src-tauri/python/
 # Bundled MinGit on Windows (downloaded by build scripts)

--- a/README.md
+++ b/README.md
@@ -226,6 +226,33 @@ Settings are stored in `settings.json`:
 - `launch_at_startup` - Launch the app automatically at login (default: true; see [Running as a remote builder](#running-as-a-remote-builder))
 - `check_updates` - Check for ESPHome updates automatically
 
+## Translations
+
+The app's UI (tray menu, dialogs, and notifications) is translated on
+[Lokalise](https://lokalise.com). Want to help translate the app into your
+language? Join the project here:
+
+**<https://app.lokalise.com/public/756339856a4b2415a30c62.63256624/>**
+
+The UI language is auto-detected from the system locale, falling back to
+English per string when a translation is missing. Set the
+`ESPHOME_DESKTOP_LANGUAGE` environment variable (e.g. `fr`, `zh-CN`) to
+override the detection.
+
+How it works:
+
+- [`src-tauri/translations/en.json`](src-tauri/translations/en.json) is the
+  in-repo source of truth for the English strings. It is the only committed
+  translation file; edit it via normal pull requests.
+- When a change to it lands on `main`, the
+  [Upload translations](.github/workflows/translations-upload.yml) workflow
+  pushes the keys to Lokalise so translators always see the latest strings.
+- Release builds download every translated locale from Lokalise
+  ([`.github/scripts/translations.py`](.github/scripts/translations.py)) and
+  embed them into the binaries, so a new language added on Lokalise ships
+  with the next release without any code change. Development builds are
+  English-only.
+
 ## Troubleshooting
 
 ### macOS: "App is damaged and can't be opened"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1162,6 +1162,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "sys-locale",
  "tauri",
  "tauri-build",
  "tauri-plugin-autostart",
@@ -4356,6 +4357,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "sys-locale"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -14,6 +14,8 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 
 [build-dependencies]
 tauri-build = { version = "2.5.4", features = [] }
+# build.rs validates the translation JSON it embeds
+serde_json = "1.0"
 
 [dependencies]
 # Tauri core
@@ -54,6 +56,9 @@ open = "5"
 
 # Home directory detection
 dirs = "6"
+
+# System locale detection for UI translations
+sys-locale = "0.3"
 
 # Platform-specific
 [target.'cfg(unix)'.dependencies]

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -51,9 +51,12 @@ fn embed_translations() {
             .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
         serde_json::from_str::<serde_json::Value>(&contents)
             .unwrap_or_else(|e| panic!("{} is not valid JSON: {e}", path.display()));
+        // Reference the file relative to CARGO_MANIFEST_DIR rather than by
+        // the absolute path this build ran from, so the generated source is
+        // stable across machines (reproducible builds, no local paths leaking
+        // into build artifacts). Forward slashes work on Windows here too.
         generated.push_str(&format!(
-            "    ({stem:?}, include_str!({:?})),\n",
-            path.display()
+            "    ({stem:?}, include_str!(concat!(env!(\"CARGO_MANIFEST_DIR\"), \"/translations/{stem}.json\"))),\n",
         ));
     }
     generated.push_str("];\n");

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,66 @@
+use std::path::Path;
+
 fn main() {
+    embed_translations();
     tauri_build::build()
+}
+
+/// Generate `$OUT_DIR/embedded_translations.rs` with the contents of every
+/// `translations/*.json` present at compile time.
+///
+/// `en.json` is the committed source of truth and always present; the other
+/// locales are gitignored and only exist when the release workflow downloads
+/// them from Lokalise before building, so a dev build is English-only while a
+/// release build embeds every translated locale. Embedding (rather than
+/// bundling as resources) means the lookup can never fail at runtime on a
+/// missing or unreadable file.
+fn embed_translations() {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
+    let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR not set");
+    let translations_dir = Path::new(&manifest_dir).join("translations");
+
+    // Re-run when locale files are added or removed, not just edited.
+    println!("cargo:rerun-if-changed={}", translations_dir.display());
+
+    let mut locales: Vec<(String, std::path::PathBuf)> = std::fs::read_dir(&translations_dir)
+        .expect("translations/ directory is missing; en.json must exist")
+        .filter_map(|entry| {
+            let path = entry.expect("failed to read translations/ entry").path();
+            let stem = path.file_stem()?.to_str()?.to_string();
+            (path.extension()? == "json").then_some((stem, path))
+        })
+        .collect();
+
+    // Deterministic embed order (and thus deterministic builds) regardless of
+    // filesystem iteration order.
+    locales.sort();
+
+    assert!(
+        locales.iter().any(|(stem, _)| stem == "en"),
+        "translations/en.json is missing"
+    );
+
+    let mut generated = String::from(
+        "/// Locale stem → raw JSON, for every translation file present at compile time.\n\
+         pub(crate) static EMBEDDED_TRANSLATIONS: &[(&str, &str)] = &[\n",
+    );
+    for (stem, path) in &locales {
+        // Validate at build time so a corrupt download fails the build rather
+        // than panicking (or silently falling back) at runtime.
+        let contents = std::fs::read_to_string(path)
+            .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
+        serde_json::from_str::<serde_json::Value>(&contents)
+            .unwrap_or_else(|e| panic!("{} is not valid JSON: {e}", path.display()));
+        generated.push_str(&format!(
+            "    ({stem:?}, include_str!({:?})),\n",
+            path.display()
+        ));
+    }
+    generated.push_str("];\n");
+
+    std::fs::write(
+        Path::new(&out_dir).join("embedded_translations.rs"),
+        generated,
+    )
+    .expect("failed to write embedded_translations.rs");
 }

--- a/src-tauri/src/app_update/mod.rs
+++ b/src-tauri/src/app_update/mod.rs
@@ -19,6 +19,8 @@ use tauri_plugin_notification::NotificationExt;
 use tauri_plugin_updater::UpdaterExt;
 use tracing::{debug, error, info, warn};
 
+use crate::i18n::{t, t_with};
+
 /// Whether the orchestrator should proceed to check the Python packages
 /// (`esphome` / `esphome-device-builder`) after the desktop self-update
 /// check completes.
@@ -41,7 +43,14 @@ pub async fn check_for_user(app_handle: &AppHandle, show_no_update_dialog: bool)
         Ok(u) => u,
         Err(e) => {
             warn!("Updater not available: {}", e);
-            show_error(app_handle, format!("Updater not available: {}", e)).await;
+            show_error(
+                app_handle,
+                t_with(
+                    "app_update.updater_unavailable",
+                    &[("error", &e.to_string())],
+                ),
+            )
+            .await;
             return NextStep::Continue;
         }
     };
@@ -60,10 +69,10 @@ pub async fn check_for_user(app_handle: &AppHandle, show_no_update_dialog: bool)
             let msg = format_update_prompt(&current_version, &new_version, &notes);
             let confirmed = crate::dialog::confirm(
                 app_handle,
-                "Desktop Update Available",
+                &t("app_update.available_title"),
                 msg,
-                "Update Now",
-                "Later",
+                &t("common.update_now"),
+                &t("common.later"),
             )
             .await;
 
@@ -83,10 +92,10 @@ pub async fn check_for_user(app_handle: &AppHandle, show_no_update_dialog: bool)
             let current = app_handle.package_info().version.to_string();
             info!("Desktop app is up to date ({})", current);
             if show_no_update_dialog {
-                let msg = format!("ESPHome Device Builder {} is the latest version.", current);
+                let msg = t_with("app_update.latest", &[("version", &current)]);
                 crate::dialog::notice(
                     app_handle,
-                    "No Updates Available",
+                    &t("update.none_title"),
                     msg,
                     MessageDialogKind::Info,
                 )
@@ -96,7 +105,11 @@ pub async fn check_for_user(app_handle: &AppHandle, show_no_update_dialog: bool)
         }
         Err(e) => {
             warn!("Desktop update check failed: {}", e);
-            show_error(app_handle, format!("Failed to check for updates: {}", e)).await;
+            show_error(
+                app_handle,
+                t_with("update.check_failed", &[("error", &e.to_string())]),
+            )
+            .await;
             NextStep::Continue
         }
     }
@@ -124,12 +137,14 @@ pub async fn check_and_notify(app_handle: &AppHandle, tray_available: bool) -> N
             if let Err(e) = app_handle
                 .notification()
                 .builder()
-                .title("ESPHome Device Builder Update Available")
-                .body(format!(
-                    "Version {} is available (you have {}). {}",
-                    update.version,
-                    update.current_version,
-                    crate::updates_menu_hint(tray_available)
+                .title(t("update.builder_notification_title"))
+                .body(t_with(
+                    "app_update.notification_body",
+                    &[
+                        ("latest", update.version.as_str()),
+                        ("current", &update.current_version),
+                        ("hint", &crate::updates_menu_hint(tray_available)),
+                    ],
                 ))
                 .show()
             {
@@ -164,18 +179,24 @@ async fn apply_update(app_handle: &AppHandle, update: tauri_plugin_updater::Upda
             // backend child it spawns) keeps the Local Network grant mDNS
             // discovery needs — see `platform::relaunch_for_update`. The dialog is
             // informational (single OK) just to explain the restart.
-            let msg = format!(
-                "ESPHome Device Builder {} has been installed.\n\nIt will now restart to apply the update.",
-                new_version
-            );
-            crate::dialog::notice(app_handle, "Update Installed", msg, MessageDialogKind::Info)
-                .await;
+            let msg = t_with("app_update.installed_body", &[("version", &new_version)]);
+            crate::dialog::notice(
+                app_handle,
+                &t("app_update.installed_title"),
+                msg,
+                MessageDialogKind::Info,
+            )
+            .await;
 
             info!("Relaunching to apply desktop update");
             crate::platform::relaunch_for_update(app_handle);
         }
         Err(e) => {
-            show_error(app_handle, format!("Failed to update: {}", e)).await;
+            show_error(
+                app_handle,
+                t_with("app_update.update_failed", &[("error", &e)]),
+            )
+            .await;
         }
     }
 }
@@ -295,7 +316,7 @@ async fn restore_backend(app_handle: &AppHandle) {
 async fn show_error(app_handle: &AppHandle, msg: String) {
     crate::dialog::notice(
         app_handle,
-        "Update Check Failed",
+        &t("update.check_failed_title"),
         msg,
         MessageDialogKind::Error,
     )
@@ -305,21 +326,16 @@ async fn show_error(app_handle: &AppHandle, msg: String) {
 fn format_update_prompt(current: &str, new: &str, notes: &str) -> String {
     let trimmed_notes = notes.trim();
     if trimmed_notes.is_empty() {
-        format!(
-            "ESPHome Device Builder {} is available.\n\nYou currently have version {}.\n\nWould you like to download and install it now?",
-            new, current
-        )
+        t_with("app_update.prompt", &[("new", new), ("current", current)])
     } else {
         // Keep release notes short in the dialog so it doesn't grow off-screen.
-        let preview: String = trimmed_notes.chars().take(800).collect();
-        let elided = if trimmed_notes.chars().count() > 800 {
-            "\n…"
-        } else {
-            ""
-        };
-        format!(
-            "ESPHome Device Builder {} is available.\n\nYou currently have version {}.\n\nRelease notes:\n{}{}\n\nWould you like to download and install it now?",
-            new, current, preview, elided
+        let mut preview: String = trimmed_notes.chars().take(800).collect();
+        if trimmed_notes.chars().count() > 800 {
+            preview.push_str("\n…");
+        }
+        t_with(
+            "app_update.prompt_with_notes",
+            &[("new", new), ("current", current), ("notes", &preview)],
         )
     }
 }

--- a/src-tauri/src/daemon/mod.rs
+++ b/src-tauri/src/daemon/mod.rs
@@ -358,11 +358,16 @@ impl DaemonManager {
                 if let Err(e) = app_handle
                     .notification()
                     .builder()
-                    .title(format!("{} stopped", backend_label))
-                    .body(format!(
-                        "{} exited unexpectedly ({}). \
-                         Open the tray menu and choose \"View Logs...\" for details.",
-                        backend_label, status
+                    .title(crate::i18n::t_with(
+                        "daemon.stopped_title",
+                        &[("backend", &backend_label)],
+                    ))
+                    .body(crate::i18n::t_with(
+                        "daemon.stopped_body",
+                        &[
+                            ("backend", backend_label.as_str()),
+                            ("status", &status.to_string()),
+                        ],
                     ))
                     .show()
                 {

--- a/src-tauri/src/git_check/mod.rs
+++ b/src-tauri/src/git_check/mod.rs
@@ -17,6 +17,8 @@ use tauri::AppHandle;
 use tauri_plugin_notification::NotificationExt;
 use tracing::{info, warn};
 
+use crate::i18n::{t, t_with};
+
 /// Candidate file names for the git executable, most-specific first.
 ///
 /// On Windows git may be installed as `git.exe` (the usual Git-for-Windows
@@ -26,26 +28,6 @@ const GIT_EXECUTABLES: &[&str] = &["git.exe", "git.cmd"];
 
 #[cfg(not(target_os = "windows"))]
 const GIT_EXECUTABLES: &[&str] = &["git"];
-
-const GIT_MISSING_TITLE: &str = "Git is not installed";
-
-/// Body for platforms where the user installs git themselves. macOS has its own
-/// body (we trigger the Command Line Tools installer there instead).
-#[cfg(not(target_os = "macos"))]
-const GIT_MISSING_BODY: &str = "ESPHome uses Git to download external components, remote \
-(github://) packages, voice models, and other dependencies, so many configurations won't \
-compile without it. Install Git, then restart ESPHome Device Builder so it can detect it.";
-
-/// macOS-specific body. We trigger Apple's Command Line Tools installer (which
-/// includes git) via `xcode-select --install`, so point the user at that
-/// dialog rather than the daunting git-scm.com download.
-#[cfg(target_os = "macos")]
-const GIT_MISSING_BODY_MACOS: &str = "ESPHome uses Git to download external components, remote \
-(github://) packages, voice models, and other dependencies, so many configurations won't \
-compile without it. macOS is opening its Command Line Tools installer, which includes Git \u{2014} \
-finish that install, then restart ESPHome Device Builder so it can detect it.";
-
-const PARENT_GIT_REPO_TITLE: &str = "A parent folder is a Git repository";
 
 /// Iterate over every git executable found on a PATH-style value, in
 /// left-to-right order.
@@ -167,11 +149,11 @@ fn command_line_tools_installed() -> bool {
 }
 
 /// Show the git-missing notification with the given body.
-fn show_git_missing_notification(app_handle: &AppHandle, body: &str) {
+fn show_git_missing_notification(app_handle: &AppHandle, body: String) {
     if let Err(e) = app_handle
         .notification()
         .builder()
-        .title(GIT_MISSING_TITLE)
+        .title(t("git_check.missing_title"))
         .body(body)
         .show()
     {
@@ -231,15 +213,18 @@ pub fn notify_if_git_missing(app_handle: &AppHandle) {
          components will fail until git is installed (see issue #113)"
     );
 
+    // macOS has its own body: we trigger Apple's Command Line Tools installer
+    // (which includes git) via `xcode-select --install`, so point the user at
+    // that dialog rather than the daunting git-scm.com download.
     #[cfg(target_os = "macos")]
     {
         trigger_command_line_tools_install();
-        show_git_missing_notification(app_handle, GIT_MISSING_BODY_MACOS);
+        show_git_missing_notification(app_handle, t("git_check.missing_body_macos"));
     }
 
     #[cfg(not(target_os = "macos"))]
     {
-        show_git_missing_notification(app_handle, GIT_MISSING_BODY);
+        show_git_missing_notification(app_handle, t("git_check.missing_body"));
     }
 }
 
@@ -347,20 +332,18 @@ pub fn notify_if_config_dir_in_git_repo(app_handle: &AppHandle, config_dir: &Pat
         repo_root.display()
     );
 
-    let body = format!(
-        "Your ESPHome configuration ({}) sits inside a Git repository rooted at \
-         {}. ESP-IDF builds can pick up that repository and fail to compile with \
-         an opaque CMake \"head-ref\" error. If your devices fail to build, \
-         remove the stray .git entry (file or folder) from that repository root, \
-         or move your ESPHome configuration outside that repository.",
-        config_dir.display(),
-        repo_root.display()
+    let body = t_with(
+        "git_check.parent_repo_body",
+        &[
+            ("config_dir", &config_dir.display().to_string()),
+            ("repo_root", &repo_root.display().to_string()),
+        ],
     );
 
     if let Err(e) = app_handle
         .notification()
         .builder()
-        .title(PARENT_GIT_REPO_TITLE)
+        .title(t("git_check.parent_repo_title"))
         .body(body)
         .show()
     {

--- a/src-tauri/src/i18n/mod.rs
+++ b/src-tauri/src/i18n/mod.rs
@@ -1,0 +1,542 @@
+//! Runtime UI translations.
+//!
+//! `translations/en.json` is the committed source of truth for every
+//! user-facing string (tray menu, dialogs, notifications). Other locales are
+//! translated on Lokalise, downloaded by the release workflow, and embedded
+//! into the binary at compile time by `build.rs` (see
+//! `EMBEDDED_TRANSLATIONS`), so dev builds are English-only and release
+//! builds carry every locale.
+//!
+//! Keys are dot-separated paths into the nested JSON
+//! (e.g. `tray.open_dashboard`). Lookups resolve with a per-key English
+//! fallback, so a partially translated locale shows English for the missing
+//! keys rather than raw key names. Values may contain named `{placeholder}`
+//! tokens filled by [`t_with`].
+//!
+//! The locale is auto-detected from the system, with the
+//! `ESPHOME_DESKTOP_LANGUAGE` environment variable as an explicit override.
+//! (Deliberately no per-app language setting for now; if users report the
+//! detected language mismatching the device-builder's, revisit syncing the
+//! choice across the stack.)
+//!
+//! Logs and CLI/control-channel output intentionally stay English — this
+//! module is only for strings a user sees in the UI.
+
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+use tracing::warn;
+
+include!(concat!(env!("OUT_DIR"), "/embedded_translations.rs"));
+
+/// The base locale: always embedded, always complete.
+const BASE_LOCALE: &str = "en";
+
+/// Environment override for the UI language, checked before every other
+/// source. Mainly for testing a locale different from the OS one.
+const LOCALE_ENV_VAR: &str = "ESPHOME_DESKTOP_LANGUAGE";
+
+/// The active key → message table, built once on first use.
+static TABLE: OnceLock<HashMap<String, String>> = OnceLock::new();
+
+fn table() -> &'static HashMap<String, String> {
+    TABLE.get_or_init(|| {
+        let locale = choose_locale(std::env::var(LOCALE_ENV_VAR).ok(), sys_locale::get_locale());
+        build_table(test_pinned(locale).as_deref(), EMBEDDED_TRANSLATIONS)
+    })
+}
+
+/// Pin unit tests to English regardless of the host machine's locale or env,
+/// or of extra locale files a release-style build has downloaded next to
+/// en.json. The locale-selection pieces (`choose_locale`, `pick_locale`,
+/// `build_table`) are tested directly.
+#[cfg(test)]
+fn test_pinned(_locale: Option<String>) -> Option<String> {
+    None
+}
+
+#[cfg(not(test))]
+fn test_pinned(locale: Option<String>) -> Option<String> {
+    locale
+}
+
+/// Look up the message for `key` in the active locale (English fallback).
+///
+/// A key missing from `en.json` is a bug caught by the consistency tests
+/// below; at runtime it degrades to returning the key itself.
+pub(crate) fn t(key: &str) -> String {
+    match table().get(key) {
+        Some(message) => message.clone(),
+        None => {
+            warn!("missing translation key: {}", key);
+            key.to_string()
+        }
+    }
+}
+
+/// Look up the message for `key` and fill its named `{placeholder}` tokens.
+pub(crate) fn t_with(key: &str, args: &[(&str, &str)]) -> String {
+    interpolate(&t(key), args)
+}
+
+/// Replace each `{name}` token with its value. Unknown tokens are left
+/// verbatim so a template/args mismatch stays visible instead of vanishing.
+fn interpolate(template: &str, args: &[(&str, &str)]) -> String {
+    let mut out = template.to_string();
+    for (name, value) in args {
+        out = out.replace(&format!("{{{name}}}"), value);
+    }
+    out
+}
+
+/// Pick the locale to use: a non-empty env override wins, then the system
+/// locale. `None` means English.
+fn choose_locale(env_value: Option<String>, system_locale: Option<String>) -> Option<String> {
+    match env_value {
+        Some(v) if !v.is_empty() => Some(v),
+        _ => system_locale,
+    }
+}
+
+/// Normalize a locale tag for comparison: lowercase, hyphen-separated, and
+/// stripped of any encoding/variant suffix (`pt_BR.UTF-8` → `pt-br`).
+/// Sources disagree only on separator and case (BCP 47 `zh-CN` vs POSIX
+/// `zh_CN`), so this avoids a per-locale mapping table.
+fn normalize_locale(locale: &str) -> String {
+    let stripped = locale
+        .split(['.', '@'])
+        .next()
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    stripped.to_lowercase().replace('_', "-")
+}
+
+/// Fallback chain for a locale tag, most specific first:
+/// `zh-Hans-CN` → `["zh-hans-cn", "zh-hans", "zh"]`.
+fn locale_candidates(locale: &str) -> Vec<String> {
+    let normalized = normalize_locale(locale);
+    if normalized.is_empty() {
+        return Vec::new();
+    }
+    let parts: Vec<&str> = normalized.split('-').collect();
+    (1..=parts.len())
+        .rev()
+        .map(|n| parts[..n].join("-"))
+        .collect()
+}
+
+/// Match the requested locale against the available locale stems.
+///
+/// Tries each fallback candidate for an exact (normalized) match, then falls
+/// back to the first available stem for the same language (`fr` requested,
+/// only `fr-CA` shipped). Returns the stem exactly as embedded.
+fn pick_locale<'a>(requested: &str, available: &[&'a str]) -> Option<&'a str> {
+    let candidates = locale_candidates(requested);
+    for candidate in &candidates {
+        if let Some(stem) = available
+            .iter()
+            .find(|stem| normalize_locale(stem) == *candidate)
+        {
+            return Some(stem);
+        }
+    }
+    // Language-only fallback: any available stem whose language matches the
+    // broadest candidate (which is the bare language code).
+    let language = candidates.last()?;
+    available
+        .iter()
+        .find(|stem| {
+            normalize_locale(stem)
+                .split('-')
+                .next()
+                .is_some_and(|lang| lang == language)
+        })
+        .copied()
+}
+
+/// Flatten nested JSON into dot-separated keys. Non-string leaves are
+/// ignored — the translation files only carry strings.
+fn flatten(prefix: &str, value: &serde_json::Value, out: &mut HashMap<String, String>) {
+    match value {
+        serde_json::Value::Object(map) => {
+            for (name, child) in map {
+                let key = if prefix.is_empty() {
+                    name.clone()
+                } else {
+                    format!("{prefix}.{name}")
+                };
+                flatten(&key, child, out);
+            }
+        }
+        serde_json::Value::String(s) => {
+            out.insert(prefix.to_string(), s.clone());
+        }
+        _ => {}
+    }
+}
+
+/// Parse one embedded locale into a flat key → message map. The JSON was
+/// validated by `build.rs`, so a parse failure here is unreachable in
+/// practice; degrade to an empty map (English fallback) rather than panic.
+fn parse_locale(raw: &str) -> HashMap<String, String> {
+    let mut out = HashMap::new();
+    match serde_json::from_str::<serde_json::Value>(raw) {
+        Ok(value) => flatten("", &value, &mut out),
+        Err(e) => warn!("failed to parse embedded translation: {}", e),
+    }
+    out
+}
+
+/// Build the active table: the English base overlaid with the requested
+/// locale's non-empty messages (Lokalise exports untranslated keys as empty
+/// strings; those must fall back to English, not blank the UI).
+fn build_table(requested: Option<&str>, embedded: &[(&str, &str)]) -> HashMap<String, String> {
+    let base_raw = embedded
+        .iter()
+        .find(|(stem, _)| *stem == BASE_LOCALE)
+        .map(|(_, raw)| *raw)
+        .unwrap_or("{}");
+    let mut table = parse_locale(base_raw);
+
+    let available: Vec<&str> = embedded
+        .iter()
+        .map(|(stem, _)| *stem)
+        .filter(|stem| *stem != BASE_LOCALE)
+        .collect();
+    let Some(stem) = requested.and_then(|req| pick_locale(req, &available)) else {
+        return table;
+    };
+    let raw = embedded
+        .iter()
+        .find(|(s, _)| *s == stem)
+        .map(|(_, raw)| *raw)
+        .unwrap_or("{}");
+    for (key, message) in parse_locale(raw) {
+        // Only overlay keys that exist in English: a stale Lokalise key must
+        // not resurrect a string the code no longer uses (harmless) or, worse,
+        // mask a typo'd lookup with a stale message.
+        if !message.is_empty() && table.contains_key(&key) {
+            table.insert(key, message);
+        }
+    }
+    table
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn en_is_embedded() {
+        assert!(EMBEDDED_TRANSLATIONS
+            .iter()
+            .any(|(stem, _)| *stem == BASE_LOCALE));
+    }
+
+    #[test]
+    fn t_returns_english_message() {
+        assert_eq!(t("tray.open_dashboard"), "Open Dashboard");
+    }
+
+    #[test]
+    fn t_missing_key_returns_key() {
+        // Uppercase on purpose: the used-keys consistency scan below skips
+        // non-snake-case literals, so this deliberately-missing key doesn't
+        // trip `all_used_keys_exist_in_en_json`.
+        assert_eq!(t("no.such.KEY"), "no.such.KEY");
+    }
+
+    #[test]
+    fn t_with_fills_placeholders() {
+        assert_eq!(t_with("tray.port", &[("port", "6052")]), "Port: 6052");
+    }
+
+    #[test]
+    fn interpolate_replaces_all_and_repeated() {
+        assert_eq!(
+            interpolate("{a} and {b} and {a}", &[("a", "1"), ("b", "2")]),
+            "1 and 2 and 1"
+        );
+    }
+
+    #[test]
+    fn interpolate_leaves_unknown_tokens() {
+        assert_eq!(interpolate("hello {name}", &[]), "hello {name}");
+    }
+
+    #[test]
+    fn choose_locale_prefers_env_override() {
+        assert_eq!(
+            choose_locale(Some("fr".into()), Some("de".into())),
+            Some("fr".into())
+        );
+    }
+
+    #[test]
+    fn choose_locale_empty_env_falls_back_to_system() {
+        assert_eq!(
+            choose_locale(Some(String::new()), Some("de".into())),
+            Some("de".into())
+        );
+        assert_eq!(choose_locale(None, Some("de".into())), Some("de".into()));
+        assert_eq!(choose_locale(None, None), None);
+    }
+
+    #[test]
+    fn normalize_locale_handles_posix_tags() {
+        assert_eq!(normalize_locale("pt_BR.UTF-8"), "pt-br");
+        assert_eq!(normalize_locale("en_US@euro"), "en-us");
+        assert_eq!(normalize_locale("zh-CN"), "zh-cn");
+        assert_eq!(normalize_locale(""), "");
+    }
+
+    #[test]
+    fn locale_candidates_most_specific_first() {
+        assert_eq!(
+            locale_candidates("zh-Hans-CN"),
+            vec!["zh-hans-cn", "zh-hans", "zh"]
+        );
+        assert_eq!(locale_candidates("en"), vec!["en"]);
+        assert!(locale_candidates("").is_empty());
+    }
+
+    #[test]
+    fn pick_locale_exact_match() {
+        assert_eq!(pick_locale("fr", &["de", "fr"]), Some("fr"));
+    }
+
+    #[test]
+    fn pick_locale_region_falls_back_to_language() {
+        assert_eq!(pick_locale("fr-CA", &["de", "fr"]), Some("fr"));
+    }
+
+    #[test]
+    fn pick_locale_normalizes_separators() {
+        assert_eq!(pick_locale("zh_CN.UTF-8", &["zh-CN"]), Some("zh-CN"));
+    }
+
+    #[test]
+    fn pick_locale_language_matches_regional_stem() {
+        // Only a regional variant is shipped; a bare-language request should
+        // still land on it.
+        assert_eq!(pick_locale("fr", &["de", "fr-CA"]), Some("fr-CA"));
+    }
+
+    #[test]
+    fn pick_locale_no_match() {
+        assert_eq!(pick_locale("ja", &["de", "fr"]), None);
+        assert_eq!(pick_locale("", &["de", "fr"]), None);
+    }
+
+    #[test]
+    fn flatten_ignores_non_string_leaves() {
+        let value = serde_json::json!({
+            "a": {"b": "msg", "n": 3, "arr": ["x"]},
+            "top": "level"
+        });
+        let mut out = HashMap::new();
+        flatten("", &value, &mut out);
+        assert_eq!(out.get("a.b").map(String::as_str), Some("msg"));
+        assert_eq!(out.get("top").map(String::as_str), Some("level"));
+        assert_eq!(out.len(), 2);
+    }
+
+    #[test]
+    fn parse_locale_bad_json_is_empty() {
+        assert!(parse_locale("not json").is_empty());
+    }
+
+    #[test]
+    fn build_table_overlays_requested_locale() {
+        let embedded: &[(&str, &str)] = &[
+            ("en", r#"{"a": "english", "b": "base"}"#),
+            ("fr", r#"{"a": "français", "b": ""}"#),
+        ];
+        let table = build_table(Some("fr-FR"), embedded);
+        assert_eq!(table.get("a").map(String::as_str), Some("français"));
+        // Empty (untranslated) values fall back to English.
+        assert_eq!(table.get("b").map(String::as_str), Some("base"));
+    }
+
+    #[test]
+    fn build_table_ignores_stale_locale_keys() {
+        let embedded: &[(&str, &str)] = &[
+            ("en", r#"{"a": "english"}"#),
+            ("fr", r#"{"a": "français", "gone": "stale"}"#),
+        ];
+        let table = build_table(Some("fr"), embedded);
+        assert_eq!(table.get("a").map(String::as_str), Some("français"));
+        assert!(!table.contains_key("gone"));
+    }
+
+    #[test]
+    fn build_table_unknown_locale_is_english() {
+        let embedded: &[(&str, &str)] = &[("en", r#"{"a": "english"}"#)];
+        let table = build_table(Some("ja"), embedded);
+        assert_eq!(table.get("a").map(String::as_str), Some("english"));
+        let table = build_table(None, embedded);
+        assert_eq!(table.get("a").map(String::as_str), Some("english"));
+    }
+
+    #[test]
+    fn build_table_missing_base_is_empty() {
+        // Unreachable in practice (build.rs asserts en.json exists), but the
+        // defensive default must not panic.
+        let table = build_table(None, &[]);
+        assert!(table.is_empty());
+    }
+
+    #[test]
+    fn en_json_placeholders_are_well_formed() {
+        // Every `{...}` token in en.json must be a simple snake_case
+        // identifier — anything else is a typo that interpolation would
+        // silently leave in the UI.
+        let en = EMBEDDED_TRANSLATIONS
+            .iter()
+            .find(|(stem, _)| *stem == BASE_LOCALE)
+            .map(|(_, raw)| *raw)
+            .expect("en.json embedded");
+        for (key, message) in parse_locale(en) {
+            let mut rest = message.as_str();
+            while let Some(start) = rest.find('{') {
+                let after = &rest[start + 1..];
+                let end = after
+                    .find('}')
+                    .unwrap_or_else(|| panic!("unclosed '{{' in {key}"));
+                let name = &after[..end];
+                assert!(
+                    !name.is_empty()
+                        && name
+                            .chars()
+                            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_'),
+                    "bad placeholder {{{name}}} in {key}"
+                );
+                rest = &after[end + 1..];
+            }
+            assert!(!rest.contains('}'), "stray '}}' in {key}");
+        }
+    }
+
+    /// True for a dot-separated snake_case key path whose segments are all
+    /// non-empty and start with a letter (`tray.open_dashboard`), which is
+    /// what distinguishes translation keys from other string literals (`...`,
+    /// file names, etc.).
+    fn is_key_shaped(key: &str) -> bool {
+        key.contains('.')
+            && key.split('.').all(|segment| {
+                segment
+                    .chars()
+                    .next()
+                    .is_some_and(|c| c.is_ascii_lowercase())
+                    && segment
+                        .chars()
+                        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+            })
+    }
+
+    /// Extract translation keys from `t(` / `t_with(` call sites in a source
+    /// string. The char before the `t` must not be part of an identifier so
+    /// e.g. `format!(` or `split(` don't match, and whitespace between the
+    /// paren and the key literal is skipped so rustfmt's line breaks don't
+    /// hide a call site.
+    fn extract_keys(source: &str, out: &mut std::collections::BTreeSet<String>) {
+        for needle in ["t(", "t_with("] {
+            let mut from = 0;
+            while let Some(pos) = source[from..].find(needle) {
+                let at = from + pos;
+                from = at + needle.len();
+                if at > 0 {
+                    let prev = source.as_bytes()[at - 1];
+                    if prev.is_ascii_alphanumeric() || prev == b'_' {
+                        continue;
+                    }
+                }
+                let rest = source[at + needle.len()..].trim_start();
+                let Some(literal) = rest.strip_prefix('"') else {
+                    continue;
+                };
+                let Some(key_end) = literal.find('"') else {
+                    continue;
+                };
+                let key = &literal[..key_end];
+                if is_key_shaped(key) {
+                    out.insert(key.to_string());
+                }
+            }
+        }
+    }
+
+    /// Collect every translation key referenced from the crate's sources.
+    fn used_keys() -> std::collections::BTreeSet<String> {
+        let src_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let mut keys = std::collections::BTreeSet::new();
+        let mut stack = vec![src_dir];
+        while let Some(dir) = stack.pop() {
+            for entry in std::fs::read_dir(&dir).expect("read src dir") {
+                let path = entry.expect("read dir entry").path();
+                if path.is_dir() {
+                    stack.push(path);
+                } else if path.extension().is_some_and(|e| e == "rs") {
+                    let source = std::fs::read_to_string(&path).expect("read source file");
+                    extract_keys(&source, &mut keys);
+                }
+            }
+        }
+        keys
+    }
+
+    #[test]
+    fn all_used_keys_exist_in_en_json() {
+        let en = EMBEDDED_TRANSLATIONS
+            .iter()
+            .find(|(stem, _)| *stem == BASE_LOCALE)
+            .map(|(_, raw)| *raw)
+            .expect("en.json embedded");
+        let table = parse_locale(en);
+        let missing: Vec<String> = used_keys()
+            .into_iter()
+            .filter(|key| !table.contains_key(key))
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "keys used in code but missing from en.json: {missing:?}"
+        );
+    }
+
+    #[test]
+    fn all_en_json_keys_are_used() {
+        let en = EMBEDDED_TRANSLATIONS
+            .iter()
+            .find(|(stem, _)| *stem == BASE_LOCALE)
+            .map(|(_, raw)| *raw)
+            .expect("en.json embedded");
+        let table = parse_locale(en);
+        let used = used_keys();
+        let unused: Vec<&String> = table.keys().filter(|key| !used.contains(*key)).collect();
+        assert!(
+            unused.is_empty(),
+            "keys in en.json but never used in code: {unused:?}"
+        );
+    }
+
+    #[test]
+    fn extract_keys_skips_identifier_prefixes_and_non_keys() {
+        let mut out = std::collections::BTreeSet::new();
+        extract_keys(
+            r#"
+            let a = t("tray.quit");
+            let b = crate::i18n::t_with("tray.port", &[("port", "1")]);
+            let c = format!("not.a.key");
+            let d = split("also.not");
+            let e = t("no_dot");
+            let f = t("Bad.Case");
+            "#,
+            &mut out,
+        );
+        assert_eq!(
+            out.into_iter().collect::<Vec<_>>(),
+            vec!["tray.port".to_string(), "tray.quit".to_string()]
+        );
+    }
+}

--- a/src-tauri/src/i18n/mod.rs
+++ b/src-tauri/src/i18n/mod.rs
@@ -82,10 +82,33 @@ pub(crate) fn t_with(key: &str, args: &[(&str, &str)]) -> String {
 /// Replace each `{name}` token with its value. Unknown tokens are left
 /// verbatim so a template/args mismatch stays visible instead of vanishing.
 fn interpolate(template: &str, args: &[(&str, &str)]) -> String {
-    let mut out = template.to_string();
-    for (name, value) in args {
-        out = out.replace(&format!("{{{name}}}"), value);
+    // Single pass over the original template, so substituted values are never
+    // re-scanned — an arg value that happens to contain `{other}` (say, a
+    // brace-y error message) must land verbatim, not trigger a second
+    // substitution.
+    let mut out = String::with_capacity(template.len());
+    let mut rest = template;
+    while let Some(start) = rest.find('{') {
+        out.push_str(&rest[..start]);
+        let after = &rest[start + 1..];
+        let Some(end) = after.find('}') else {
+            // Unmatched '{' — keep the tail verbatim.
+            out.push_str(&rest[start..]);
+            return out;
+        };
+        let name = &after[..end];
+        match args.iter().find(|(arg, _)| *arg == name) {
+            Some((_, value)) => out.push_str(value),
+            None => {
+                // Unknown token: kept verbatim so a mismatch stays visible.
+                out.push('{');
+                out.push_str(name);
+                out.push('}');
+            }
+        }
+        rest = &after[end + 1..];
     }
+    out.push_str(rest);
     out
 }
 
@@ -263,6 +286,23 @@ mod tests {
     #[test]
     fn interpolate_leaves_unknown_tokens() {
         assert_eq!(interpolate("hello {name}", &[]), "hello {name}");
+    }
+
+    #[test]
+    fn interpolate_never_rescans_substituted_values() {
+        // A value that itself looks like a placeholder (e.g. a brace-y error
+        // message) must land verbatim, not trigger a second substitution.
+        assert_eq!(
+            interpolate("{a}", &[("a", "{b}"), ("b", "X")]),
+            "{b}",
+            "substituted value was re-processed as a template"
+        );
+    }
+
+    #[test]
+    fn interpolate_keeps_unmatched_brace_verbatim() {
+        assert_eq!(interpolate("50% {done", &[("done", "X")]), "50% {done");
+        assert_eq!(interpolate("a } b", &[]), "a } b");
     }
 
     #[test]
@@ -468,8 +508,17 @@ mod tests {
     }
 
     /// Collect every translation key referenced from the crate's sources.
+    ///
+    /// Skips this module's own file: it is the only source whose `t(...)`
+    /// literals live in test code (the tests right here), and counting those
+    /// as usage would let a key stay "used" after the last production
+    /// reference is removed, defeating the drift checks below.
     fn used_keys() -> std::collections::BTreeSet<String> {
         let src_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let own_file = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src")
+            .join("i18n")
+            .join("mod.rs");
         let mut keys = std::collections::BTreeSet::new();
         let mut stack = vec![src_dir];
         while let Some(dir) = stack.pop() {
@@ -477,7 +526,7 @@ mod tests {
                 let path = entry.expect("read dir entry").path();
                 if path.is_dir() {
                     stack.push(path);
-                } else if path.extension().is_some_and(|e| e == "rs") {
+                } else if path.extension().is_some_and(|e| e == "rs") && path != own_file {
                     let source = std::fs::read_to_string(&path).expect("read source file");
                     extract_keys(&source, &mut keys);
                 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ mod control;
 mod daemon;
 mod dialog;
 mod git_check;
+mod i18n;
 mod platform;
 mod settings;
 mod tray;
@@ -258,12 +259,11 @@ impl AppState {
 /// "open the tray menu" is misleading — there is no menu. Point them at the
 /// CLI instead, which drives the same update flow over the control channel.
 /// See GitHub issue #87.
-pub(crate) fn updates_menu_hint(tray_available: bool) -> &'static str {
+pub(crate) fn updates_menu_hint(tray_available: bool) -> String {
     if tray_available {
-        "Open the tray menu and choose \"Check for Updates...\" to update."
+        i18n::t("hint.updates_menu")
     } else {
-        "No system tray was detected. Run `esphome-desktop update` from a \
-         terminal to update."
+        i18n::t("hint.updates_cli")
     }
 }
 

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -1971,16 +1971,12 @@ pub fn cleanup_legacy_macos_app(app_handle: &AppHandle) {
         std::thread::spawn(move || {
             let confirmed = dialog_app
                 .dialog()
-                .message(
-                    "An older version of this app named \u{201C}ESPHome Builder\u{201D} \
-                     was found in your Applications folder. Move it to the Trash?\n\n\
-                     Your settings and configs are not affected.",
-                )
-                .title("Remove old ESPHome Builder")
+                .message(crate::i18n::t("platform.remove_legacy_prompt"))
+                .title(crate::i18n::t("platform.remove_legacy_title"))
                 .kind(MessageDialogKind::Info)
                 .buttons(MessageDialogButtons::OkCancelCustom(
-                    "Move to Trash".to_string(),
-                    "Keep".to_string(),
+                    crate::i18n::t("platform.move_to_trash"),
+                    crate::i18n::t("platform.keep"),
                 ))
                 .blocking_show();
 

--- a/src-tauri/src/tray/mod.rs
+++ b/src-tauri/src/tray/mod.rs
@@ -15,6 +15,7 @@ use tauri_plugin_notification::NotificationExt;
 use tracing::{error, info, warn};
 
 use crate::control::ops::{self, SwitchOutcome, UpdateGuard};
+use crate::i18n::{t, t_with};
 use crate::settings::{Backend, ReleaseChannel};
 use crate::AppState;
 
@@ -50,9 +51,9 @@ mod ids {
 pub fn build_tray_menu(app_handle: &AppHandle, state: &Arc<AppState>) -> Result<Menu<tauri::Wry>> {
     let settings = async_runtime::block_on(state.settings.read());
     let status_text = if state.daemon.is_running() {
-        "Status: Running"
+        t("tray.status_running")
     } else {
-        "Status: Starting..."
+        t("tray.status_starting")
     };
 
     // Create status item and store it for later updates
@@ -63,16 +64,25 @@ pub fn build_tray_menu(app_handle: &AppHandle, state: &Arc<AppState>) -> Result<
 
     // Create desktop app version display item (Tauri app version from
     // tauri.conf.json — fixed for the lifetime of the process, never updated).
-    let app_version_text = format!("Desktop: {}", app_handle.package_info().version);
+    let app_version_text = t_with(
+        "tray.desktop_version",
+        &[("version", &app_handle.package_info().version.to_string())],
+    );
     let app_version_item = MenuItemBuilder::with_id(ids::APP_VERSION, app_version_text)
         .enabled(false)
         .build(app_handle)?;
 
     // Create ESPHome version display item
-    let version_text = match &settings.installed_version {
-        Some(v) => format!("ESPHome: {}", v),
-        None => "ESPHome: unknown".to_string(),
-    };
+    let version_text = t_with(
+        "tray.esphome_version",
+        &[(
+            "version",
+            settings
+                .installed_version
+                .as_deref()
+                .unwrap_or(&t("version.unknown")),
+        )],
+    );
     let version_item = MenuItemBuilder::with_id(ids::VERSION, version_text)
         .enabled(false)
         .build(app_handle)?;
@@ -83,10 +93,15 @@ pub fn build_tray_menu(app_handle: &AppHandle, state: &Arc<AppState>) -> Result<
     // too slow / too risky (could hang) to run synchronously in the setup
     // path, so we start with a "detecting…" placeholder and refresh from a
     // background task immediately below.
-    let builder_version_item =
-        MenuItemBuilder::with_id(ids::BUILDER_VERSION, "Device Builder: detecting…")
-            .enabled(false)
-            .build(app_handle)?;
+    let builder_version_item = MenuItemBuilder::with_id(
+        ids::BUILDER_VERSION,
+        t_with(
+            "tray.builder_version",
+            &[("version", &t("version.detecting"))],
+        ),
+    )
+    .enabled(false)
+    .build(app_handle)?;
     let _ = BUILDER_VERSION_ITEM.set(builder_version_item.clone());
 
     // Kick off async detection of the installed `esphome-device-builder`
@@ -122,11 +137,12 @@ pub fn build_tray_menu(app_handle: &AppHandle, state: &Arc<AppState>) -> Result<
     let _ = CHANNEL_BETA_ITEM.set(channel_beta.clone());
     let _ = CHANNEL_DEV_ITEM.set(channel_dev.clone());
 
-    let channel_submenu = SubmenuBuilder::with_id(app_handle, "release_channel", "Release Channel")
-        .item(&channel_stable)
-        .item(&channel_beta)
-        .item(&channel_dev)
-        .build()?;
+    let channel_submenu =
+        SubmenuBuilder::with_id(app_handle, "release_channel", t("tray.release_channel"))
+            .item(&channel_stable)
+            .item(&channel_beta)
+            .item(&channel_dev)
+            .build()?;
 
     // Backend submenu items
     let current_backend = settings.backend;
@@ -151,7 +167,7 @@ pub fn build_tray_menu(app_handle: &AppHandle, state: &Arc<AppState>) -> Result<
     let _ = BACKEND_BUILDER_STABLE_ITEM.set(backend_builder_stable.clone());
     let _ = BACKEND_BUILDER_BETA_ITEM.set(backend_builder_beta.clone());
 
-    let backend_submenu = SubmenuBuilder::with_id(app_handle, "backend", "Backend")
+    let backend_submenu = SubmenuBuilder::with_id(app_handle, "backend", t("tray.backend"))
         .item(&backend_builder_stable)
         .item(&backend_builder_beta)
         .build()?;
@@ -165,26 +181,26 @@ pub fn build_tray_menu(app_handle: &AppHandle, state: &Arc<AppState>) -> Result<
         .unwrap_or(settings.launch_at_startup);
     let startup_enable = MenuItemBuilder::with_id(
         ids::STARTUP_ENABLE,
-        radio_label("Launch at Login", launch_at_startup),
+        radio_label(&t("tray.launch_at_login"), launch_at_startup),
     )
     .build(app_handle)?;
     let startup_disable = MenuItemBuilder::with_id(
         ids::STARTUP_DISABLE,
-        radio_label("Don't Launch at Login", !launch_at_startup),
+        radio_label(&t("tray.dont_launch_at_login"), !launch_at_startup),
     )
     .build(app_handle)?;
 
     let _ = STARTUP_ENABLE_ITEM.set(startup_enable.clone());
     let _ = STARTUP_DISABLE_ITEM.set(startup_disable.clone());
 
-    let startup_submenu = SubmenuBuilder::with_id(app_handle, "startup", "Startup")
+    let startup_submenu = SubmenuBuilder::with_id(app_handle, "startup", t("tray.startup"))
         .item(&startup_enable)
         .item(&startup_disable)
         .build()?;
 
     let menu = MenuBuilder::new(app_handle)
         .item(
-            &MenuItemBuilder::with_id(ids::OPEN_DASHBOARD, "Open Dashboard")
+            &MenuItemBuilder::with_id(ids::OPEN_DASHBOARD, t("tray.open_dashboard"))
                 .accelerator("CmdOrCtrl+O")
                 .build(app_handle)?,
         )
@@ -194,27 +210,30 @@ pub fn build_tray_menu(app_handle: &AppHandle, state: &Arc<AppState>) -> Result<
         .item(&version_item)
         .item(&builder_version_item)
         .item(
-            &MenuItemBuilder::with_id(ids::PORT, format!("Port: {}", settings.port))
-                .enabled(false)
-                .build(app_handle)?,
+            &MenuItemBuilder::with_id(
+                ids::PORT,
+                t_with("tray.port", &[("port", &settings.port.to_string())]),
+            )
+            .enabled(false)
+            .build(app_handle)?,
         )
         .separator()
         .item(&backend_submenu)
         .item(&channel_submenu)
         .item(&startup_submenu)
         .item(
-            &MenuItemBuilder::with_id(ids::CHECK_UPDATES, "Check for Updates...")
+            &MenuItemBuilder::with_id(ids::CHECK_UPDATES, t("tray.check_updates"))
                 .build(app_handle)?,
         )
         .separator()
-        .item(&MenuItemBuilder::with_id(ids::VIEW_LOGS, "View Logs...").build(app_handle)?)
+        .item(&MenuItemBuilder::with_id(ids::VIEW_LOGS, t("tray.view_logs")).build(app_handle)?)
+        .item(&MenuItemBuilder::with_id(ids::OPEN_CONFIG, t("tray.open_config")).build(app_handle)?)
         .item(
-            &MenuItemBuilder::with_id(ids::OPEN_CONFIG, "Open Config Folder...")
+            &MenuItemBuilder::with_id(ids::RESTART, t("tray.restart_dashboard"))
                 .build(app_handle)?,
         )
-        .item(&MenuItemBuilder::with_id(ids::RESTART, "Restart Dashboard").build(app_handle)?)
         .separator()
-        .item(&MenuItemBuilder::with_id(ids::QUIT, "Quit ESPHome").build(app_handle)?)
+        .item(&MenuItemBuilder::with_id(ids::QUIT, t("tray.quit")).build(app_handle)?)
         .build()?;
 
     // Set up menu event handler
@@ -253,9 +272,9 @@ static STARTUP_DISABLE_ITEM: std::sync::OnceLock<MenuItem<tauri::Wry>> = std::sy
 /// Update the tray status text
 pub fn update_status(_app_handle: &AppHandle, running: bool) {
     let status_text = if running {
-        "Status: Running"
+        t("tray.status_running")
     } else {
-        "Status: Stopped"
+        t("tray.status_stopped")
     };
 
     if let Some(item) = STATUS_ITEM.get() {
@@ -266,14 +285,14 @@ pub fn update_status(_app_handle: &AppHandle, running: bool) {
 /// Update the version display in the tray menu.
 pub fn update_version(version: &str) {
     if let Some(item) = VERSION_ITEM.get() {
-        let _ = item.set_text(format!("ESPHome: {}", version));
+        let _ = item.set_text(t_with("tray.esphome_version", &[("version", version)]));
     }
 }
 
 /// Update the `esphome-device-builder` version display in the tray menu.
 pub fn update_builder_version(version: &str) {
     if let Some(item) = BUILDER_VERSION_ITEM.get() {
-        let _ = item.set_text(format!("Device Builder: {}", version));
+        let _ = item.set_text(t_with("tray.builder_version", &[("version", version)]));
     }
 }
 
@@ -318,10 +337,10 @@ pub(crate) fn update_backend_checks(backend: Backend) {
 /// Update the startup menu item labels to reflect whether autostart is enabled.
 pub(crate) fn update_startup_checks(enabled: bool) {
     if let Some(item) = STARTUP_ENABLE_ITEM.get() {
-        let _ = item.set_text(radio_label("Launch at Login", enabled));
+        let _ = item.set_text(radio_label(&t("tray.launch_at_login"), enabled));
     }
     if let Some(item) = STARTUP_DISABLE_ITEM.get() {
-        let _ = item.set_text(radio_label("Don't Launch at Login", !enabled));
+        let _ = item.set_text(radio_label(&t("tray.dont_launch_at_login"), !enabled));
     }
 }
 
@@ -331,10 +350,10 @@ pub(crate) fn refresh_version_display(app_handle: &AppHandle) {
     // real detection failure ("unknown") instead of collapsing both.
     let version = match crate::update::installed_esphome_version(app_handle) {
         Ok(Some(v)) => v,
-        Ok(None) => "not installed".to_string(),
+        Ok(None) => t("version.not_installed"),
         Err(e) => {
             warn!("Could not detect ESPHome version: {}", e);
-            "unknown".to_string()
+            t("version.unknown")
         }
     };
     update_version(&version);
@@ -349,17 +368,17 @@ pub(crate) async fn refresh_builder_version_display(app_handle: &AppHandle) {
     let label = tokio::task::spawn_blocking(move || {
         match crate::update::get_installed_device_builder_version(&app) {
             Ok(Some(v)) => v,
-            Ok(None) => "not installed".to_string(),
+            Ok(None) => t("version.not_installed"),
             Err(e) => {
                 warn!("Could not detect esphome-device-builder version: {}", e);
-                "unknown".to_string()
+                t("version.unknown")
             }
         }
     })
     .await
     .unwrap_or_else(|e| {
         warn!("Device-builder version detection task failed: {}", e);
-        "unknown".to_string()
+        t("version.unknown")
     });
     update_builder_version(&label);
 }
@@ -425,8 +444,8 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>) {
                         error!("Failed to stop backend for update: {}", e);
                         crate::dialog::notice(
                             &app,
-                            "Update Failed",
-                            format!("Failed to stop dashboard: {}", e),
+                            &t("update.update_failed_title"),
+                            t_with("errors.stop_dashboard_failed", &[("error", &e.to_string())]),
                             MessageDialogKind::Error,
                         )
                         .await;
@@ -450,10 +469,10 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>) {
                                 error!("Failed to restart backend after update: {}", e);
                                 crate::dialog::notice(
                                     &app,
-                                    "Update Partially Complete",
-                                    format!(
-                                        "ESPHome updated to {}, but failed to restart dashboard: {}",
-                                        version, e
+                                    &t("update.update_partial_title"),
+                                    t_with(
+                                        "update.esphome_partial",
+                                        &[("version", version.as_str()), ("error", &e.to_string())],
                                     ),
                                     MessageDialogKind::Warning,
                                 )
@@ -461,14 +480,13 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>) {
                             } else {
                                 update_status(&app, true);
                                 let msg = if channel == ReleaseChannel::Dev {
-                                    "ESPHome has been updated to the latest dev version."
-                                        .to_string()
+                                    t("update.esphome_updated_dev")
                                 } else {
-                                    format!("ESPHome has been updated to version {}.", version)
+                                    t_with("update.esphome_updated", &[("version", &version)])
                                 };
                                 crate::dialog::notice(
                                     &app,
-                                    "Update Complete",
+                                    &t("update.update_complete_title"),
                                     msg,
                                     MessageDialogKind::Info,
                                 )
@@ -479,8 +497,11 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>) {
                             error!("Update failed: {}", e);
                             crate::dialog::notice(
                                 &app,
-                                "Update Failed",
-                                format!("Failed to update ESPHome: {}", e),
+                                &t("update.update_failed_title"),
+                                t_with(
+                                    "update.esphome_update_failed",
+                                    &[("error", &e.to_string())],
+                                ),
                                 MessageDialogKind::Error,
                             )
                             .await;
@@ -517,8 +538,8 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>) {
                     error!("Failed to stop backend for device-builder update: {}", e);
                     crate::dialog::notice(
                         &app,
-                        "Update Failed",
-                        format!("Failed to stop backend: {}", e),
+                        &t("update.update_failed_title"),
+                        t_with("errors.stop_backend_failed", &[("error", &e.to_string())]),
                         MessageDialogKind::Error,
                     )
                     .await;
@@ -543,10 +564,13 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>) {
                             );
                             crate::dialog::notice(
                                 &app,
-                                "Update Partially Complete",
-                                format!(
-                                    "Device builder updated to {}, but failed to restart backend: {}",
-                                    builder_version, e
+                                &t("update.update_partial_title"),
+                                t_with(
+                                    "update.builder_partial",
+                                    &[
+                                        ("version", builder_version.as_str()),
+                                        ("error", &e.to_string()),
+                                    ],
                                 ),
                                 MessageDialogKind::Warning,
                             )
@@ -555,11 +579,8 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>) {
                             update_status(&app, true);
                             crate::dialog::notice(
                                 &app,
-                                "Update Complete",
-                                format!(
-                                    "ESPHome Device Builder has been updated to version {}.",
-                                    builder_version
-                                ),
+                                &t("update.update_complete_title"),
+                                t_with("update.builder_updated", &[("version", &builder_version)]),
                                 MessageDialogKind::Info,
                             )
                             .await;
@@ -569,8 +590,8 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>) {
                         error!("Device-builder update failed: {}", e);
                         crate::dialog::notice(
                             &app,
-                            "Update Failed",
-                            format!("Failed to update ESPHome Device Builder: {}", e),
+                            &t("update.update_failed_title"),
+                            t_with("update.builder_update_failed", &[("error", &e.to_string())]),
                             MessageDialogKind::Error,
                         )
                         .await;
@@ -611,19 +632,26 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>) {
                 }
 
                 // Confirm the channel switch with the user.
-                let warning = if new_channel == ReleaseChannel::Dev {
-                    "Warning: The dev channel installs ESPHome directly from GitHub and does NOT support automatic updates. You will need to manually check for updates.\n\n"
-                } else {
-                    ""
-                };
-
-                let msg = format!(
-                    "{}Switch ESPHome from {} to {} channel?\n\nThis will stop the dashboard, install the appropriate version, and restart.",
-                    warning, old_channel, new_channel
+                let prompt = t_with(
+                    "switch_channel.prompt",
+                    &[
+                        ("old", &old_channel.to_string()),
+                        ("new", &new_channel.to_string()),
+                    ],
                 );
-                let confirmed =
-                    crate::dialog::confirm(&app, "Switch Release Channel", msg, "Switch", "Cancel")
-                        .await;
+                let msg = if new_channel == ReleaseChannel::Dev {
+                    format!("{}\n\n{}", t("switch_channel.dev_warning"), prompt)
+                } else {
+                    prompt
+                };
+                let confirmed = crate::dialog::confirm(
+                    &app,
+                    &t("switch_channel.title"),
+                    msg,
+                    &t("common.switch"),
+                    &t("common.cancel"),
+                )
+                .await;
 
                 if !confirmed {
                     // Revert the check marks
@@ -639,13 +667,13 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>) {
                 {
                     SwitchOutcome::Unchanged => {}
                     SwitchOutcome::Success { .. } => {
-                        let msg = format!(
-                            "Successfully switched to the {} release channel.",
-                            new_channel
+                        let msg = t_with(
+                            "switch_channel.switched",
+                            &[("channel", &new_channel.to_string())],
                         );
                         crate::dialog::notice(
                             &app,
-                            "Channel Switched",
+                            &t("switch_channel.switched_title"),
                             msg,
                             MessageDialogKind::Info,
                         )
@@ -654,8 +682,8 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>) {
                     SwitchOutcome::StopFailed(e) => {
                         crate::dialog::notice(
                             &app,
-                            "Channel Switch Failed",
-                            format!("Failed to stop dashboard: {}", e),
+                            &t("switch_channel.failed_title"),
+                            t_with("errors.stop_dashboard_failed", &[("error", &e.to_string())]),
                             MessageDialogKind::Error,
                         )
                         .await;
@@ -663,8 +691,8 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>) {
                     SwitchOutcome::InstallFailed { error, .. } => {
                         crate::dialog::notice(
                             &app,
-                            "Channel Switch Failed",
-                            format!("Failed to switch channel: {}", error),
+                            &t("switch_channel.failed_title"),
+                            t_with("switch_channel.failed", &[("error", &error.to_string())]),
                             MessageDialogKind::Error,
                         )
                         .await;
@@ -672,10 +700,13 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>) {
                     SwitchOutcome::StartFailed(e) => {
                         crate::dialog::notice(
                             &app,
-                            "Channel Switch Partially Complete",
-                            format!(
-                                "Switched to {} channel, but failed to restart dashboard: {}",
-                                new_channel, e
+                            &t("switch_channel.partial_title"),
+                            t_with(
+                                "switch_channel.partial",
+                                &[
+                                    ("channel", &new_channel.to_string()),
+                                    ("error", &e.to_string()),
+                                ],
                             ),
                             MessageDialogKind::Warning,
                         )
@@ -705,14 +736,18 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>) {
                 }
 
                 // Confirm the switch with the user.
-                let msg = format!(
-                    "Switch to {}?\n\n\
-                     This will install the `esphome-device-builder` Python package, \
-                     stop the current backend, and restart with the new one.",
-                    new_backend
+                let msg = t_with(
+                    "switch_backend.prompt",
+                    &[("backend", &new_backend.to_string())],
                 );
-                let confirmed =
-                    crate::dialog::confirm(&app, "Switch Backend", msg, "Switch", "Cancel").await;
+                let confirmed = crate::dialog::confirm(
+                    &app,
+                    &t("switch_backend.title"),
+                    msg,
+                    &t("common.switch"),
+                    &t("common.cancel"),
+                )
+                .await;
 
                 if !confirmed {
                     update_backend_checks(old_backend);
@@ -727,17 +762,20 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>) {
                     SwitchOutcome::Unchanged => {}
                     SwitchOutcome::Success { ready } => {
                         let body = if ready {
-                            format!("{} is ready.", new_backend)
+                            t_with(
+                                "switch_backend.ready",
+                                &[("backend", &new_backend.to_string())],
+                            )
                         } else {
-                            format!(
-                                "Switched to {}, but it didn't become ready in time. Check the logs.",
-                                new_backend
+                            t_with(
+                                "switch_backend.not_ready",
+                                &[("backend", &new_backend.to_string())],
                             )
                         };
                         if let Err(e) = app
                             .notification()
                             .builder()
-                            .title("Backend Switched")
+                            .title(t("switch_backend.switched_title"))
                             .body(body)
                             .show()
                         {
@@ -747,8 +785,8 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>) {
                     SwitchOutcome::StopFailed(e) => {
                         crate::dialog::notice(
                             &app,
-                            "Backend Switch Failed",
-                            format!("Failed to stop backend: {}", e),
+                            &t("switch_backend.failed_title"),
+                            t_with("errors.stop_backend_failed", &[("error", &e.to_string())]),
                             MessageDialogKind::Error,
                         )
                         .await;
@@ -756,8 +794,11 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>) {
                     SwitchOutcome::InstallFailed { error, .. } => {
                         crate::dialog::notice(
                             &app,
-                            "Backend Switch Failed",
-                            format!("Failed to install esphome-device-builder: {}", error),
+                            &t("switch_backend.failed_title"),
+                            t_with(
+                                "switch_backend.install_failed",
+                                &[("error", &error.to_string())],
+                            ),
                             MessageDialogKind::Error,
                         )
                         .await;
@@ -765,8 +806,8 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<AppState>) {
                     SwitchOutcome::StartFailed(e) => {
                         crate::dialog::notice(
                             &app,
-                            "Backend Switch Failed",
-                            format!("Failed to start backend: {}", e),
+                            &t("switch_backend.failed_title"),
+                            t_with("switch_backend.start_failed", &[("error", &e.to_string())]),
                             MessageDialogKind::Error,
                         )
                         .await;

--- a/src-tauri/src/update/mod.rs
+++ b/src-tauri/src/update/mod.rs
@@ -12,6 +12,7 @@ use tauri_plugin_dialog::{DialogExt, MessageDialogKind};
 use tauri_plugin_notification::NotificationExt;
 use tracing::{debug, error, info, warn};
 
+use crate::i18n::{t, t_with};
 use crate::platform;
 use crate::settings::{Backend, ReleaseChannel};
 
@@ -117,23 +118,20 @@ impl UpdateChecker {
         // Dev channel: offer to reinstall from git HEAD
         if channel == ReleaseChannel::Dev {
             let installed = installed_esphome_version(app_handle).ok().flatten();
-            let installed_str = installed.as_deref().unwrap_or("unknown").to_string();
+            let installed_str = installed.unwrap_or_else(|| t("version.unknown"));
 
             let dialog_app = app_handle.clone();
             let should_update = tokio::task::spawn_blocking(move || {
                 dialog_app
                     .dialog()
-                    .message(format!(
-                        "You are on the dev channel.\n\n\
-                         Currently installed: {}\n\n\
-                         This will reinstall ESPHome from the latest commit on GitHub.\n\n\
-                         Would you like to update now?",
-                        installed_str
+                    .message(t_with(
+                        "update.dev_channel_prompt",
+                        &[("version", &installed_str)],
                     ))
-                    .title("Dev Channel Update")
+                    .title(t("update.dev_channel_title"))
                     .buttons(tauri_plugin_dialog::MessageDialogButtons::OkCancelCustom(
-                        "Update Now".to_string(),
-                        "Cancel".to_string(),
+                        t("common.update_now"),
+                        t("common.cancel"),
                     ))
                     .blocking_show()
             })
@@ -155,9 +153,9 @@ impl UpdateChecker {
                 let _ = tokio::task::spawn_blocking(move || {
                     dialog_app
                         .dialog()
-                        .message("ESPHome is not installed")
+                        .message(t("update.not_installed"))
                         .kind(MessageDialogKind::Error)
-                        .title("Update Check Failed")
+                        .title(t("update.check_failed_title"))
                         .blocking_show();
                 })
                 .await;
@@ -166,13 +164,13 @@ impl UpdateChecker {
             Err(e) => {
                 warn!("Could not detect installed version: {}", e);
                 let dialog_app = app_handle.clone();
-                let msg = format!("Could not detect installed version: {}", e);
+                let msg = t_with("update.detect_failed", &[("error", &e.to_string())]);
                 let _ = tokio::task::spawn_blocking(move || {
                     dialog_app
                         .dialog()
                         .message(msg)
                         .kind(MessageDialogKind::Error)
-                        .title("Update Check Failed")
+                        .title(t("update.check_failed_title"))
                         .blocking_show();
                 })
                 .await;
@@ -188,9 +186,9 @@ impl UpdateChecker {
                 let _ = tokio::task::spawn_blocking(move || {
                     dialog_app
                         .dialog()
-                        .message("Could not determine latest version")
+                        .message(t("update.latest_unknown"))
                         .kind(MessageDialogKind::Error)
-                        .title("Update Check Failed")
+                        .title(t("update.check_failed_title"))
                         .blocking_show();
                 })
                 .await;
@@ -199,13 +197,13 @@ impl UpdateChecker {
             Err(e) => {
                 warn!("Update check failed: {}", e);
                 let dialog_app = app_handle.clone();
-                let msg = format!("Failed to check for updates: {}", e);
+                let msg = t_with("update.check_failed", &[("error", &e.to_string())]);
                 let _ = tokio::task::spawn_blocking(move || {
                     dialog_app
                         .dialog()
                         .message(msg)
                         .kind(MessageDialogKind::Error)
-                        .title("Update Check Failed")
+                        .title(t("update.check_failed_title"))
                         .blocking_show();
                 })
                 .await;
@@ -220,6 +218,7 @@ impl UpdateChecker {
                 installed, latest, installed
             );
 
+            // Channel names are deliberately untranslated (product terms).
             let channel_label = match channel {
                 ReleaseChannel::Stable => "stable",
                 ReleaseChannel::Beta => "beta",
@@ -228,18 +227,22 @@ impl UpdateChecker {
 
             // Ask user if they want to update
             let dialog_app = app_handle.clone();
-            let msg = format!(
-                "ESPHome {} ({}) is available.\n\nYou currently have version {}.\n\nWould you like to update now?",
-                latest, channel_label, installed
+            let msg = t_with(
+                "update.available_prompt",
+                &[
+                    ("latest", latest.as_str()),
+                    ("channel", channel_label),
+                    ("installed", &installed),
+                ],
             );
             let should_update = tokio::task::spawn_blocking(move || {
                 dialog_app
                     .dialog()
                     .message(msg)
-                    .title("Update Available")
+                    .title(t("update.available_title"))
                     .buttons(tauri_plugin_dialog::MessageDialogButtons::OkCancelCustom(
-                        "Update Now".to_string(),
-                        "Later".to_string(),
+                        t("common.update_now"),
+                        t("common.later"),
                     ))
                     .blocking_show()
             })
@@ -253,13 +256,13 @@ impl UpdateChecker {
             info!("ESPHome is up to date ({})", installed);
 
             let dialog_app = app_handle.clone();
-            let msg = format!("ESPHome {} is the latest version.", installed);
+            let msg = t_with("update.esphome_latest", &[("version", &installed)]);
             let _ = tokio::task::spawn_blocking(move || {
                 dialog_app
                     .dialog()
                     .message(msg)
                     .kind(MessageDialogKind::Info)
-                    .title("No Updates Available")
+                    .title(t("update.none_title"))
                     .blocking_show();
             })
             .await;
@@ -311,6 +314,7 @@ impl UpdateChecker {
                 installed, latest, installed
             );
 
+            // Channel names are deliberately untranslated (product terms).
             let channel_label = match channel {
                 ReleaseChannel::Stable => "stable",
                 ReleaseChannel::Beta => "beta",
@@ -321,13 +325,15 @@ impl UpdateChecker {
             if let Err(e) = app_handle
                 .notification()
                 .builder()
-                .title("ESPHome Update Available")
-                .body(format!(
-                    "ESPHome {} ({}) is available (you have {}). {}",
-                    latest,
-                    channel_label,
-                    installed,
-                    crate::updates_menu_hint(tray_available)
+                .title(t("update.esphome_notification_title"))
+                .body(t_with(
+                    "update.esphome_notification_body",
+                    &[
+                        ("latest", latest.as_str()),
+                        ("channel", channel_label),
+                        ("installed", &installed),
+                        ("hint", &crate::updates_menu_hint(tray_available)),
+                    ],
                 ))
                 .show()
             {
@@ -512,12 +518,14 @@ impl UpdateChecker {
             if let Err(e) = app_handle
                 .notification()
                 .builder()
-                .title("ESPHome Device Builder Update Available")
-                .body(format!(
-                    "ESPHome Device Builder {} is available (you have {}). {}",
-                    latest,
-                    installed,
-                    crate::updates_menu_hint(tray_available)
+                .title(t("update.builder_notification_title"))
+                .body(t_with(
+                    "update.builder_notification_body",
+                    &[
+                        ("latest", latest.as_str()),
+                        ("installed", &installed),
+                        ("hint", &crate::updates_menu_hint(tray_available)),
+                    ],
                 ))
                 .show()
             {
@@ -571,18 +579,18 @@ impl UpdateChecker {
         );
 
         let dialog_app = app_handle.clone();
-        let msg = format!(
-            "ESPHome Device Builder {} is available.\n\nYou currently have version {}.\n\nWould you like to update now?",
-            latest, installed
+        let msg = t_with(
+            "update.builder_available_prompt",
+            &[("latest", latest.as_str()), ("installed", &installed)],
         );
         let should_update = tokio::task::spawn_blocking(move || {
             dialog_app
                 .dialog()
                 .message(msg)
-                .title("Device Builder Update Available")
+                .title(t("update.builder_available_title"))
                 .buttons(tauri_plugin_dialog::MessageDialogButtons::OkCancelCustom(
-                    "Update Now".to_string(),
-                    "Later".to_string(),
+                    t("common.update_now"),
+                    t("common.later"),
                 ))
                 .blocking_show()
         })

--- a/src-tauri/translations/en.json
+++ b/src-tauri/translations/en.json
@@ -1,0 +1,119 @@
+{
+  "tray": {
+    "status_running": "Status: Running",
+    "status_starting": "Status: Starting...",
+    "status_stopped": "Status: Stopped",
+    "desktop_version": "Desktop: {version}",
+    "esphome_version": "ESPHome: {version}",
+    "builder_version": "Device Builder: {version}",
+    "port": "Port: {port}",
+    "open_dashboard": "Open Dashboard",
+    "release_channel": "Release Channel",
+    "backend": "Backend",
+    "startup": "Startup",
+    "launch_at_login": "Launch at Login",
+    "dont_launch_at_login": "Don't Launch at Login",
+    "check_updates": "Check for Updates...",
+    "view_logs": "View Logs...",
+    "open_config": "Open Config Folder...",
+    "restart_dashboard": "Restart Dashboard",
+    "quit": "Quit ESPHome"
+  },
+  "version": {
+    "detecting": "detecting…",
+    "not_installed": "not installed",
+    "unknown": "unknown"
+  },
+  "common": {
+    "update_now": "Update Now",
+    "later": "Later",
+    "cancel": "Cancel",
+    "switch": "Switch"
+  },
+  "errors": {
+    "stop_dashboard_failed": "Failed to stop dashboard: {error}",
+    "stop_backend_failed": "Failed to stop backend: {error}"
+  },
+  "update": {
+    "update_failed_title": "Update Failed",
+    "update_partial_title": "Update Partially Complete",
+    "update_complete_title": "Update Complete",
+    "check_failed_title": "Update Check Failed",
+    "none_title": "No Updates Available",
+    "available_title": "Update Available",
+    "esphome_update_failed": "Failed to update ESPHome: {error}",
+    "esphome_updated": "ESPHome has been updated to version {version}.",
+    "esphome_updated_dev": "ESPHome has been updated to the latest dev version.",
+    "esphome_partial": "ESPHome updated to {version}, but failed to restart dashboard: {error}",
+    "esphome_latest": "ESPHome {version} is the latest version.",
+    "esphome_notification_title": "ESPHome Update Available",
+    "esphome_notification_body": "ESPHome {latest} ({channel}) is available (you have {installed}). {hint}",
+    "available_prompt": "ESPHome {latest} ({channel}) is available.\n\nYou currently have version {installed}.\n\nWould you like to update now?",
+    "dev_channel_title": "Dev Channel Update",
+    "dev_channel_prompt": "You are on the dev channel.\n\nCurrently installed: {version}\n\nThis will reinstall ESPHome from the latest commit on GitHub.\n\nWould you like to update now?",
+    "not_installed": "ESPHome is not installed",
+    "detect_failed": "Could not detect installed version: {error}",
+    "latest_unknown": "Could not determine latest version",
+    "check_failed": "Failed to check for updates: {error}",
+    "builder_update_failed": "Failed to update ESPHome Device Builder: {error}",
+    "builder_updated": "ESPHome Device Builder has been updated to version {version}.",
+    "builder_partial": "Device builder updated to {version}, but failed to restart backend: {error}",
+    "builder_notification_title": "ESPHome Device Builder Update Available",
+    "builder_notification_body": "ESPHome Device Builder {latest} is available (you have {installed}). {hint}",
+    "builder_available_title": "Device Builder Update Available",
+    "builder_available_prompt": "ESPHome Device Builder {latest} is available.\n\nYou currently have version {installed}.\n\nWould you like to update now?"
+  },
+  "app_update": {
+    "available_title": "Desktop Update Available",
+    "prompt": "ESPHome Device Builder {new} is available.\n\nYou currently have version {current}.\n\nWould you like to download and install it now?",
+    "prompt_with_notes": "ESPHome Device Builder {new} is available.\n\nYou currently have version {current}.\n\nRelease notes:\n{notes}\n\nWould you like to download and install it now?",
+    "latest": "ESPHome Device Builder {version} is the latest version.",
+    "updater_unavailable": "Updater not available: {error}",
+    "update_failed": "Failed to update: {error}",
+    "notification_body": "Version {latest} is available (you have {current}). {hint}",
+    "installed_title": "Update Installed",
+    "installed_body": "ESPHome Device Builder {version} has been installed.\n\nIt will now restart to apply the update."
+  },
+  "switch_channel": {
+    "title": "Switch Release Channel",
+    "dev_warning": "Warning: The dev channel installs ESPHome directly from GitHub and does NOT support automatic updates. You will need to manually check for updates.",
+    "prompt": "Switch ESPHome from {old} to {new} channel?\n\nThis will stop the dashboard, install the appropriate version, and restart.",
+    "switched_title": "Channel Switched",
+    "switched": "Successfully switched to the {channel} release channel.",
+    "failed_title": "Channel Switch Failed",
+    "failed": "Failed to switch channel: {error}",
+    "partial_title": "Channel Switch Partially Complete",
+    "partial": "Switched to {channel} channel, but failed to restart dashboard: {error}"
+  },
+  "switch_backend": {
+    "title": "Switch Backend",
+    "prompt": "Switch to {backend}?\n\nThis will install the `esphome-device-builder` Python package, stop the current backend, and restart with the new one.",
+    "switched_title": "Backend Switched",
+    "ready": "{backend} is ready.",
+    "not_ready": "Switched to {backend}, but it didn't become ready in time. Check the logs.",
+    "failed_title": "Backend Switch Failed",
+    "install_failed": "Failed to install esphome-device-builder: {error}",
+    "start_failed": "Failed to start backend: {error}"
+  },
+  "daemon": {
+    "stopped_title": "{backend} stopped",
+    "stopped_body": "{backend} exited unexpectedly ({status}). Open the tray menu and choose \"View Logs...\" for details."
+  },
+  "git_check": {
+    "missing_title": "Git is not installed",
+    "missing_body": "ESPHome uses Git to download external components, remote (github://) packages, voice models, and other dependencies, so many configurations won't compile without it. Install Git, then restart ESPHome Device Builder so it can detect it.",
+    "missing_body_macos": "ESPHome uses Git to download external components, remote (github://) packages, voice models, and other dependencies, so many configurations won't compile without it. macOS is opening its Command Line Tools installer, which includes Git — finish that install, then restart ESPHome Device Builder so it can detect it.",
+    "parent_repo_title": "A parent folder is a Git repository",
+    "parent_repo_body": "Your ESPHome configuration ({config_dir}) sits inside a Git repository rooted at {repo_root}. ESP-IDF builds can pick up that repository and fail to compile with an opaque CMake \"head-ref\" error. If your devices fail to build, remove the stray .git entry (file or folder) from that repository root, or move your ESPHome configuration outside that repository."
+  },
+  "platform": {
+    "remove_legacy_title": "Remove old ESPHome Builder",
+    "remove_legacy_prompt": "An older version of this app named “ESPHome Builder” was found in your Applications folder. Move it to the Trash?\n\nYour settings and configs are not affected.",
+    "move_to_trash": "Move to Trash",
+    "keep": "Keep"
+  },
+  "hint": {
+    "updates_menu": "Open the tray menu and choose \"Check for Updates...\" to update.",
+    "updates_cli": "No system tray was detected. Run `esphome-desktop update` from a terminal to update."
+  }
+}

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -103,13 +103,16 @@ def test_write_locale_bundle_prints_repo_relative_paths(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     # When the destination sits inside the repo root, the log line shows the
-    # repo-relative path (the ValueError fallback is covered by the
-    # tmp_path-outside-repo tests above).
+    # repo-relative path. (The ValueError fallback for a destination outside
+    # the repo is exercised by test_write_locale_bundle_writes_non_base_locales,
+    # whose tmp_path destination is not under REPO_ROOT.)
     monkeypatch.setattr(translations, "REPO_ROOT", tmp_path)
     dest = tmp_path / "src-tauri" / "translations"
     dest.mkdir(parents=True)
     translations.write_locale_bundle(_zip_bytes({"fr.json": "{}"}), dest)
-    assert "src-tauri/translations/fr.json" in capsys.readouterr().out
+    # Compare with native separators so the assertion holds on Windows too.
+    expected = str(Path("src-tauri") / "translations" / "fr.json")
+    assert expected in capsys.readouterr().out
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -18,6 +18,7 @@ import importlib.util
 import io
 import json
 import os
+import socket
 import subprocess
 import sys
 import threading
@@ -205,6 +206,28 @@ def test_request_surfaces_http_errors(fake_lokalise: _FakeLokalise) -> None:
         _client(fake_lokalise).wait_for_process("p1")
 
 
+def _dead_port() -> int:
+    """An ephemeral port with nothing listening on it."""
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        port = sock.getsockname()[1]
+    return port
+
+
+def test_request_surfaces_network_errors() -> None:
+    # Connection refused (URLError, not HTTPError) must still land as a
+    # LokaliseError so main() prints one ::error:: line, not a stack trace.
+    client = translations.LokaliseClient(
+        "token",
+        "proj",
+        api_base=f"http://127.0.0.1:{_dead_port()}",
+        poll_interval=0.0,
+        sleep=lambda _s: None,
+    )
+    with pytest.raises(translations.LokaliseError, match="failed"):
+        client.wait_for_process("p1")
+
+
 # --------------------------------------------------------------------------- #
 # Upload.
 # --------------------------------------------------------------------------- #
@@ -348,6 +371,29 @@ def test_run_download_fails_on_empty_bundle(
     _script_download(fake_lokalise, {"en.json": "{}"})
     with pytest.raises(translations.LokaliseError, match="no non-base"):
         translations.run_download(_client(fake_lokalise), tmp_path)
+
+
+def test_fetch_bytes_wraps_http_errors(fake_lokalise: _FakeLokalise) -> None:
+    # An expired/forbidden signed bundle URL (any HTTP error) must land as a
+    # LokaliseError; the fake server 404s unscripted paths.
+    with pytest.raises(translations.LokaliseError, match="Failed to download bundle"):
+        translations.fetch_bytes(f"{_base_url(fake_lokalise)}/missing.zip")
+
+
+def test_fetch_bytes_wraps_network_errors() -> None:
+    with pytest.raises(translations.LokaliseError, match="Failed to download bundle"):
+        translations.fetch_bytes(f"http://127.0.0.1:{_dead_port()}/bundle.zip")
+
+
+def test_write_locale_bundle_rejects_corrupt_zip(tmp_path: Path) -> None:
+    with pytest.raises(translations.LokaliseError, match="not a valid zip"):
+        translations.write_locale_bundle(b"this is not a zip", tmp_path)
+
+
+def test_write_locale_bundle_rejects_invalid_json_entry(tmp_path: Path) -> None:
+    bundle = _zip_bytes({"fr.json": "{truncated"})
+    with pytest.raises(translations.LokaliseError, match="fr.json.*not valid JSON"):
+        translations.write_locale_bundle(bundle, tmp_path)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -1,0 +1,435 @@
+#!/usr/bin/env python3
+"""Tests for .github/scripts/translations.py.
+
+The Lokalise sync script feeds the release pipeline: ``upload`` pushes
+en.json keys to translators and ``download`` fetches the locale files a
+release embeds. A bug here could silently ship an English-only release or
+prune translated keys, so every path — the pure helpers, the API client
+against a real (local) HTTP server, and the CLI dispatch — gets a
+regression net. Nothing here touches the real Lokalise API.
+
+pytest suite (maintainer-requested framework, fully typed, no classes).
+"""
+
+from __future__ import annotations
+
+import base64
+import importlib.util
+import io
+import json
+import os
+import subprocess
+import sys
+import threading
+import zipfile
+from collections.abc import Iterator
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT_PATH = REPO_ROOT / ".github" / "scripts" / "translations.py"
+
+
+def _load_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("translations", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+translations = _load_module()
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers.
+# --------------------------------------------------------------------------- #
+
+
+def test_to_bcp47_canonicalizes_separators_and_case() -> None:
+    assert translations.to_bcp47("zh_CN") == "zh-CN"
+    assert translations.to_bcp47("pt-br") == "pt-BR"
+    assert translations.to_bcp47("sr_latn_rs") == "sr-Latn-RS"
+    assert translations.to_bcp47("es_419") == "es-419"
+    assert translations.to_bcp47("EN") == "en"
+    # Non-standard subtags pass through lowercased rather than raising.
+    assert translations.to_bcp47("x_weird9") == "x-weird9"
+
+
+def test_locale_from_zip_entry() -> None:
+    assert translations.locale_from_zip_entry("fr.json") == "fr"
+    assert translations.locale_from_zip_entry("nested/zh_CN.json") == "zh-CN"
+    assert translations.locale_from_zip_entry("readme.txt") is None
+
+
+def _zip_bytes(entries: dict[str, str]) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as bundle:
+        for name, content in entries.items():
+            bundle.writestr(name, content)
+    return buf.getvalue()
+
+
+def test_write_locale_bundle_writes_non_base_locales(tmp_path: Path) -> None:
+    written = translations.write_locale_bundle(
+        _zip_bytes(
+            {
+                "en.json": '{"a": "english"}',
+                "fr.json": '{"a": "français"}',
+                "zh_CN.json": '{"a": "中文"}',
+                "notes.txt": "not a locale",
+            }
+        ),
+        tmp_path,
+    )
+    assert written == ["fr", "zh-CN"]
+    # en.json is the committed source of truth: never written by a download.
+    assert not (tmp_path / "en.json").exists()
+    # Repo JSON conventions: 2-space indent, raw unicode, trailing newline.
+    assert (tmp_path / "fr.json").read_text(encoding="utf-8") == (
+        '{\n  "a": "français"\n}\n'
+    )
+    assert "中文" in (tmp_path / "zh-CN.json").read_text(encoding="utf-8")
+
+
+def test_write_locale_bundle_prints_repo_relative_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # When the destination sits inside the repo root, the log line shows the
+    # repo-relative path (the ValueError fallback is covered by the
+    # tmp_path-outside-repo tests above).
+    monkeypatch.setattr(translations, "REPO_ROOT", tmp_path)
+    dest = tmp_path / "src-tauri" / "translations"
+    dest.mkdir(parents=True)
+    translations.write_locale_bundle(_zip_bytes({"fr.json": "{}"}), dest)
+    assert "src-tauri/translations/fr.json" in capsys.readouterr().out
+
+
+# --------------------------------------------------------------------------- #
+# Fake Lokalise server. Serves scripted responses per (method, path) and
+# records request payloads, so the client is exercised over real HTTP.
+# --------------------------------------------------------------------------- #
+
+
+class _FakeLokalise(ThreadingHTTPServer):
+    # (method, path) -> list of (status, body bytes); the last entry repeats.
+    script: dict[tuple[str, str], list[tuple[int, bytes]]]
+    requests: list[tuple[str, str, dict[str, Any] | None]]
+
+
+class _Handler(BaseHTTPRequestHandler):
+    server: _FakeLokalise  # type: ignore[assignment]
+
+    def _serve(self) -> None:
+        length = int(self.headers.get("Content-Length") or 0)
+        body = json.loads(self.rfile.read(length)) if length else None
+        self.server.requests.append((self.command, self.path, body))
+
+        responses = self.server.script.get((self.command, self.path))
+        if not responses:
+            self.send_response(404)
+            self.end_headers()
+            return
+        status, payload = responses.pop(0) if len(responses) > 1 else responses[0]
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(payload)
+
+    do_GET = _serve
+    do_POST = _serve
+
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
+        pass  # keep pytest output clean
+
+
+@pytest.fixture
+def fake_lokalise() -> Iterator[_FakeLokalise]:
+    server = _FakeLokalise(("127.0.0.1", 0), _Handler)
+    server.script = {}
+    server.requests = []
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield server
+    server.shutdown()
+    thread.join()
+
+
+def _base_url(server: _FakeLokalise) -> str:
+    host, port = server.server_address[0], server.server_address[1]
+    return f"http://{host}:{port}"
+
+
+def _client(server: _FakeLokalise, **kwargs: Any) -> Any:
+    return translations.LokaliseClient(
+        "token",
+        "proj",
+        api_base=_base_url(server),
+        poll_interval=0.0,
+        sleep=lambda _s: None,
+        **kwargs,
+    )
+
+
+def _json(payload: dict[str, Any], status: int = 200) -> tuple[int, bytes]:
+    return (status, json.dumps(payload).encode())
+
+
+# --------------------------------------------------------------------------- #
+# Client construction and request plumbing.
+# --------------------------------------------------------------------------- #
+
+
+def test_client_requires_token_and_project() -> None:
+    with pytest.raises(translations.LokaliseError, match="LOKALISE_API_TOKEN"):
+        translations.LokaliseClient("", "proj")
+    with pytest.raises(translations.LokaliseError, match="LOKALISE_PROJECT_ID"):
+        translations.LokaliseClient("token", "")
+
+
+def test_request_surfaces_http_errors(fake_lokalise: _FakeLokalise) -> None:
+    fake_lokalise.script[("GET", "/projects/proj/processes/p1")] = [
+        (401, b'{"error": "bad token"}')
+    ]
+    with pytest.raises(translations.LokaliseError, match="HTTP 401"):
+        _client(fake_lokalise).wait_for_process("p1")
+
+
+# --------------------------------------------------------------------------- #
+# Upload.
+# --------------------------------------------------------------------------- #
+
+
+def test_upload_polls_until_finished(fake_lokalise: _FakeLokalise) -> None:
+    fake_lokalise.script[("POST", "/projects/proj/files/upload")] = [
+        _json({"process": {"process_id": "p1"}})
+    ]
+    fake_lokalise.script[("GET", "/projects/proj/processes/p1")] = [
+        _json({"process": {"status": "queued"}}),
+        _json({"process": {"status": "running"}}),
+        _json({"process": {"status": "finished", "details": {"files": 1}}}),
+    ]
+
+    process = _client(fake_lokalise).upload_base_file("QUJD", cleanup_mode=False)
+
+    assert process["status"] == "finished"
+    upload_body = fake_lokalise.requests[0][2]
+    assert upload_body is not None
+    assert upload_body["data"] == "QUJD"
+    assert upload_body["lang_iso"] == "en"
+    assert upload_body["cleanup_mode"] is False
+    # Placeholder/plural handling must stay verbatim for the Rust runtime.
+    assert upload_body["convert_placeholders"] is False
+    assert upload_body["detect_icu_plurals"] is False
+    assert upload_body["replace_modified"] is True
+
+
+def test_upload_cleanup_mode_is_forwarded(fake_lokalise: _FakeLokalise) -> None:
+    fake_lokalise.script[("POST", "/projects/proj/files/upload")] = [
+        _json({"process": {"process_id": "p1"}})
+    ]
+    fake_lokalise.script[("GET", "/projects/proj/processes/p1")] = [
+        _json({"process": {"status": "finished"}})
+    ]
+
+    _client(fake_lokalise).upload_base_file("QUJD", cleanup_mode=True)
+
+    upload_body = fake_lokalise.requests[0][2]
+    assert upload_body is not None
+    assert upload_body["cleanup_mode"] is True
+
+
+def test_upload_without_process_id_fails(fake_lokalise: _FakeLokalise) -> None:
+    fake_lokalise.script[("POST", "/projects/proj/files/upload")] = [_json({})]
+    with pytest.raises(translations.LokaliseError, match="process id"):
+        _client(fake_lokalise).upload_base_file("QUJD", cleanup_mode=False)
+
+
+def test_failed_process_raises(fake_lokalise: _FakeLokalise) -> None:
+    fake_lokalise.script[("GET", "/projects/proj/processes/p1")] = [
+        _json({"process": {"status": "failed"}})
+    ]
+    with pytest.raises(translations.LokaliseError, match="failed"):
+        _client(fake_lokalise).wait_for_process("p1")
+
+
+def test_stuck_process_times_out(fake_lokalise: _FakeLokalise) -> None:
+    fake_lokalise.script[("GET", "/projects/proj/processes/p1")] = [
+        _json({"process": {"status": "running"}})
+    ]
+    client = _client(fake_lokalise, poll_timeout=0.0)
+    with pytest.raises(translations.LokaliseError, match="timed out"):
+        client.wait_for_process("p1")
+
+
+# --------------------------------------------------------------------------- #
+# Download.
+# --------------------------------------------------------------------------- #
+
+
+def _script_download(fake_lokalise: _FakeLokalise, entries: dict[str, str]) -> None:
+    """Script the async-export flow ending in a bundle zip download."""
+    bundle_url = f"{_base_url(fake_lokalise)}/bundle.zip"
+    fake_lokalise.script[("POST", "/projects/proj/files/async-download")] = [
+        _json({"process_id": "p2"})
+    ]
+    fake_lokalise.script[("GET", "/projects/proj/processes/p2")] = [
+        _json(
+            {
+                "process": {
+                    "status": "finished",
+                    "details": {"download_url": bundle_url},
+                }
+            }
+        )
+    ]
+    fake_lokalise.script[("GET", "/bundle.zip")] = [(200, _zip_bytes(entries))]
+
+
+def test_download_bundle_url_round_trip(fake_lokalise: _FakeLokalise) -> None:
+    _script_download(fake_lokalise, {"fr.json": "{}"})
+
+    url = _client(fake_lokalise).download_bundle_url()
+
+    assert url.endswith("/bundle.zip")
+    export_body = fake_lokalise.requests[0][2]
+    assert export_body is not None
+    assert export_body["format"] == "json"
+    assert export_body["bundle_structure"] == "%LANG_ISO%.json"
+    # Untranslated keys must be skipped so the app's English fallback kicks in.
+    assert export_body["export_empty_as"] == "skip"
+
+
+def test_download_without_process_id_fails(fake_lokalise: _FakeLokalise) -> None:
+    fake_lokalise.script[("POST", "/projects/proj/files/async-download")] = [_json({})]
+    with pytest.raises(translations.LokaliseError, match="process id"):
+        _client(fake_lokalise).download_bundle_url()
+
+
+def test_download_without_url_fails(fake_lokalise: _FakeLokalise) -> None:
+    fake_lokalise.script[("POST", "/projects/proj/files/async-download")] = [
+        _json({"process_id": "p2"})
+    ]
+    fake_lokalise.script[("GET", "/projects/proj/processes/p2")] = [
+        _json({"process": {"status": "finished", "details": {}}})
+    ]
+    with pytest.raises(translations.LokaliseError, match="download_url"):
+        _client(fake_lokalise).download_bundle_url()
+
+
+def test_run_download_writes_locales(
+    fake_lokalise: _FakeLokalise, tmp_path: Path
+) -> None:
+    _script_download(
+        fake_lokalise, {"en.json": "{}", "fr.json": '{"tray": {"quit": "Quitter"}}'}
+    )
+
+    assert translations.run_download(_client(fake_lokalise), tmp_path) == 0
+
+    data = json.loads((tmp_path / "fr.json").read_text(encoding="utf-8"))
+    assert data == {"tray": {"quit": "Quitter"}}
+
+
+def test_run_download_fails_on_empty_bundle(
+    fake_lokalise: _FakeLokalise, tmp_path: Path
+) -> None:
+    # Only the base language comes back: a wrong project id or corrupt
+    # export must fail loudly, not quietly ship an English-only release.
+    _script_download(fake_lokalise, {"en.json": "{}"})
+    with pytest.raises(translations.LokaliseError, match="no non-base"):
+        translations.run_download(_client(fake_lokalise), tmp_path)
+
+
+# --------------------------------------------------------------------------- #
+# CLI dispatch.
+# --------------------------------------------------------------------------- #
+
+
+def _set_env(monkeypatch: pytest.MonkeyPatch, server: _FakeLokalise) -> None:
+    monkeypatch.setenv("LOKALISE_API_TOKEN", "token")
+    monkeypatch.setenv("LOKALISE_PROJECT_ID", "proj")
+    monkeypatch.setenv("LOKALISE_API_BASE", _base_url(server))
+
+
+def test_main_upload_reads_repo_en_json(
+    fake_lokalise: _FakeLokalise, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_env(monkeypatch, fake_lokalise)
+    fake_lokalise.script[("POST", "/projects/proj/files/upload")] = [
+        _json({"process": {"process_id": "p1"}})
+    ]
+    fake_lokalise.script[("GET", "/projects/proj/processes/p1")] = [
+        _json({"process": {"status": "finished"}})
+    ]
+
+    assert translations.main(["upload"]) == 0
+
+    upload_body = fake_lokalise.requests[0][2]
+    assert upload_body is not None
+    # The upload carries the real committed en.json.
+    en_json = (REPO_ROOT / "src-tauri" / "translations" / "en.json").read_bytes()
+    assert upload_body["data"] == base64.b64encode(en_json).decode()
+    assert upload_body["cleanup_mode"] is False
+
+
+def test_main_upload_cleanup_flag(
+    fake_lokalise: _FakeLokalise, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_env(monkeypatch, fake_lokalise)
+    fake_lokalise.script[("POST", "/projects/proj/files/upload")] = [
+        _json({"process": {"process_id": "p1"}})
+    ]
+    fake_lokalise.script[("GET", "/projects/proj/processes/p1")] = [
+        _json({"process": {"status": "finished"}})
+    ]
+
+    assert translations.main(["upload", "--cleanup"]) == 0
+
+    upload_body = fake_lokalise.requests[0][2]
+    assert upload_body is not None
+    assert upload_body["cleanup_mode"] is True
+
+
+def test_main_download_writes_into_translations_dir(
+    fake_lokalise: _FakeLokalise,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _set_env(monkeypatch, fake_lokalise)
+    monkeypatch.setattr(translations, "TRANSLATIONS_DIR", tmp_path)
+    _script_download(fake_lokalise, {"fr.json": '{"a": "b"}'})
+
+    assert translations.main(["download"]) == 0
+    assert (tmp_path / "fr.json").exists()
+
+
+def test_main_reports_errors_and_exits_nonzero(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.delenv("LOKALISE_API_TOKEN", raising=False)
+    monkeypatch.delenv("LOKALISE_PROJECT_ID", raising=False)
+
+    assert translations.main(["download"]) == 1
+    assert "::error::" in capsys.readouterr().err
+
+
+def test_script_entry_point_runs_main() -> None:
+    # Executed as a real subprocess to cover the `__main__` guard; with no
+    # credentials in the environment it must exit 1 with a CI error line.
+    env = {k: v for k, v in os.environ.items() if not k.startswith("LOKALISE_")}
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "download"],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    assert result.returncode == 1
+    assert "::error::" in result.stderr


### PR DESCRIPTION
# What does this implement/fix?

Makes every user-facing UI string (tray menu, dialogs, notifications) translatable, mirroring the device-builder-frontend setup: `src-tauri/translations/en.json` is the committed source of keys, translations are hosted on [Lokalise](https://app.lokalise.com/public/756339856a4b2415a30c62.63256624/), keys upload automatically when en.json changes on main, and release builds download every translated locale and embed it into the binaries.

- New `i18n` module: `t()` / `t_with()` lookups with `{placeholder}` interpolation, system-locale auto-detection (POSIX/BCP 47 normalization, `zh-Hans-CN` → `zh-hans` → `zh` fallback chain), per-key English fallback for partially translated locales, and an `ESPHOME_DESKTOP_LANGUAGE` env override. Channel names (Stable/Beta/Dev), backend names, logs, and CLI output deliberately stay English.
- `build.rs` embeds every `translations/*.json` present at compile time (validated at build time), so dev builds are English-only and release builds carry all locales; non-en locales are gitignored.
- Self-policing tests: every `t("…")` key used in code must exist in en.json and every en.json key must be used, so keys and code can't drift.
- `.github/scripts/translations.py` (stdlib-only, unit-tested against a local fake Lokalise server): `upload` pushes en.json as the base language (no pruning unless `--cleanup`), `download` pulls all project locales via the async-export endpoint and fails loudly on an empty bundle.
- CI: a new `Upload translations` workflow pushes keys on en.json changes; the Build workflow gains a `translations` job that holds the Lokalise token in isolation (the build matrix never sees it) and hands locales to release builds via artifact. Unset secrets downgrade a release to English-only with a warning while the Lokalise project is bootstrapped.
- README section pointing translators at the public Lokalise join link.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes <link to issue>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tested on the relevant platform(s) (macOS, Windows, Linux).