### PR TITLE
Enable the stable device builder backend in the tray menu

### DIFF
--- a/src-tauri/src/tray/mod.rs
+++ b/src-tauri/src/tray/mod.rs
@@ -125,8 +125,7 @@ pub fn build_tray_menu(app_handle: &AppHandle, state: &Arc<AppState>) -> Result<
 
     // Backend submenu items
     let current_backend = settings.backend;
-    // TODO: use `build` once a stable release of esphome-device-builder is out
-    let backend_builder_stable = BACKEND_BUILDER_STABLE_ITEM.build_disabled(
+    let backend_builder_stable = BACKEND_BUILDER_STABLE_ITEM.build(
         app_handle,
         ids::BACKEND_BUILDER_STABLE,
         current_backend == Backend::BuilderStable,
@@ -240,6 +239,7 @@ impl RadioItem {
     }
 
     /// Like [`RadioItem::build`], but the item is greyed out.
+    #[allow(dead_code)]
     fn build_disabled(
         &self,
         app_handle: &AppHandle,


### PR DESCRIPTION
# What does this implement/fix?

The "ESPHome Device Builder (stable)" item in the tray Backend submenu was built greyed out because `esphome-device-builder` had no final release on PyPI, so the stable-only pip install (no `--pre`) had nothing to resolve to. Final releases exist now (1.2.0, 1.3.0), so the item is built enabled and the stale TODO comment is dropped. The `build_disabled` helper is kept (now `#[allow(dead_code)]`) in case an item needs gating again later.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).