### PR TITLE
fix: kill the Python backend when the desktop dies on Windows

### DIFF
--- a/.github/scripts/e2e_windows_backend_lifetime.ps1
+++ b/.github/scripts/e2e_windows_backend_lifetime.ps1
@@ -108,8 +108,17 @@ $handles = @($backendPids | ForEach-Object { Get-Process -Id $_ -ErrorAction Sil
 # Force-kill the desktop with no chance to run any shutdown code. This is the
 # NSIS uninstaller, a crash, and End Task. Nothing but the job object can save
 # the backend from being orphaned here.
+if ($app.HasExited) {
+    # Interesting in its own right: the desktop fell over on its own between the
+    # backend coming up and us killing it, so there is a different bug to see.
+    Show-Diagnostics "the desktop exited on its own (code $($app.ExitCode)) before the force-kill"
+    throw 'the desktop process exited before it could be force-killed; nothing was tested'
+}
+
 Write-Host "Force-killing the desktop (PID $($app.Id))"
-Stop-Process -Id $app.Id -Force
+# Tolerate a race with the check above rather than throwing past the
+# diagnostics; the WaitForExit below is what actually decides.
+Stop-Process -Id $app.Id -Force -ErrorAction SilentlyContinue
 $app.WaitForExit(30000) | Out-Null
 
 $gone = $false

--- a/.github/scripts/e2e_windows_backend_lifetime.ps1
+++ b/.github/scripts/e2e_windows_backend_lifetime.ps1
@@ -94,7 +94,15 @@ Write-Host "Launching $($exe.Name)"
 # or throw — leaves nothing of ours running. A leaked GUI app still holding the
 # install directory open is the exact failure mode this script exists to detect,
 # so it must not be one this script can cause.
-$app = Start-Process -FilePath $exe.FullName -PassThru
+# `--no-open-dashboard` is doing two jobs. It keeps a browser from opening on the
+# runner, and — load-bearing — it stops `main.rs` treating this as a bare
+# terminal launch. `Start-Process` hands the app our console, so
+# `attach_parent_console()` succeeds and `is_bare_terminal_launch()` sees
+# from_terminal + no args, prints `--help` and exits 0 without ever starting the
+# backend. That is correct behaviour for someone typing `esphome-desktop` at a
+# prompt, and it is exactly what the first run of this script hit. Any explicit
+# flag falls through to a normal launch, which is what a double-click gets.
+$app = Start-Process -FilePath $exe.FullName -ArgumentList '--no-open-dashboard' -PassThru
 try {
     # The backend is Python importing ESPHome, which is not fast, and this is a
     # cold first run on a CI runner. Fail with diagnostics rather than hang.

--- a/.github/scripts/e2e_windows_backend_lifetime.ps1
+++ b/.github/scripts/e2e_windows_backend_lifetime.ps1
@@ -8,9 +8,13 @@
 # backend to come up, force-kill the desktop the way the uninstaller and Task
 # Manager do, and require the backend to be gone.
 #
-# Without the job object this fails: the backend is reparented and keeps holding
-# `python.exe` (and `git.exe`, and the rest of the compile subtree) open, which
-# is exactly the stranded install directory users reported.
+# This has been observed to fail without the job object, rather than assumed to.
+# PR #332 disabled `daemon::start_inner`'s call to `assign_to_kill_on_close_job`
+# and changed nothing else; this script then reported "the backend outlived the
+# force-killed desktop", with a dashboard still serving on 127.0.0.1:6052 after
+# its desktop was gone — the stranded install directory users reported. If you
+# are changing this script, that pairing is what makes it worth running: a check
+# that would pass either way is worse than no check.
 #
 # Diagnostics are deliberate rather than tidy. This is the one test nobody can
 # reproduce without a Windows machine, so when it fails it has to say why on its
@@ -181,6 +185,33 @@ try {
 
     Write-Host "Backend died with the desktop after $([int]$watch.Elapsed.TotalMilliseconds)ms"
     Write-Host 'PASS: the backend cannot outlive the desktop process'
+
+    # --- and the symptom, not just the mechanism --------------------------
+    # Nobody reported "a process lingers". They reported an install directory
+    # that could not be removed, because the orphan held `python.exe` and
+    # `git.exe` open. That is the assertion that matches the bug report, and it
+    # is only meaningful sitting on top of the one above.
+    $uninstaller = Join-Path $InstallDir 'uninstall.exe'
+    if (-not (Test-Path $uninstaller)) { throw "no uninstaller at $uninstaller" }
+    Write-Host 'Uninstalling to confirm nothing is left holding the tree open'
+
+    # `-Wait` is not enough on its own and the reason matters: a bare `/S`
+    # uninstall copies itself to $TEMP and re-execs, so the process started here
+    # returns immediately while the copy does the work. Poll for the tree.
+    # (Passing `_?=` keeps it in place and makes `-Wait` meaningful, but NSIS
+    # then deliberately leaves `uninstall.exe` behind and the directory never
+    # goes away — that same in-place mode is what made the reverted installer
+    # hooks kill themselves, see #328.)
+    Start-Process -FilePath $uninstaller -ArgumentList '/S' -Wait
+    $unwatch = [Diagnostics.Stopwatch]::StartNew()
+    while ($unwatch.Elapsed.TotalSeconds -lt 90 -and (Test-Path $InstallDir)) {
+        Start-Sleep -Milliseconds 500
+    }
+    if (Test-Path $InstallDir) {
+        Show-Diagnostics 'the install tree survived the uninstall'
+        throw "$InstallDir still exists after uninstalling; something is holding it open"
+    }
+    Write-Host "PASS: the install directory was removed after $([int]$unwatch.Elapsed.TotalSeconds)s"
 }
 finally {
     if (-not $app.HasExited) {

--- a/.github/scripts/e2e_windows_backend_lifetime.ps1
+++ b/.github/scripts/e2e_windows_backend_lifetime.ps1
@@ -1,0 +1,130 @@
+# End-to-end check that the Python backend cannot outlive the desktop process.
+#
+# The unit tests prove the job object's mechanics: the flag is set, a child is
+# assigned, a grandchild inherits, and a force-killed owner takes its members
+# with it. What none of them touch is the real thing — the installed bundle, the
+# real `python.exe`, spawned by the real app through the real code path. That is
+# what this does: install the bundle we just built, start it, wait for the
+# backend to come up, force-kill the desktop the way the uninstaller and Task
+# Manager do, and require the backend to be gone.
+#
+# Without the job object this fails: the backend is reparented and keeps holding
+# `python.exe` (and `git.exe`, and the rest of the compile subtree) open, which
+# is exactly the stranded install directory users reported.
+#
+# Diagnostics are deliberate rather than tidy. This is the one test nobody can
+# reproduce without a Windows machine, so when it fails it has to say why on its
+# own.
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$InstallDir = Join-Path $env:LOCALAPPDATA 'ESPHome Device Builder'
+$AppDataDir = Join-Path $env:APPDATA 'io.esphome.builder'
+
+function Get-BackendProcesses {
+    # Scope by executable path, not image name: the runner has its own Pythons
+    # and this must only ever see the bundled one.
+    $prefix = $InstallDir + '\'
+    @(Get-CimInstance Win32_Process | Where-Object {
+        $_.ExecutablePath -and
+        $_.ExecutablePath.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase) -and
+        $_.Name -ieq 'python.exe'
+    })
+}
+
+function Show-Diagnostics {
+    param([string]$Why)
+    Write-Host "::group::Diagnostics — $Why"
+
+    $log = Join-Path $AppDataDir 'logs\dashboard.log'
+    if (Test-Path $log) {
+        Write-Host "--- dashboard.log (tail) ---"
+        Get-Content $log -Tail 60 | ForEach-Object { Write-Host $_ }
+    } else {
+        Write-Host "--- no dashboard.log at $log ---"
+    }
+
+    Write-Host "--- processes under the install dir ---"
+    $prefix = $InstallDir + '\'
+    Get-CimInstance Win32_Process |
+        Where-Object { $_.ExecutablePath -and $_.ExecutablePath.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase) } |
+        Select-Object ProcessId, ParentProcessId, Name, ExecutablePath |
+        Format-Table -AutoSize | Out-String | ForEach-Object { Write-Host $_ }
+
+    Write-Host "--- install dir top level ---"
+    if (Test-Path $InstallDir) {
+        Get-ChildItem $InstallDir | Select-Object Mode, Length, Name |
+            Format-Table -AutoSize | Out-String | ForEach-Object { Write-Host $_ }
+    }
+    Write-Host "::endgroup::"
+}
+
+# --- install the bundle we just built -------------------------------------
+$installer = Get-ChildItem 'src-tauri/target/release/bundle/nsis/*.exe' -ErrorAction SilentlyContinue |
+    Select-Object -First 1
+if (-not $installer) { throw 'no NSIS installer found; did the bundle step run?' }
+Write-Host "Installing $($installer.Name)"
+
+$proc = Start-Process -FilePath $installer.FullName -ArgumentList '/S' -Wait -PassThru
+if ($proc.ExitCode -ne 0) { throw "silent install failed with exit code $($proc.ExitCode)" }
+if (-not (Test-Path $InstallDir)) { throw "installer reported success but $InstallDir does not exist" }
+
+# Discover the main binary rather than assuming the product name: it is derived
+# from tauri.conf.json and would drift silently.
+$exe = Get-ChildItem $InstallDir -Filter *.exe |
+    Where-Object { $_.Name -ine 'uninstall.exe' } | Select-Object -First 1
+if (-not $exe) { throw "no main binary in $InstallDir" }
+Write-Host "Launching $($exe.Name)"
+
+# --- start it and wait for the backend ------------------------------------
+$app = Start-Process -FilePath $exe.FullName -PassThru
+
+# The backend is Python importing ESPHome, which is not fast, and this is a
+# cold first run on a CI runner. Fail with diagnostics rather than hang.
+$deadline = [Diagnostics.Stopwatch]::StartNew()
+$backend = @()
+while ($deadline.Elapsed.TotalSeconds -lt 180) {
+    $backend = Get-BackendProcesses
+    if ($backend.Count -gt 0) { break }
+    if ($app.HasExited) {
+        Show-Diagnostics "the desktop exited on its own (code $($app.ExitCode)) before the backend appeared"
+        throw 'the desktop process exited before starting the backend'
+    }
+    Start-Sleep -Milliseconds 500
+}
+if ($backend.Count -eq 0) {
+    Show-Diagnostics 'the backend never started'
+    throw "no bundled python.exe under $InstallDir after 180s"
+}
+
+$backendPids = @($backend.ProcessId)
+Write-Host "Backend up after $([int]$deadline.Elapsed.TotalSeconds)s: PID(s) $($backendPids -join ', ')"
+
+# Hold handles so the PIDs cannot be recycled while we watch them.
+$handles = @($backendPids | ForEach-Object { Get-Process -Id $_ -ErrorAction SilentlyContinue })
+
+# --- the actual test ------------------------------------------------------
+# Force-kill the desktop with no chance to run any shutdown code. This is the
+# NSIS uninstaller, a crash, and End Task. Nothing but the job object can save
+# the backend from being orphaned here.
+Write-Host "Force-killing the desktop (PID $($app.Id))"
+Stop-Process -Id $app.Id -Force
+$app.WaitForExit(30000) | Out-Null
+
+$gone = $false
+$watch = [Diagnostics.Stopwatch]::StartNew()
+while ($watch.Elapsed.TotalSeconds -lt 30) {
+    if ((Get-BackendProcesses).Count -eq 0) { $gone = $true; break }
+    Start-Sleep -Milliseconds 250
+}
+
+if (-not $gone) {
+    Show-Diagnostics 'the backend outlived the force-killed desktop'
+    # Do not leave it running for the rest of the job.
+    $handles | Where-Object { $_ -and -not $_.HasExited } | ForEach-Object { Stop-Process -Id $_.Id -Force -ErrorAction SilentlyContinue }
+    throw 'the backend survived the desktop being force-killed; the job object did not take it down'
+}
+
+Write-Host "Backend died with the desktop after $([int]$watch.Elapsed.TotalMilliseconds)ms"
+Write-Host 'PASS: the backend cannot outlive the desktop process'

--- a/.github/scripts/e2e_windows_backend_lifetime.ps1
+++ b/.github/scripts/e2e_windows_backend_lifetime.ps1
@@ -78,62 +78,71 @@ if (-not $exe) { throw "no main binary in $InstallDir" }
 Write-Host "Launching $($exe.Name)"
 
 # --- start it and wait for the backend ------------------------------------
+# Everything from the launch onward is wrapped so that every exit — pass, fail,
+# or throw — leaves nothing of ours running. A leaked GUI app still holding the
+# install directory open is the exact failure mode this script exists to detect,
+# so it must not be one this script can cause.
 $app = Start-Process -FilePath $exe.FullName -PassThru
-
-# The backend is Python importing ESPHome, which is not fast, and this is a
-# cold first run on a CI runner. Fail with diagnostics rather than hang.
-$deadline = [Diagnostics.Stopwatch]::StartNew()
-$backend = @()
-while ($deadline.Elapsed.TotalSeconds -lt 180) {
-    $backend = Get-BackendProcesses
-    if ($backend.Count -gt 0) { break }
-    if ($app.HasExited) {
-        Show-Diagnostics "the desktop exited on its own (code $($app.ExitCode)) before the backend appeared"
-        throw 'the desktop process exited before starting the backend'
+try {
+    # The backend is Python importing ESPHome, which is not fast, and this is a
+    # cold first run on a CI runner. Fail with diagnostics rather than hang.
+    $deadline = [Diagnostics.Stopwatch]::StartNew()
+    $backend = @()
+    while ($deadline.Elapsed.TotalSeconds -lt 180) {
+        $backend = Get-BackendProcesses
+        if ($backend.Count -gt 0) { break }
+        if ($app.HasExited) {
+            Show-Diagnostics "the desktop exited on its own (code $($app.ExitCode)) before the backend appeared"
+            throw 'the desktop process exited before starting the backend'
+        }
+        Start-Sleep -Milliseconds 500
     }
-    Start-Sleep -Milliseconds 500
+    if ($backend.Count -eq 0) {
+        Show-Diagnostics 'the backend never started'
+        throw "no bundled python.exe under $InstallDir after 180s"
+    }
+
+    Write-Host "Backend up after $([int]$deadline.Elapsed.TotalSeconds)s: PID(s) $(@($backend.ProcessId) -join ', ')"
+
+    # --- the actual test --------------------------------------------------
+    # Force-kill the desktop with no chance to run any shutdown code. This is
+    # the NSIS uninstaller, a crash, and End Task. Nothing but the job object
+    # can save the backend from being orphaned here.
+    if ($app.HasExited) {
+        # Interesting in its own right: the desktop fell over on its own between
+        # the backend coming up and us killing it, so there is a different bug
+        # to see, and nothing was actually tested.
+        Show-Diagnostics "the desktop exited on its own (code $($app.ExitCode)) before the force-kill"
+        throw 'the desktop process exited before it could be force-killed; nothing was tested'
+    }
+
+    Write-Host "Force-killing the desktop (PID $($app.Id))"
+    # Tolerate a race with the check above rather than throwing past the
+    # diagnostics; the wait and the poll below are what actually decide.
+    Stop-Process -Id $app.Id -Force -ErrorAction SilentlyContinue
+    $app.WaitForExit(30000) | Out-Null
+
+    $gone = $false
+    $watch = [Diagnostics.Stopwatch]::StartNew()
+    while ($watch.Elapsed.TotalSeconds -lt 30) {
+        if ((Get-BackendProcesses).Count -eq 0) { $gone = $true; break }
+        Start-Sleep -Milliseconds 250
+    }
+
+    if (-not $gone) {
+        Show-Diagnostics 'the backend outlived the force-killed desktop'
+        throw 'the backend survived the desktop being force-killed; the job object did not take it down'
+    }
+
+    Write-Host "Backend died with the desktop after $([int]$watch.Elapsed.TotalMilliseconds)ms"
+    Write-Host 'PASS: the backend cannot outlive the desktop process'
 }
-if ($backend.Count -eq 0) {
-    Show-Diagnostics 'the backend never started'
-    throw "no bundled python.exe under $InstallDir after 180s"
+finally {
+    if ($app -and -not $app.HasExited) {
+        Stop-Process -Id $app.Id -Force -ErrorAction SilentlyContinue
+    }
+    # On the failing path the whole point is that these are still alive.
+    foreach ($p in Get-BackendProcesses) {
+        Stop-Process -Id $p.ProcessId -Force -ErrorAction SilentlyContinue
+    }
 }
-
-$backendPids = @($backend.ProcessId)
-Write-Host "Backend up after $([int]$deadline.Elapsed.TotalSeconds)s: PID(s) $($backendPids -join ', ')"
-
-# Hold handles so the PIDs cannot be recycled while we watch them.
-$handles = @($backendPids | ForEach-Object { Get-Process -Id $_ -ErrorAction SilentlyContinue })
-
-# --- the actual test ------------------------------------------------------
-# Force-kill the desktop with no chance to run any shutdown code. This is the
-# NSIS uninstaller, a crash, and End Task. Nothing but the job object can save
-# the backend from being orphaned here.
-if ($app.HasExited) {
-    # Interesting in its own right: the desktop fell over on its own between the
-    # backend coming up and us killing it, so there is a different bug to see.
-    Show-Diagnostics "the desktop exited on its own (code $($app.ExitCode)) before the force-kill"
-    throw 'the desktop process exited before it could be force-killed; nothing was tested'
-}
-
-Write-Host "Force-killing the desktop (PID $($app.Id))"
-# Tolerate a race with the check above rather than throwing past the
-# diagnostics; the WaitForExit below is what actually decides.
-Stop-Process -Id $app.Id -Force -ErrorAction SilentlyContinue
-$app.WaitForExit(30000) | Out-Null
-
-$gone = $false
-$watch = [Diagnostics.Stopwatch]::StartNew()
-while ($watch.Elapsed.TotalSeconds -lt 30) {
-    if ((Get-BackendProcesses).Count -eq 0) { $gone = $true; break }
-    Start-Sleep -Milliseconds 250
-}
-
-if (-not $gone) {
-    Show-Diagnostics 'the backend outlived the force-killed desktop'
-    # Do not leave it running for the rest of the job.
-    $handles | Where-Object { $_ -and -not $_.HasExited } | ForEach-Object { Stop-Process -Id $_.Id -Force -ErrorAction SilentlyContinue }
-    throw 'the backend survived the desktop being force-killed; the job object did not take it down'
-}
-
-Write-Host "Backend died with the desktop after $([int]$watch.Elapsed.TotalMilliseconds)ms"
-Write-Host 'PASS: the backend cannot outlive the desktop process'

--- a/.github/scripts/e2e_windows_backend_lifetime.ps1
+++ b/.github/scripts/e2e_windows_backend_lifetime.ps1
@@ -19,8 +19,15 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-$InstallDir = Join-Path $env:LOCALAPPDATA 'ESPHome Device Builder'
-$AppDataDir = Join-Path $env:APPDATA 'io.esphome.builder'
+# Read the product name rather than duplicating it: the install directory is
+# derived from it, and this script already refuses to assume it for the binary
+# name a few lines down. Hardcoding it here and discovering it there would be
+# the same assumption wearing a disguise.
+$conf = Get-Content 'src-tauri/tauri.conf.json' -Raw | ConvertFrom-Json
+$InstallDir = Join-Path $env:LOCALAPPDATA $conf.productName
+$AppDataDir = Join-Path $env:APPDATA $conf.identifier
+# Trailing separator so `C:\foo` cannot prefix-match `C:\foobar`.
+$Prefix = $InstallDir + '\'
 
 # Callers must wrap this in `@(...)`. The `@()` below does not survive the
 # return: PowerShell unwraps a returned array, so no matches comes back as
@@ -29,12 +36,11 @@ $AppDataDir = Join-Path $env:APPDATA 'io.esphome.builder'
 # broke the first two runs of this script, before it had checked anything.
 function Get-BackendProcesses {
     # Scope by executable path, not image name: the runner has its own Pythons
-    # and this must only ever see the bundled one.
-    $prefix = $InstallDir + '\'
-    @(Get-CimInstance Win32_Process | Where-Object {
+    # and this must only ever see the bundled one. The WQL filter keeps the
+    # marshalling down; the path test is what makes it correct.
+    @(Get-CimInstance Win32_Process -Filter "Name='python.exe'" | Where-Object {
         $_.ExecutablePath -and
-        $_.ExecutablePath.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase) -and
-        $_.Name -ieq 'python.exe'
+        $_.ExecutablePath.StartsWith($Prefix, [System.StringComparison]::OrdinalIgnoreCase)
     })
 }
 
@@ -51,9 +57,10 @@ function Show-Diagnostics {
     }
 
     Write-Host "--- processes under the install dir ---"
-    $prefix = $InstallDir + '\'
+    # Unfiltered on purpose: on failure we want everything still holding the
+    # directory open, not just Python.
     Get-CimInstance Win32_Process |
-        Where-Object { $_.ExecutablePath -and $_.ExecutablePath.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase) } |
+        Where-Object { $_.ExecutablePath -and $_.ExecutablePath.StartsWith($Prefix, [System.StringComparison]::OrdinalIgnoreCase) } |
         Select-Object ProcessId, ParentProcessId, Name, ExecutablePath |
         Format-Table -AutoSize | Out-String | ForEach-Object { Write-Host $_ }
 
@@ -109,6 +116,18 @@ try {
 
     Write-Host "Backend up after $([int]$deadline.Elapsed.TotalSeconds)s: PID(s) $(@($backend.ProcessId) -join ', ')"
 
+    # Take handles *before* killing the desktop, for the same reason the Rust
+    # test does: a held handle pins the PID so it cannot be recycled under us,
+    # and it turns the check below into a wait on the process itself rather
+    # than a poll for its absence, which reports the real latency.
+    $watched = @(@($backend.ProcessId) | ForEach-Object {
+        Get-Process -Id $_ -ErrorAction SilentlyContinue
+    } | Where-Object { $_ })
+    if ($watched.Count -eq 0) {
+        Show-Diagnostics 'the backend vanished between being found and being watched'
+        throw 'could not open a handle to any backend process'
+    }
+
     # --- the actual test --------------------------------------------------
     # Force-kill the desktop with no chance to run any shutdown code. This is
     # the NSIS uninstaller, a crash, and End Task. Nothing but the job object
@@ -127,11 +146,10 @@ try {
     Stop-Process -Id $app.Id -Force -ErrorAction SilentlyContinue
     $app.WaitForExit(30000) | Out-Null
 
-    $gone = $false
     $watch = [Diagnostics.Stopwatch]::StartNew()
-    while ($watch.Elapsed.TotalSeconds -lt 30) {
-        if (@(Get-BackendProcesses).Count -eq 0) { $gone = $true; break }
-        Start-Sleep -Milliseconds 250
+    $gone = $true
+    foreach ($b in $watched) {
+        if (-not $b.WaitForExit(30000)) { $gone = $false }
     }
 
     if (-not $gone) {
@@ -143,7 +161,7 @@ try {
     Write-Host 'PASS: the backend cannot outlive the desktop process'
 }
 finally {
-    if ($app -and -not $app.HasExited) {
+    if (-not $app.HasExited) {
         Stop-Process -Id $app.Id -Force -ErrorAction SilentlyContinue
     }
     # On the failing path the whole point is that these are still alive.

--- a/.github/scripts/e2e_windows_backend_lifetime.ps1
+++ b/.github/scripts/e2e_windows_backend_lifetime.ps1
@@ -203,15 +203,39 @@ try {
     # goes away — that same in-place mode is what made the reverted installer
     # hooks kill themselves, see #328.)
     Start-Process -FilePath $uninstaller -ArgumentList '/S' -Wait
+
+    # Assert on the interpreter, not the whole tree. A locked `python.exe` fails
+    # its `Delete`, keeps `$INSTDIR\python` non-empty and strands the directory
+    # — that is the bug, so its removal is the signal, and it cannot be faked by
+    # anything else.
+    #
+    # The tree itself legitimately survives a healthy uninstall: Tauri `Delete`s
+    # only what its manifest lists and then calls non-recursive `RMDir`, while
+    # `prepare_bundle.sh` strips every `__pycache__` before packaging ("Python
+    # regenerates .pyc files at runtime"), so the app recreates .pyc files that
+    # were never in the manifest and `RMDir` finds the directory non-empty.
+    # Asserting the tree disappears is therefore red on every run, for a reason
+    # that has nothing to do with us.
+    $py = Join-Path $InstallDir 'python\python.exe'
     $unwatch = [Diagnostics.Stopwatch]::StartNew()
-    while ($unwatch.Elapsed.TotalSeconds -lt 90 -and (Test-Path $InstallDir)) {
+    while ($unwatch.Elapsed.TotalSeconds -lt 90 -and (Test-Path $py)) {
         Start-Sleep -Milliseconds 500
     }
-    if (Test-Path $InstallDir) {
-        Show-Diagnostics 'the install tree survived the uninstall'
-        throw "$InstallDir still exists after uninstalling; something is holding it open"
+    if (Test-Path $py) {
+        Show-Diagnostics 'the bundled interpreter survived the uninstall'
+        throw "$py still exists after uninstalling; something is holding it open"
     }
-    Write-Host "PASS: the install directory was removed after $([int]$unwatch.Elapsed.TotalSeconds)s"
+    Write-Host "PASS: the bundled interpreter was removed after $([int]$unwatch.Elapsed.TotalSeconds)s"
+
+    if (Test-Path $InstallDir) {
+        # Reported, not asserted — see above. These are not locks.
+        Write-Host 'NOTE: leftovers under the install dir (regenerated .pyc, not a lock):'
+        Get-ChildItem $InstallDir -Recurse -File -ErrorAction SilentlyContinue |
+            Select-Object -First 20 -ExpandProperty FullName |
+            ForEach-Object { Write-Host "      $_" }
+    } else {
+        Write-Host 'The install directory was removed entirely.'
+    }
 }
 finally {
     if (-not $app.HasExited) {

--- a/.github/scripts/e2e_windows_backend_lifetime.ps1
+++ b/.github/scripts/e2e_windows_backend_lifetime.ps1
@@ -35,12 +35,24 @@ $Prefix = $InstallDir + '\'
 # under `Set-StrictMode -Version Latest`. That is not hypothetical — it is what
 # broke the first two runs of this script, before it had checked anything.
 function Get-BackendProcesses {
-    # Scope by executable path, not image name: the runner has its own Pythons
-    # and this must only ever see the bundled one. The WQL filter keeps the
-    # marshalling down; the path test is what makes it correct.
+    # Three filters, each load-bearing:
+    #
+    #   Name     — cheap, pushed into WQL so we don't marshal every process.
+    #   Path     — the runner has its own Pythons; only the bundled one counts.
+    #   argv     — and only the *backend*. `Settings::load` runs the same
+    #              install-dir interpreter as `-m esphome version` synchronously
+    #              in `setup()`, before the daemon spawns and for several seconds
+    #              on a cold runner. Matching any install-dir python.exe grabs
+    #              that detector instead: the script would report "backend up",
+    #              kill the desktop before the backend existed, watch the
+    #              detector exit on its own, and print PASS — with or without the
+    #              job object. The backend is `-m esphome_device_builder ...`
+    #              (daemon::start_inner); the detector is `-m esphome version`.
     @(Get-CimInstance Win32_Process -Filter "Name='python.exe'" | Where-Object {
         $_.ExecutablePath -and
-        $_.ExecutablePath.StartsWith($Prefix, [System.StringComparison]::OrdinalIgnoreCase)
+        $_.ExecutablePath.StartsWith($Prefix, [System.StringComparison]::OrdinalIgnoreCase) -and
+        $_.CommandLine -and
+        $_.CommandLine -match 'esphome_device_builder'
     })
 }
 
@@ -56,12 +68,14 @@ function Show-Diagnostics {
         Write-Host "--- no dashboard.log at $log ---"
     }
 
-    Write-Host "--- processes under the install dir ---"
+    Write-Host "--- processes under the install dir (CommandLine included: the"
+    Write-Host "    backend is -m esphome_device_builder, the version probe is"
+    Write-Host "    -m esphome version) ---"
     # Unfiltered on purpose: on failure we want everything still holding the
     # directory open, not just Python.
     Get-CimInstance Win32_Process |
         Where-Object { $_.ExecutablePath -and $_.ExecutablePath.StartsWith($Prefix, [System.StringComparison]::OrdinalIgnoreCase) } |
-        Select-Object ProcessId, ParentProcessId, Name, ExecutablePath |
+        Select-Object ProcessId, ParentProcessId, Name, CommandLine |
         Format-Table -AutoSize | Out-String | ForEach-Object { Write-Host $_ }
 
     Write-Host "--- install dir top level ---"

--- a/.github/scripts/e2e_windows_backend_lifetime.ps1
+++ b/.github/scripts/e2e_windows_backend_lifetime.ps1
@@ -22,6 +22,11 @@ $ErrorActionPreference = 'Stop'
 $InstallDir = Join-Path $env:LOCALAPPDATA 'ESPHome Device Builder'
 $AppDataDir = Join-Path $env:APPDATA 'io.esphome.builder'
 
+# Callers must wrap this in `@(...)`. The `@()` below does not survive the
+# return: PowerShell unwraps a returned array, so no matches comes back as
+# `$null` and one match as a bare object, and `.Count` on either is a hard error
+# under `Set-StrictMode -Version Latest`. That is not hypothetical — it is what
+# broke the first two runs of this script, before it had checked anything.
 function Get-BackendProcesses {
     # Scope by executable path, not image name: the runner has its own Pythons
     # and this must only ever see the bundled one.
@@ -89,7 +94,7 @@ try {
     $deadline = [Diagnostics.Stopwatch]::StartNew()
     $backend = @()
     while ($deadline.Elapsed.TotalSeconds -lt 180) {
-        $backend = Get-BackendProcesses
+        $backend = @(Get-BackendProcesses)
         if ($backend.Count -gt 0) { break }
         if ($app.HasExited) {
             Show-Diagnostics "the desktop exited on its own (code $($app.ExitCode)) before the backend appeared"
@@ -125,7 +130,7 @@ try {
     $gone = $false
     $watch = [Diagnostics.Stopwatch]::StartNew()
     while ($watch.Elapsed.TotalSeconds -lt 30) {
-        if ((Get-BackendProcesses).Count -eq 0) { $gone = $true; break }
+        if (@(Get-BackendProcesses).Count -eq 0) { $gone = $true; break }
         Start-Sleep -Milliseconds 250
     }
 
@@ -142,7 +147,7 @@ finally {
         Stop-Process -Id $app.Id -Force -ErrorAction SilentlyContinue
     }
     # On the failing path the whole point is that these are still alive.
-    foreach ($p in Get-BackendProcesses) {
+    foreach ($p in @(Get-BackendProcesses)) {
         Stop-Process -Id $p.ProcessId -Force -ErrorAction SilentlyContinue
     }
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -314,20 +314,6 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
 
-      # The only check that exercises the installed bundle rather than the
-      # crate: it installs what we just built, starts it, and force-kills the
-      # desktop to prove the real `python.exe` cannot outlive it. The unit tests
-      # cover the job object's mechanics; nothing but this covers the actual
-      # app, and nobody can reproduce it without a Windows machine.
-      #
-      # Runs against the CI bundle only. The release build is signed and
-      # `workflow_run`-triggered, and installing it on the release path would
-      # put a GUI app between a tag and its artifacts for no extra signal.
-      - name: E2E — the backend cannot outlive the desktop (Windows)
-        if: matrix.platform == 'windows' && github.event_name != 'workflow_run'
-        shell: pwsh
-        run: ./.github/scripts/e2e_windows_backend_lifetime.ps1
-
       # Build step - macOS CI
       - name: Build (macOS CI)
         if: matrix.platform == 'macos' && github.event_name != 'workflow_run'
@@ -486,6 +472,23 @@ jobs:
         with:
           path: src-tauri/target/release/bundle/nsis/*.exe
           archive: false
+
+      # After the upload on purpose: this is the one failure nobody can
+      # reproduce locally, so the installer that failed has to survive as an
+      # artifact rather than being suppressed by the step that rejected it.
+      #
+      # Exercises the installed bundle rather than the crate — it installs what
+      # we just built, starts it, and force-kills the desktop to prove the real
+      # `python.exe` cannot outlive it. The unit tests cover the job object's
+      # mechanics; only this covers the actual app.
+      #
+      # CI bundle only. The release build is signed and `workflow_run`-triggered,
+      # and installing a GUI app between a tag and its artifacts buys no signal
+      # the CI leg has not already given.
+      - name: E2E backend lifetime (Windows CI)
+        if: matrix.platform == 'windows' && github.event_name != 'workflow_run'
+        shell: pwsh
+        run: ./.github/scripts/e2e_windows_backend_lifetime.ps1
 
       - name: Upload NSIS updater signature
         if: contains(matrix.bundles, 'nsis') && github.event_name == 'workflow_run'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -303,13 +303,18 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
 
       # Build step - Windows CI
+      # `--bundles` so the matrix stays authoritative, as it already is on Linux.
+      # Without it `targets: "all"` in tauri.conf.json decides, which quietly
+      # builds an MSI as well: two bundles, one of which nothing uploads or
+      # installs. The E2E step below reads `bundle/nsis/`, so the guarantee it
+      # depends on should be stated here rather than inherited from a default.
       - name: Build (Windows CI)
         if: matrix.platform == 'windows' && github.event_name != 'workflow_run'
-        run: cargo tauri build
+        run: cargo tauri build --bundles ${{ matrix.bundles }}
 
       - name: Build (Windows Release with signing)
         if: matrix.platform == 'windows' && github.event_name == 'workflow_run'
-        run: cargo tauri build --config src-tauri/tauri.release.conf.json
+        run: cargo tauri build --bundles ${{ matrix.bundles }} --config src-tauri/tauri.release.conf.json
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -314,6 +314,20 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
 
+      # The only check that exercises the installed bundle rather than the
+      # crate: it installs what we just built, starts it, and force-kills the
+      # desktop to prove the real `python.exe` cannot outlive it. The unit tests
+      # cover the job object's mechanics; nothing but this covers the actual
+      # app, and nobody can reproduce it without a Windows machine.
+      #
+      # Runs against the CI bundle only. The release build is signed and
+      # `workflow_run`-triggered, and installing it on the release path would
+      # put a GUI app between a tag and its artifacts for no extra signal.
+      - name: E2E — the backend cannot outlive the desktop (Windows)
+        if: matrix.platform == 'windows' && github.event_name != 'workflow_run'
+        shell: pwsh
+        run: ./.github/scripts/e2e_windows_backend_lifetime.ps1
+
       # Build step - macOS CI
       - name: Build (macOS CI)
         if: matrix.platform == 'macos' && github.event_name != 'workflow_run'

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -70,7 +70,12 @@ cocoa = "0.26"
 tauri = { version = "2.11.2", features = ["image-png"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.62", features = ["Win32_System_Threading", "Win32_Foundation", "Win32_System_Console"] }
+windows = { version = "0.62", features = ["Win32_System_Threading", "Win32_Foundation", "Win32_System_Console", "Win32_System_JobObjects", "Win32_Security"] }
+
+# "Win32_System_Diagnostics_ToolHelp" is only needed to walk to the grandchild in
+# the job object test, so it stays out of the shipping binary's feature set.
+[target.'cfg(target_os = "windows")'.dev-dependencies]
+windows = { version = "0.62", features = ["Win32_System_Diagnostics_ToolHelp"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libloading = "0.9"

--- a/src-tauri/src/daemon/mod.rs
+++ b/src-tauri/src/daemon/mod.rs
@@ -280,11 +280,9 @@ impl DaemonManager {
         // which a grandchild could escape the job. Closing it properly needs
         // CREATE_SUSPENDED plus a manual ResumeThread, which tokio doesn't
         // expose; Python has not spawned anything that early, so accept it.
-        // `raw_handle()` is None only if the child has already been reaped, in
-        // which case there is nothing to assign. Fold that in with assignment
-        // failure: both mean the same thing to a reader of the log, and the
-        // helper has already logged the underlying Win32 error, so this states
-        // the consequence once rather than repeating the cause.
+        // `raw_handle()` is None only if the child was already reaped, which
+        // needs no assignment either — hence `is_some_and`. The helper logs the
+        // Win32 cause; this logs the consequence.
         #[cfg(windows)]
         if !child
             .raw_handle()

--- a/src-tauri/src/daemon/mod.rs
+++ b/src-tauri/src/daemon/mod.rs
@@ -267,6 +267,35 @@ impl DaemonManager {
         cmd.env("PYTHONIOENCODING", "utf-8");
 
         let child = cmd.spawn().context("Failed to spawn ESPHome process")?;
+
+        // Tie the backend's lifetime to ours so it can never be orphaned by an
+        // exit path that doesn't run our code (uninstaller force-kill, crash,
+        // Task Manager). See `platform::assign_to_kill_on_close_job` for why
+        // this is needed on Windows specifically and why the job holds only the
+        // child. Best-effort: if the job is unavailable we still have the
+        // graceful CTRL_BREAK path, so log and carry on rather than failing the
+        // start.
+        //
+        // There is a small window between CreateProcess and the assignment in
+        // which a grandchild could escape the job. Closing it properly needs
+        // CREATE_SUSPENDED plus a manual ResumeThread, which tokio doesn't
+        // expose; Python has not spawned anything that early, so accept it.
+        // `raw_handle()` is None only if the child has already been reaped, in
+        // which case there is nothing to assign. Fold that in with assignment
+        // failure: both mean the same thing to a reader of the log, and the
+        // helper has already logged the underlying Win32 error, so this states
+        // the consequence once rather than repeating the cause.
+        #[cfg(windows)]
+        if !child
+            .raw_handle()
+            .is_some_and(platform::assign_to_kill_on_close_job)
+        {
+            warn!(
+                "{BACKEND_NAME} is not covered by the kill-on-close job; it may outlive \
+                 the desktop if this process is killed without running its shutdown path"
+            );
+        }
+
         if let Some(pid) = child.id() {
             self.dashboard_pid.store(pid as PidInt, Ordering::SeqCst);
         }

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -2423,8 +2423,19 @@ mod tests {
             let mut ok = Process32FirstW(snapshot, &mut entry).is_ok();
             while ok {
                 if entry.th32ParentProcessID == parent {
-                    let name = String::from_utf16_lossy(&entry.szExeFile);
-                    if name.trim_end_matches('\0').eq_ignore_ascii_case(exe_name) {
+                    // Slice at the first NUL rather than converting the whole
+                    // fixed buffer and trimming: `entry` is reused every
+                    // iteration and nothing promises the API zero-fills past
+                    // the terminator, so a short name landing after a longer
+                    // one leaves stale tail bytes ("ping.exe\0er.exe"). Those
+                    // survive a trailing-NUL trim and silently fail the match.
+                    let len = entry
+                        .szExeFile
+                        .iter()
+                        .position(|&c| c == 0)
+                        .unwrap_or(entry.szExeFile.len());
+                    let name = String::from_utf16_lossy(&entry.szExeFile[..len]);
+                    if name.eq_ignore_ascii_case(exe_name) {
                         found = Some(entry.th32ProcessID);
                         break;
                     }

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -2519,13 +2519,14 @@ mod tests {
         }
     }
 
-    /// The kill-on-close semantic itself is the kernel's guarantee, and proving
-    /// it end to end would need a helper binary that outlives the test process.
-    /// What is ours to get wrong is the wiring, so assert that: a real child
-    /// lands in the job, a descendant of it inherits membership, and the job
-    /// actually carries the limit flag that makes membership fatal. Without the
-    /// flag the assignment would still "succeed" and buy us nothing; without
-    /// the inheritance the compile-subtree and `git.exe` story is untrue.
+    /// The wiring half: a real child lands in the job, a descendant of it
+    /// inherits membership, and the job carries the limit flag that makes
+    /// membership fatal. Without the flag the assignment would still "succeed"
+    /// and buy us nothing; without the inheritance the compile-subtree and
+    /// `git.exe` story is untrue.
+    ///
+    /// The other half — that membership actually kills when the owner dies — is
+    /// `job_kills_its_member_when_the_owner_is_force_killed`.
     #[cfg(target_os = "windows")]
     #[test]
     fn daemon_child_lands_in_a_kill_on_close_job() {
@@ -2624,6 +2625,136 @@ mod tests {
         assert!(
             flags.0 & JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE.0 != 0,
             "job must be kill-on-close, otherwise membership does not outlive-protect anything"
+        );
+    }
+
+    /// Set on the re-executed test binary to put it in helper mode.
+    #[cfg(target_os = "windows")]
+    const JOB_HELPER_ENV: &str = "ESPHOME_JOB_KILL_HELPER";
+    /// How the helper hands its member's PID back to the driver.
+    #[cfg(target_os = "windows")]
+    const JOB_HELPER_MARKER: &str = "JOB_MEMBER_PID=";
+    #[cfg(target_os = "windows")]
+    const JOB_HELPER_TEST: &str = "platform::tests::job_kill_helper";
+
+    /// The owner half of `job_kills_its_member_when_the_owner_is_force_killed`.
+    ///
+    /// `#[ignore]` so a normal `cargo test` never runs it: it is only meaningful
+    /// when the driver re-execs this binary with `--ignored --exact` and
+    /// `JOB_HELPER_ENV` set, and it deliberately blocks until killed. The env
+    /// guard means an `--ignored` run by hand exits immediately rather than
+    /// hanging for two minutes.
+    #[cfg(target_os = "windows")]
+    #[test]
+    #[ignore]
+    fn job_kill_helper() {
+        if std::env::var(JOB_HELPER_ENV).is_err() {
+            return;
+        }
+
+        // Spawn the member exactly the way `daemon::start_inner` spawns the
+        // backend — tokio's Command, `configure_daemon_tokio_command`, and the
+        // handle from tokio's `raw_handle()` — so this exercises the real code
+        // path rather than a std::process lookalike that happens to agree.
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("helper: tokio runtime");
+        let child_pid = rt.block_on(async {
+            let mut cmd = tokio::process::Command::new("ping.exe");
+            cmd.args(["-n", "120", "127.0.0.1"]);
+            configure_daemon_tokio_command(&mut cmd);
+            let child = cmd.spawn().expect("helper: failed to spawn member");
+            let handle = child.raw_handle().expect("helper: member has no handle");
+            assert!(
+                assign_to_kill_on_close_job(handle),
+                "helper: could not assign the member to the job"
+            );
+            let pid = child.id().expect("helper: member has no pid");
+            // Leak the Child: dropping it would let tokio reap or kill the
+            // member, and the driver needs it alive until *we* are killed.
+            std::mem::forget(child);
+            pid
+        });
+
+        // Printing the PID is also the driver's signal that assignment is done,
+        // so it can't kill us before the member is actually in the job.
+        println!("{JOB_HELPER_MARKER}{child_pid}");
+        use std::io::Write;
+        let _ = std::io::stdout().flush();
+
+        // Block until the driver force-kills us. Bounded so a driver that dies
+        // early leaves this to time out rather than wedge CI forever.
+        std::thread::sleep(std::time::Duration::from_secs(120));
+    }
+
+    /// The claim the whole change rests on: when the owning process dies without
+    /// running any of its own code, Windows kills the job's members.
+    ///
+    /// Everything else about this feature is verifiable in-process, but not this
+    /// — the owner has to actually die, and it can't be the test process. So the
+    /// test binary re-execs itself as the owner, waits for it to report a member
+    /// it has assigned, then `TerminateProcess`es it. That is precisely the
+    /// shape of the cases this exists for: the NSIS uninstaller force-killing
+    /// us, a crash, End Task. No `Drop`, no exit handler, no cooperation.
+    ///
+    /// A handle to the member is opened *before* the kill, so the PID can't be
+    /// recycled underneath us and the wait is on the member itself rather than a
+    /// poll for its absence.
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn job_kills_its_member_when_the_owner_is_force_killed() {
+        use ::windows::Win32::Foundation::{CloseHandle, WAIT_OBJECT_0};
+        use ::windows::Win32::System::Threading::{
+            OpenProcess, WaitForSingleObject, PROCESS_QUERY_LIMITED_INFORMATION,
+            PROCESS_SYNCHRONIZE,
+        };
+        use std::io::{BufRead, BufReader};
+
+        let exe = std::env::current_exe().expect("current_exe");
+        let mut owner = std::process::Command::new(exe)
+            .args(["--ignored", "--exact", JOB_HELPER_TEST, "--nocapture"])
+            .env(JOB_HELPER_ENV, "1")
+            .stdout(std::process::Stdio::piped())
+            .spawn()
+            .expect("failed to spawn the owner helper");
+
+        let stdout = owner.stdout.take().expect("owner stdout");
+        let member_pid = BufReader::new(stdout)
+            .lines()
+            .map_while(Result::ok)
+            .find_map(|line| {
+                line.strip_prefix(JOB_HELPER_MARKER)
+                    .and_then(|pid| pid.trim().parse::<u32>().ok())
+            });
+        let Some(member_pid) = member_pid else {
+            let _ = owner.kill();
+            panic!("the owner never reported a job member; it likely failed to assign one");
+        };
+
+        // SAFETY: `member_pid` was just reported by a live child; the handle is
+        // closed on every path below.
+        let member = unsafe {
+            OpenProcess(
+                PROCESS_SYNCHRONIZE | PROCESS_QUERY_LIMITED_INFORMATION,
+                false,
+                member_pid,
+            )
+        }
+        .expect("could not open the job member");
+
+        // The point of the whole test: kill the owner outright.
+        owner.kill().expect("failed to kill the owner");
+        let _ = owner.wait();
+
+        // SAFETY: `member` is a live handle we own and close immediately after.
+        let waited = unsafe { WaitForSingleObject(member, 15_000) };
+        let _ = unsafe { CloseHandle(member) };
+
+        assert_eq!(
+            waited, WAIT_OBJECT_0,
+            "the job did not kill its member when the owning process was force-killed; \
+             the backend would survive the desktop and keep holding the install dir open"
         );
     }
 

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -1209,6 +1209,133 @@ pub fn configure_daemon_tokio_command(cmd: &mut tokio::process::Command) {
     }
 }
 
+/// Tie a spawned child's lifetime to ours on Windows via a kill-on-close job
+/// object. Returns `true` if the child was assigned to the job.
+///
+/// Every graceful shutdown path we have — `send_ctrl_break`, then
+/// `TerminateProcess` as the fallback — only runs when the desktop gets to run
+/// code. None of it runs when the NSIS uninstaller force-kills us, when we
+/// crash, or when the user ends the task from Task Manager. `kill_on_drop` is
+/// no help either: the normal quit path calls `std::process::exit()`, which
+/// skips `Drop`. The backend is then orphaned, and because Windows runs the
+/// interpreter straight out of the install directory (`ensure_user_python`
+/// returns early rather than copying it to app data), that orphan keeps
+/// `python.exe` — and every file its compile subtree touches, `git.exe`
+/// included — open. A later uninstall or in-place upgrade cannot replace or
+/// remove them, which strands the install tree and breaks the next launch.
+///
+/// A job object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` closes that gap
+/// without needing any cooperation from the dying process: when the last
+/// handle to the job goes away, Windows terminates everything in it. The
+/// kernel closes our handles however we exit, so this holds for a crash or a
+/// force-kill just as much as for a clean quit. Descendants inherit job
+/// membership, so the backend's compiler and git children are covered too.
+///
+/// The job deliberately holds only the daemon child, never the desktop process
+/// itself. The updater spawns the NSIS installer as our child and then exits;
+/// a job that included us would kill that installer mid-update.
+///
+/// Nested jobs have been supported since Windows 8, so already being inside
+/// someone else's job (a launcher, a test runner) does not defeat this outright
+/// the way it would have before, when a second assignment always failed. That
+/// is not a guarantee of success: assignment can still fail, for instance if
+/// the job hierarchy can't be formed. Hence best-effort, and hence the caller
+/// gets told whether it worked rather than being allowed to assume it.
+///
+/// This is a floor, not a replacement for the graceful path: `stop()` still
+/// sends `CTRL_BREAK_EVENT` first and gives the backend its full shutdown
+/// window. The job only decides what happens to a child that outlives us.
+#[cfg(target_os = "windows")]
+pub fn assign_to_kill_on_close_job(process: std::os::windows::io::RawHandle) -> bool {
+    use ::windows::Win32::Foundation::HANDLE;
+    use ::windows::Win32::System::JobObjects::AssignProcessToJobObject;
+
+    let Some(job) = kill_on_close_job() else {
+        return false;
+    };
+
+    // SAFETY: `job` is a live job handle owned by the process-wide OnceLock
+    // (never closed, see `kill_on_close_job`). `process` is the caller's live
+    // child handle, which tokio's `Child` keeps open for us. Assignment does
+    // not take ownership of either handle.
+    match unsafe { AssignProcessToJobObject(job, HANDLE(process)) } {
+        Ok(()) => true,
+        Err(e) => {
+            tracing::warn!("Failed to assign backend to kill-on-close job object: {e}");
+            false
+        }
+    }
+}
+
+/// Owns the process-wide job handle. `HANDLE` is a raw pointer and so neither
+/// `Send` nor `Sync`; a job handle is just a kernel object reference with no
+/// thread affinity, so sharing it across threads is sound.
+#[cfg(target_os = "windows")]
+struct JobHandle(::windows::Win32::Foundation::HANDLE);
+
+#[cfg(target_os = "windows")]
+unsafe impl Send for JobHandle {}
+#[cfg(target_os = "windows")]
+unsafe impl Sync for JobHandle {}
+
+/// The process-wide kill-on-close job, created on first use.
+///
+/// The handle is intentionally never closed. Its lifetime *is* the mechanism:
+/// the job kills its members when the last handle to it closes, and we want
+/// that to happen exactly when our process dies. Leaking it into a `OnceLock`
+/// leaves the close to the kernel at process teardown, which is the one moment
+/// that fires on every exit path including the ones that never run our code.
+///
+/// `None` if the job could not be set up; the caller then just loses the
+/// backstop and keeps the graceful path. The `JobHandle` newtype exists only to
+/// carry the handle across the `OnceLock`, which requires `Sync`; callers get
+/// the bare `HANDLE`, which is `Copy`.
+#[cfg(target_os = "windows")]
+fn kill_on_close_job() -> Option<::windows::Win32::Foundation::HANDLE> {
+    use ::windows::core::PCWSTR;
+    use ::windows::Win32::Foundation::CloseHandle;
+    use ::windows::Win32::System::JobObjects::{
+        CreateJobObjectW, JobObjectExtendedLimitInformation, SetInformationJobObject,
+        JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+    };
+
+    static JOB: std::sync::OnceLock<Option<JobHandle>> = std::sync::OnceLock::new();
+
+    JOB.get_or_init(|| {
+        // SAFETY: Win32 job-object FFI. The unnamed job is created with default
+        // security and is owned solely by this closure; on the error path we
+        // close it before returning, so no handle leaks and none escapes except
+        // the one we deliberately keep for the process lifetime.
+        unsafe {
+            let job = match CreateJobObjectW(None, PCWSTR::null()) {
+                Ok(job) => job,
+                Err(e) => {
+                    tracing::warn!("Failed to create job object for the backend: {e}");
+                    return None;
+                }
+            };
+
+            let mut info = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+            info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+
+            if let Err(e) = SetInformationJobObject(
+                job,
+                JobObjectExtendedLimitInformation,
+                &info as *const _ as *const std::ffi::c_void,
+                std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+            ) {
+                tracing::warn!("Failed to set kill-on-close limit on the backend job object: {e}");
+                let _ = CloseHandle(job);
+                return None;
+            }
+
+            Some(JobHandle(job))
+        }
+    })
+    .as_ref()
+    .map(|job| job.0)
+}
+
 /// Deliver a graceful `CTRL_BREAK_EVENT` to a child process group on Windows.
 ///
 /// Returns `true` if the event was delivered, `false` if it could not be (the
@@ -2265,6 +2392,239 @@ mod tests {
             );
             assert!(!removed.contains(&var.to_string()));
         }
+    }
+    /// PID of `parent`'s child named `exe_name`, via a process snapshot.
+    /// Used to reach the grandchild the test needs to assert on.
+    ///
+    /// Matching on the image name rather than taking the first child: a console
+    /// is still allocated even under `CREATE_NO_WINDOW`, so `conhost.exe` can
+    /// show up parented alongside the process we actually want.
+    #[cfg(target_os = "windows")]
+    fn child_pid_named(parent: u32, exe_name: &str) -> Option<u32> {
+        use ::windows::Win32::Foundation::CloseHandle;
+        use ::windows::Win32::System::Diagnostics::ToolHelp::{
+            CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W,
+            TH32CS_SNAPPROCESS,
+        };
+
+        let mut found = None;
+
+        // SAFETY: the snapshot handle is closed on every exit path, and
+        // `entry` is initialized with the `dwSize` the API requires before
+        // being handed to Process32FirstW/NextW.
+        unsafe {
+            let Ok(snapshot) = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0) else {
+                return None;
+            };
+            let mut entry = PROCESSENTRY32W {
+                dwSize: std::mem::size_of::<PROCESSENTRY32W>() as u32,
+                ..Default::default()
+            };
+            let mut ok = Process32FirstW(snapshot, &mut entry).is_ok();
+            while ok {
+                if entry.th32ParentProcessID == parent {
+                    let name = String::from_utf16_lossy(&entry.szExeFile);
+                    if name.trim_end_matches('\0').eq_ignore_ascii_case(exe_name) {
+                        found = Some(entry.th32ProcessID);
+                        break;
+                    }
+                }
+                ok = Process32NextW(snapshot, &mut entry).is_ok();
+            }
+            let _ = CloseHandle(snapshot);
+        }
+
+        found
+    }
+
+    /// Resume a process spawned with `CREATE_SUSPENDED` by resuming its threads.
+    ///
+    /// `std::process::Command` hands back only a process handle, so reaching the
+    /// initial thread means going through a thread snapshot.
+    #[cfg(target_os = "windows")]
+    fn resume_process(pid: u32) -> bool {
+        use ::windows::Win32::Foundation::CloseHandle;
+        use ::windows::Win32::System::Diagnostics::ToolHelp::{
+            CreateToolhelp32Snapshot, Thread32First, Thread32Next, TH32CS_SNAPTHREAD, THREADENTRY32,
+        };
+        use ::windows::Win32::System::Threading::{
+            OpenThread, ResumeThread, THREAD_SUSPEND_RESUME,
+        };
+
+        let mut resumed = false;
+
+        // SAFETY: snapshot and thread handles are closed on every exit path;
+        // `entry` carries the `dwSize` the API requires before first use.
+        unsafe {
+            let Ok(snapshot) = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0) else {
+                return false;
+            };
+            let mut entry = THREADENTRY32 {
+                dwSize: std::mem::size_of::<THREADENTRY32>() as u32,
+                ..Default::default()
+            };
+            let mut ok = Thread32First(snapshot, &mut entry).is_ok();
+            while ok {
+                if entry.th32OwnerProcessID == pid {
+                    if let Ok(thread) = OpenThread(THREAD_SUSPEND_RESUME, false, entry.th32ThreadID)
+                    {
+                        // ResumeThread returns the *previous* suspend count, or
+                        // -1 on failure. Only a count of 1 or more is a real
+                        // resume: 0 means the thread was already running, which
+                        // is precisely the state that would make the caller's
+                        // inheritance assertion vacuous rather than wrong, so it
+                        // must not count.
+                        match ResumeThread(thread) {
+                            u32::MAX | 0 => {}
+                            _ => resumed = true,
+                        }
+                        let _ = CloseHandle(thread);
+                    }
+                }
+                ok = Thread32Next(snapshot, &mut entry).is_ok();
+            }
+            let _ = CloseHandle(snapshot);
+        }
+
+        resumed
+    }
+
+    /// Whether `pid` is a member of `job`, and a handle-terminate of it, in one
+    /// pass so the test can both assert on a grandchild and clean it up.
+    #[cfg(target_os = "windows")]
+    fn grandchild_in_job_then_kill(
+        pid: u32,
+        job: ::windows::Win32::Foundation::HANDLE,
+    ) -> Option<bool> {
+        use ::windows::Win32::Foundation::CloseHandle;
+        use ::windows::Win32::System::JobObjects::IsProcessInJob;
+        use ::windows::Win32::System::Threading::{
+            OpenProcess, TerminateProcess, PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_TERMINATE,
+        };
+
+        // SAFETY: the opened handle is closed on every exit path; the BOOL out
+        // param is a live local.
+        unsafe {
+            let handle = OpenProcess(
+                PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_TERMINATE,
+                false,
+                pid,
+            )
+            .ok()?;
+            let mut in_job = ::windows::core::BOOL(0);
+            let queried = IsProcessInJob(handle, Some(job), &mut in_job).is_ok();
+            let _ = TerminateProcess(handle, 1);
+            let _ = CloseHandle(handle);
+            queried.then(|| in_job.as_bool())
+        }
+    }
+
+    /// The kill-on-close semantic itself is the kernel's guarantee, and proving
+    /// it end to end would need a helper binary that outlives the test process.
+    /// What is ours to get wrong is the wiring, so assert that: a real child
+    /// lands in the job, a descendant of it inherits membership, and the job
+    /// actually carries the limit flag that makes membership fatal. Without the
+    /// flag the assignment would still "succeed" and buy us nothing; without
+    /// the inheritance the compile-subtree and `git.exe` story is untrue.
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn daemon_child_lands_in_a_kill_on_close_job() {
+        use ::windows::Win32::System::JobObjects::{
+            IsProcessInJob, JobObjectExtendedLimitInformation, QueryInformationJobObject,
+            JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+        };
+        use ::windows::Win32::System::Threading::{CREATE_NO_WINDOW, CREATE_SUSPENDED};
+        use std::os::windows::io::AsRawHandle;
+        use std::os::windows::process::CommandExt;
+
+        let job = kill_on_close_job().expect("job object should be creatable");
+
+        // `cmd.exe` runs `ping` as a *grandchild*: only cmd is assigned to the
+        // job, so ping is covered purely by the inheritance this asserts on.
+        //
+        // CREATE_SUSPENDED is what makes that assertion deterministic. Job
+        // membership is only inherited by processes created *after* the parent
+        // joins, so if cmd got to run `ping` before the assignment below, ping
+        // would legitimately not be in the job and this would fail as a flake
+        // that reads like a real inheritance bug. Starting cmd suspended means
+        // it cannot spawn anything until we resume it, which is strictly after
+        // the assignment. (The production spawn accepts this same race rather
+        // than paying for it; see the note in `daemon::start_inner`.)
+        //
+        // CREATE_NO_WINDOW is folded in here rather than via
+        // `configure_no_window_command` because `creation_flags` overwrites
+        // rather than accumulates. Without it a local `cargo test` flashes a
+        // console per run.
+        let mut cmd = std::process::Command::new("cmd.exe");
+        cmd.args(["/c", "ping", "-n", "30", "127.0.0.1"]);
+        cmd.creation_flags((CREATE_NO_WINDOW | CREATE_SUSPENDED).0);
+        let mut child = cmd.spawn().expect("failed to spawn test child");
+
+        let assigned = assign_to_kill_on_close_job(child.as_raw_handle());
+        let resumed = resume_process(child.id());
+
+        // Poll rather than sleep a fixed guess, and don't hang the suite if
+        // ping never appears.
+        let mut grandchild = None;
+        for _ in 0..100 {
+            if let Some(pid) = child_pid_named(child.id(), "ping.exe") {
+                grandchild = Some(pid);
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+        // Kills the grandchild as it goes; `child.kill()` below reaps only cmd
+        // itself, which would otherwise leave ping running for its full 30s.
+        let grandchild_in_job = grandchild.and_then(|pid| grandchild_in_job_then_kill(pid, job));
+
+        // SAFETY: both handles are live — `job` is the process-wide job and the
+        // child handle is kept open by `child`, which outlives this call.
+        let in_job = unsafe {
+            let mut in_job = ::windows::core::BOOL(0);
+            IsProcessInJob(
+                ::windows::Win32::Foundation::HANDLE(child.as_raw_handle()),
+                Some(job),
+                &mut in_job,
+            )
+            .expect("IsProcessInJob failed");
+            in_job.as_bool()
+        };
+
+        // SAFETY: `job` is a live job handle; the out buffer and its declared
+        // length match `JobObjectExtendedLimitInformation`.
+        let flags = unsafe {
+            let mut info = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+            QueryInformationJobObject(
+                Some(job),
+                JobObjectExtendedLimitInformation,
+                &mut info as *mut _ as *mut std::ffi::c_void,
+                std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+                None,
+            )
+            .expect("QueryInformationJobObject failed");
+            info.BasicLimitInformation.LimitFlags
+        };
+
+        let _ = child.kill();
+        let _ = child.wait();
+
+        assert!(assigned, "child should have been assigned to the job");
+        assert!(
+            resumed,
+            "suspended child was never resumed; the inheritance assertion below \
+             would be vacuous rather than wrong"
+        );
+        assert!(in_job, "child should be a member of the job");
+        assert_eq!(
+            grandchild_in_job,
+            Some(true),
+            "a descendant of the assigned child must inherit job membership; the backend's \
+             compilers and git children are only covered because of this"
+        );
+        assert!(
+            flags.0 & JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE.0 != 0,
+            "job must be kill-on-close, otherwise membership does not outlive-protect anything"
+        );
     }
 
     #[test]

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -1287,9 +1287,7 @@ unsafe impl Sync for JobHandle {}
 /// that fires on every exit path including the ones that never run our code.
 ///
 /// `None` if the job could not be set up; the caller then just loses the
-/// backstop and keeps the graceful path. The `JobHandle` newtype exists only to
-/// carry the handle across the `OnceLock`, which requires `Sync`; callers get
-/// the bare `HANDLE`, which is `Copy`.
+/// backstop and keeps the graceful path.
 #[cfg(target_os = "windows")]
 fn kill_on_close_job() -> Option<::windows::Win32::Foundation::HANDLE> {
     use ::windows::core::PCWSTR;
@@ -2717,8 +2715,7 @@ mod tests {
     fn job_kills_its_member_when_the_owner_is_force_killed() {
         use ::windows::Win32::Foundation::{CloseHandle, WAIT_OBJECT_0};
         use ::windows::Win32::System::Threading::{
-            OpenProcess, WaitForSingleObject, PROCESS_QUERY_LIMITED_INFORMATION,
-            PROCESS_SYNCHRONIZE,
+            OpenProcess, WaitForSingleObject, PROCESS_SYNCHRONIZE,
         };
         use std::io::{BufRead, BufReader};
 
@@ -2745,14 +2742,8 @@ mod tests {
 
         // SAFETY: `member_pid` was just reported by a live child; the handle is
         // closed on every path below.
-        let member = unsafe {
-            OpenProcess(
-                PROCESS_SYNCHRONIZE | PROCESS_QUERY_LIMITED_INFORMATION,
-                false,
-                member_pid,
-            )
-        }
-        .expect("could not open the job member");
+        let member = unsafe { OpenProcess(PROCESS_SYNCHRONIZE, false, member_pid) }
+            .expect("could not open the job member");
 
         // The point of the whole test: kill the owner outright.
         owner.kill().expect("failed to kill the owner");


### PR DESCRIPTION
# What does this implement/fix?

On Windows the backend could outlive the desktop app; once it did, it held files in the install directory open, so uninstalling left the tree behind and in-place upgrades failed to replace `python.exe` and `git.exe`.

Every shutdown path we had only runs when the desktop gets to run code, and `kill_on_drop` never fires because the quit path calls `std::process::exit()` and skips `Drop`. So an uninstaller force-kill, a crash, or End Task orphaned the backend with nothing tying its lifetime to ours.

This assigns the backend child to a job object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`. The kernel closes our handles however we exit, so Windows terminates the backend and its whole compile subtree even on the paths that never run our code. The graceful `CTRL_BREAK_EVENT` path is unchanged and still runs first; the job is only a floor for a child that outlives us. The job holds only the child, never the desktop process, since the updater spawns the NSIS installer as our child and then exits. Nothing changes on Unix.

The uninstaller side is separate; the shipped 0.15.0 uninstaller has no hook, so it needs its own fix to clear a backend that is already orphaned.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes https://github.com/esphome/esphome-desktop/issues/320

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).

Not checked off deliberately; this is Windows only code and I wrote it on macOS, so I could not exercise the real behaviour. `fmt`, `clippy` and `cargo test` are clean on the host, and I cross checked the Win32 FFI by compiling it for `x86_64-pc-windows-msvc` in isolation, but the CI Windows job and a manual pass are what actually prove it. Manual check worth running: launch the app, confirm `python.exe` is up, `taskkill /F` the desktop binary, confirm `python.exe` goes away, then uninstall and confirm `%LOCALAPPDATA%\ESPHome Device Builder\` is fully removed.
