### PR TITLE
fix: clear a stale Windows backend from the installer hooks

### DIFF
--- a/src-tauri/installer-hooks.nsi
+++ b/src-tauri/installer-hooks.nsi
@@ -12,11 +12,72 @@
 ; The bundle identifier (`io.esphome.builder`) is unchanged, so user data
 ; under `%APPDATA%\io.esphome.builder\` carries over without migration.
 
+; Kill every process running from under `Dir`, then wait for it to actually go.
+;
+; Closing the backend is the app's job, not the installer's, and the app now
+; does it unconditionally: the backend is held in a job object with
+; JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE, so Windows kills it whenever the desktop
+; process dies, however it dies. These hooks are the backstop for the cases that
+; guarantee cannot reach.
+;
+; The one it structurally cannot reach is the upgrade off a version that predates
+; the job object. Such a build can still leave a backend behind, and PREINSTALL
+; runs before the newly installed app has ever launched, so nothing else is going
+; to clear it. That matters because on Windows the backend runs straight out of
+; the install directory (`ensure_user_python` returns early rather than copying
+; the interpreter to app data), so an orphan keeps `python.exe`, `git.exe` and
+; everything else its compile subtree touched open; the install then can't
+; overwrite those files and the uninstall can't remove them, which strands the
+; tree and forces users to kill processes by hand before a reinstall works.
+;
+; Beyond that it is belt and braces: job object setup is best effort in the app
+; and logs a warning if it fails, and this costs one PowerShell invocation.
+;
+; Match on the executable's full path rather than its name: a bare
+; `taskkill /IM python.exe` would take the user's own Python installs with it.
+; The directory is passed through the environment instead of being interpolated
+; into the script text so that a path containing a quote (a username like
+; O'Brien) can't break out of the command.
+;
+; Safe to run from the uninstaller: NSIS uninstallers re-exec from a copy in
+; $TEMP so they can delete their own install dir, so the running uninstaller's
+; path is not under `Dir` and it does not match itself.
+;
+; Best effort throughout. If PowerShell is missing or wedged the timeout gives
+; up and the install continues; the worst case is the leftover files users
+; already get today.
+!macro KillProcessesUnder Dir
+  System::Call 'kernel32::SetEnvironmentVariableW(w "ESPHOME_KILL_ROOT", w "${Dir}")'
+  nsExec::ExecToLog /TIMEOUT=60000 `powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "$$ErrorActionPreference = 'SilentlyContinue'; $$root = [System.IO.Path]::GetFullPath($$env:ESPHOME_KILL_ROOT + '\'); $$procs = @(Get-CimInstance Win32_Process | Where-Object { $$_.ExecutablePath -and $$_.ExecutablePath.StartsWith($$root, [System.StringComparison]::OrdinalIgnoreCase) }); foreach ($$p in $$procs) { Stop-Process -Id $$p.ProcessId -Force }; foreach ($$p in $$procs) { Wait-Process -Id $$p.ProcessId -Timeout 20 }"`
+  Pop $0
+  System::Call 'kernel32::SetEnvironmentVariableW(w "ESPHOME_KILL_ROOT", n)'
+!macroend
+
 !macro NSIS_HOOK_PREINSTALL
+  ; A backend still holding files open here makes the file overwrites below
+  ; fail, which is the "failed to update several files including git.exe"
+  ; upgrade failure. This is the case the app-side job object cannot cover: the
+  ; orphan belongs to the old build being replaced.
+  DetailPrint "Closing any running ESPHome Device Builder processes..."
+  !insertmacro KillProcessesUnder "$INSTDIR"
+
   ${If} ${FileExists} "$LOCALAPPDATA\ESPHome Builder\uninstall.exe"
     DetailPrint "Removing previous ESPHome Builder install..."
+    ; RMDir /r silently skips files that are still open, so the legacy tree
+    ; needs its own sweep before it can actually be removed.
+    !insertmacro KillProcessesUnder "$LOCALAPPDATA\ESPHome Builder"
     RMDir /r "$LOCALAPPDATA\ESPHome Builder"
   ${EndIf}
   Delete "$SMPROGRAMS\ESPHome Builder.lnk"
   Delete "$DESKTOP\ESPHome Builder.lnk"
+!macroend
+
+!macro NSIS_HOOK_PREUNINSTALL
+  ; The job object should already have taken the backend down with the app that
+  ; the uninstaller just closed, so this is normally a no-op. It only earns its
+  ; keep if that guarantee did not hold, in which case the uninstall would
+  ; otherwise leave the tree behind and the user would be back to killing
+  ; processes from Task Manager by hand.
+  DetailPrint "Closing any running ESPHome Device Builder processes..."
+  !insertmacro KillProcessesUnder "$INSTDIR"
 !macroend

--- a/src-tauri/installer-hooks.nsi
+++ b/src-tauri/installer-hooks.nsi
@@ -14,13 +14,15 @@
 
 ; Kill every process running from under `Dir`, then wait for it to actually go.
 ;
-; Closing the backend is the app's job, not the installer's, and the app now
-; does it unconditionally: the backend is held in a job object with
+; Closing the backend is the app's job, not the installer's. PR #321 makes the
+; app do it unconditionally by holding the backend in a job object with
 ; JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE, so Windows kills it whenever the desktop
 ; process dies, however it dies. These hooks are the backstop for the cases that
-; guarantee cannot reach.
+; guarantee cannot reach. If you are reading this and find no job object in
+; src-tauri/src/, that PR has not landed yet and these hooks are currently doing
+; the whole job rather than backstopping it.
 ;
-; The one it structurally cannot reach is the upgrade off a version that predates
+; The case it structurally cannot reach is the upgrade off a version that predates
 ; the job object. Such a build can still leave a backend behind, and PREINSTALL
 ; runs before the newly installed app has ever launched, so nothing else is going
 ; to clear it. That matters because on Windows the backend runs straight out of
@@ -32,6 +34,10 @@
 ;
 ; Beyond that it is belt and braces: job object setup is best effort in the app
 ; and logs a warning if it fails, and this costs one PowerShell invocation.
+;
+; The sweep is bounded twice over: Wait-Process takes every PID at once under a
+; single 20s cap rather than per process, so it cannot creep past the nsExec
+; timeout no matter how many processes are stuck.
 ;
 ; Match on the executable's full path rather than its name: a bare
 ; `taskkill /IM python.exe` would take the user's own Python installs with it.
@@ -46,11 +52,28 @@
 ; Best effort throughout. If PowerShell is missing or wedged the timeout gives
 ; up and the install continues; the worst case is the leftover files users
 ; already get today.
+; An empty `Dir` must never reach the sweep. `[System.IO.Path]::GetFullPath('\')`
+; resolves to `C:\`, every running process then matches the prefix test, and the
+; sweep would `Stop-Process -Force` the user's entire session mid-install. That
+; is a catastrophically worse outcome than the locked files this exists to clear,
+; so it is guarded twice: here, where the value is known, and again inside the
+; script, so neither guard alone is load-bearing. `$INSTDIR` should always be set
+; by the time these hooks run, but the uninstaller populates it from the registry
+; and a corrupt install is exactly when someone reaches for the uninstaller.
 !macro KillProcessesUnder Dir
-  System::Call 'kernel32::SetEnvironmentVariableW(w "ESPHOME_KILL_ROOT", w "${Dir}")'
-  nsExec::ExecToLog /TIMEOUT=60000 `powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "$$ErrorActionPreference = 'SilentlyContinue'; $$root = [System.IO.Path]::GetFullPath($$env:ESPHOME_KILL_ROOT + '\'); $$procs = @(Get-CimInstance Win32_Process | Where-Object { $$_.ExecutablePath -and $$_.ExecutablePath.StartsWith($$root, [System.StringComparison]::OrdinalIgnoreCase) }); foreach ($$p in $$procs) { Stop-Process -Id $$p.ProcessId -Force }; foreach ($$p in $$procs) { Wait-Process -Id $$p.ProcessId -Timeout 20 }"`
-  Pop $0
-  System::Call 'kernel32::SetEnvironmentVariableW(w "ESPHOME_KILL_ROOT", n)'
+  ${If} "${Dir}" == ""
+    DetailPrint "Skipping process sweep: no directory to scope it to."
+  ${Else}
+    ; Save $0 rather than clobbering it; the register is shared with whatever
+    ; Tauri's generated template is using around these hooks.
+    Push $0
+    System::Call 'kernel32::SetEnvironmentVariableW(w "ESPHOME_KILL_ROOT", w "${Dir}")'
+    nsExec::ExecToLog /TIMEOUT=60000 `powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "$$ErrorActionPreference = 'SilentlyContinue'; $$root = $$env:ESPHOME_KILL_ROOT; if (-not $$root) { exit }; $$root = [System.IO.Path]::GetFullPath($$root + '\'); $$procs = @(Get-CimInstance Win32_Process | Where-Object { $$_.ExecutablePath -and $$_.ExecutablePath.StartsWith($$root, [System.StringComparison]::OrdinalIgnoreCase) }); if ($$procs) { foreach ($$p in $$procs) { Stop-Process -Id $$p.ProcessId -Force }; Wait-Process -Id $$procs.ProcessId -Timeout 20 }"`
+    ; Discard nsExec's status, then restore the caller's $0.
+    Pop $0
+    Pop $0
+    System::Call 'kernel32::SetEnvironmentVariableW(w "ESPHOME_KILL_ROOT", n)'
+  ${EndIf}
 !macroend
 
 !macro NSIS_HOOK_PREINSTALL

--- a/src-tauri/installer-hooks.nsi
+++ b/src-tauri/installer-hooks.nsi
@@ -52,14 +52,28 @@
 ; Best effort throughout. If PowerShell is missing or wedged the timeout gives
 ; up and the install continues; the worst case is the leftover files users
 ; already get today.
-; An empty `Dir` must never reach the sweep. `[System.IO.Path]::GetFullPath('\')`
-; resolves to `C:\`, every running process then matches the prefix test, and the
-; sweep would `Stop-Process -Force` the user's entire session mid-install. That
-; is a catastrophically worse outcome than the locked files this exists to clear,
-; so it is guarded twice: here, where the value is known, and again inside the
-; script, so neither guard alone is load-bearing. `$INSTDIR` should always be set
-; by the time these hooks run, but the uninstaller populates it from the registry
-; and a corrupt install is exactly when someone reaches for the uninstaller.
+; The sweep must never be scoped to a filesystem root. Every running process
+; matches a `C:\` prefix test, so the sweep would `Stop-Process -Force` the
+; user's entire session mid-install: catastrophically worse than the locked files
+; this exists to clear. Two ways in, guarded separately because they fail
+; differently:
+;
+;   - An empty `Dir`, where `GetFullPath('\')` resolves to `C:\`. Guarded twice
+;     over, at the NSIS layer where the value is known and again in the script,
+;     so neither guard alone is load-bearing. `$INSTDIR` should always be set by
+;     the time these hooks run, but the uninstaller populates it from the
+;     registry and a corrupt install is exactly when someone reaches for the
+;     uninstaller. Note `SetEnvironmentVariableW` with an empty string deletes
+;     the variable rather than emptying it; both are falsy in PowerShell, so the
+;     script-side guard covers either without having to know which happened.
+;   - A `Dir` that is itself a root, `D:\` or `\\server\share\`, which survives
+;     any amount of trailing-separator normalisation because normalising a root
+;     yields a root. Comparing the normalised path against its own `GetPathRoot`
+;     catches the whole class rather than the two spellings we happened to think
+;     of; a real install directory always has a parent, a root never does.
+;
+; Neither is likely. Both are one clause, and the argument is blast radius rather
+; than probability, which is not a trade worth reasoning your way out of.
 !macro KillProcessesUnder Dir
   ${If} "${Dir}" == ""
     DetailPrint "Skipping process sweep: no directory to scope it to."
@@ -68,7 +82,7 @@
     ; Tauri's generated template is using around these hooks.
     Push $0
     System::Call 'kernel32::SetEnvironmentVariableW(w "ESPHOME_KILL_ROOT", w "${Dir}")'
-    nsExec::ExecToLog /TIMEOUT=60000 `powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "$$ErrorActionPreference = 'SilentlyContinue'; $$root = $$env:ESPHOME_KILL_ROOT; if (-not $$root) { exit }; $$root = [System.IO.Path]::GetFullPath($$root + '\'); $$procs = @(Get-CimInstance Win32_Process | Where-Object { $$_.ExecutablePath -and $$_.ExecutablePath.StartsWith($$root, [System.StringComparison]::OrdinalIgnoreCase) }); if ($$procs) { foreach ($$p in $$procs) { Stop-Process -Id $$p.ProcessId -Force }; Wait-Process -Id $$procs.ProcessId -Timeout 20 }"`
+    nsExec::ExecToLog /TIMEOUT=60000 `powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "$$ErrorActionPreference = 'SilentlyContinue'; $$root = $$env:ESPHOME_KILL_ROOT; if (-not $$root) { exit }; $$root = [System.IO.Path]::GetFullPath($$root + '\'); if ($$root -eq [System.IO.Path]::GetPathRoot($$root)) { exit }; $$procs = @(Get-CimInstance Win32_Process | Where-Object { $$_.ExecutablePath -and $$_.ExecutablePath.StartsWith($$root, [System.StringComparison]::OrdinalIgnoreCase) }); if ($$procs) { foreach ($$p in $$procs) { Stop-Process -Id $$p.ProcessId -Force }; Wait-Process -Id $$procs.ProcessId -Timeout 20 }"`
     ; Discard nsExec's status, then restore the caller's $0.
     Pop $0
     Pop $0

--- a/src-tauri/installer-hooks.nsi
+++ b/src-tauri/installer-hooks.nsi
@@ -42,8 +42,9 @@
 ; Match on the executable's full path rather than its name: a bare
 ; `taskkill /IM python.exe` would take the user's own Python installs with it.
 ; The directory is passed through the environment instead of being interpolated
-; into the script text so that a path containing a quote (a username like
-; O'Brien) can't break out of the command.
+; into the script text, so a path containing an apostrophe (a username like
+; O'Brien) can't terminate the PowerShell string literal and break out of the
+; command.
 ;
 ; Safe to run from the uninstaller: NSIS uninstallers re-exec from a copy in
 ; $TEMP so they can delete their own install dir, so the running uninstaller's
@@ -81,6 +82,13 @@
     ; Save $0 rather than clobbering it; the register is shared with whatever
     ; Tauri's generated template is using around these hooks.
     Push $0
+    ; Clear any inherited value before setting ours. The name is ours, but
+    ; nothing stops it already existing in the environment, and if the set below
+    ; failed the sweep would otherwise run scoped to whatever was already
+    ; there. Clearing first means a failed set leaves it absent, which the
+    ; script's own falsy guard turns into an exit rather than a wrong-directory
+    ; kill.
+    System::Call 'kernel32::SetEnvironmentVariableW(w "ESPHOME_KILL_ROOT", n)'
     System::Call 'kernel32::SetEnvironmentVariableW(w "ESPHOME_KILL_ROOT", w "${Dir}")'
     nsExec::ExecToLog /TIMEOUT=60000 `powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "$$ErrorActionPreference = 'SilentlyContinue'; $$root = $$env:ESPHOME_KILL_ROOT; if (-not $$root) { exit }; $$root = [System.IO.Path]::GetFullPath($$root + '\'); if ($$root -eq [System.IO.Path]::GetPathRoot($$root)) { exit }; $$procs = @(Get-CimInstance Win32_Process | Where-Object { $$_.ExecutablePath -and $$_.ExecutablePath.StartsWith($$root, [System.StringComparison]::OrdinalIgnoreCase) }); if ($$procs) { foreach ($$p in $$procs) { Stop-Process -Id $$p.ProcessId -Force }; Wait-Process -Id $$procs.ProcessId -Timeout 20 }"`
     ; Discard nsExec's status, then restore the caller's $0.

--- a/src-tauri/installer-hooks.nsi
+++ b/src-tauri/installer-hooks.nsi
@@ -35,9 +35,9 @@
 ; Beyond that it is belt and braces: job object setup is best effort in the app
 ; and logs a warning if it fails, and this costs one PowerShell invocation.
 ;
-; The sweep is bounded twice over: Wait-Process takes every PID at once under a
-; single 20s cap rather than per process, so it cannot creep past the nsExec
-; timeout no matter how many processes are stuck.
+; The sweep is bounded: Stop-Process and Wait-Process each take every PID at
+; once, under a single 20s cap rather than one per process, so the wait cannot
+; creep past the nsExec timeout no matter how many processes are stuck.
 ;
 ; Match on the executable's full path rather than its name: a bare
 ; `taskkill /IM python.exe` would take the user's own Python installs with it.
@@ -50,9 +50,25 @@
 ; $TEMP so they can delete their own install dir, so the running uninstaller's
 ; path is not under `Dir` and it does not match itself.
 ;
+; KNOWN INTERACTION, not yet decided: Tauri's template runs these hooks *before*
+; its own `CheckIfAppIsRunning` (installer.nsi:642 then :645; :779 then :782 for
+; uninstall). The main binary lives directly in `$INSTDIR`, so a `$INSTDIR` sweep
+; matches and force-kills it first, and `CheckIfAppIsRunning`'s
+; "app is running, OK to close it?" MessageBox — whose Cancel aborts the install
+; — never fires. So on a manual install over a running app the user silently
+; loses the chance to cancel. (Updater-driven installs set passive mode, which
+; suppresses that prompt anyway, so this only affects hand-run installers.)
+;
+; Excluding the main binary here is not the fix: it would kill the backend first
+; and prompt second, so cancelling would cost the user their compile *and* the
+; install. The real options are to skip the sweep while the app is live and let
+; the template own that case, or to accept the preemption deliberately. Left as
+; the status quo pending that call rather than picked silently here.
+;
 ; Best effort throughout. If PowerShell is missing or wedged the timeout gives
 ; up and the install continues; the worst case is the leftover files users
 ; already get today.
+;
 ; The sweep must never be scoped to a filesystem root. Every running process
 ; matches a `C:\` prefix test, so the sweep would `Stop-Process -Force` the
 ; user's entire session mid-install: catastrophically worse than the locked files
@@ -72,13 +88,14 @@
 ;     yields a root. Comparing the normalised path against its own `GetPathRoot`
 ;     catches the whole class rather than the two spellings we happened to think
 ;     of; a real install directory always has a parent, a root never does.
-;
-; Neither is likely. Both are one clause, and the argument is blast radius rather
-; than probability, which is not a trade worth reasoning your way out of.
 !macro KillProcessesUnder Dir
   ${If} "${Dir}" == ""
     DetailPrint "Skipping process sweep: no directory to scope it to."
   ${Else}
+    ; Worded for the common case, where nothing is running and this finds
+    ; nothing; every call site sweeps the same way, so the message lives here
+    ; rather than being repeated (and drifting) at each one.
+    DetailPrint "Checking for running ESPHome Device Builder processes..."
     ; Save $0 rather than clobbering it; the register is shared with whatever
     ; Tauri's generated template is using around these hooks.
     Push $0
@@ -90,7 +107,7 @@
     ; kill.
     System::Call 'kernel32::SetEnvironmentVariableW(w "ESPHOME_KILL_ROOT", n)'
     System::Call 'kernel32::SetEnvironmentVariableW(w "ESPHOME_KILL_ROOT", w "${Dir}")'
-    nsExec::ExecToLog /TIMEOUT=60000 `powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "$$ErrorActionPreference = 'SilentlyContinue'; $$root = $$env:ESPHOME_KILL_ROOT; if (-not $$root) { exit }; $$root = [System.IO.Path]::GetFullPath($$root + '\'); if ($$root -eq [System.IO.Path]::GetPathRoot($$root)) { exit }; $$procs = @(Get-CimInstance Win32_Process | Where-Object { $$_.ExecutablePath -and $$_.ExecutablePath.StartsWith($$root, [System.StringComparison]::OrdinalIgnoreCase) }); if ($$procs) { foreach ($$p in $$procs) { Stop-Process -Id $$p.ProcessId -Force }; Wait-Process -Id $$procs.ProcessId -Timeout 20 }"`
+    nsExec::ExecToLog /TIMEOUT=60000 `powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "$$ErrorActionPreference = 'SilentlyContinue'; $$root = $$env:ESPHOME_KILL_ROOT; if (-not $$root) { exit }; $$root = [System.IO.Path]::GetFullPath($$root + '\'); if ($$root -eq [System.IO.Path]::GetPathRoot($$root)) { exit }; $$ids = @(Get-CimInstance Win32_Process | Where-Object { $$_.ExecutablePath -and $$_.ExecutablePath.StartsWith($$root, [System.StringComparison]::OrdinalIgnoreCase) }).ProcessId; if ($$ids) { Stop-Process -Id $$ids -Force; Wait-Process -Id $$ids -Timeout 20 }"`
     ; Discard nsExec's status, then restore the caller's $0.
     Pop $0
     Pop $0
@@ -101,9 +118,7 @@
 !macro NSIS_HOOK_PREINSTALL
   ; A backend still holding files open here makes the file overwrites below
   ; fail, which is the "failed to update several files including git.exe"
-  ; upgrade failure. This is the case the app-side job object cannot cover: the
-  ; orphan belongs to the old build being replaced.
-  DetailPrint "Closing any running ESPHome Device Builder processes..."
+  ; upgrade failure.
   !insertmacro KillProcessesUnder "$INSTDIR"
 
   ${If} ${FileExists} "$LOCALAPPDATA\ESPHome Builder\uninstall.exe"
@@ -118,11 +133,11 @@
 !macroend
 
 !macro NSIS_HOOK_PREUNINSTALL
-  ; The job object should already have taken the backend down with the app that
-  ; the uninstaller just closed, so this is normally a no-op. It only earns its
-  ; keep if that guarantee did not hold, in which case the uninstall would
-  ; otherwise leave the tree behind and the user would be back to killing
-  ; processes from Task Manager by hand.
-  DetailPrint "Closing any running ESPHome Device Builder processes..."
+  ; Until #321 lands this is the only thing that closes the backend on uninstall:
+  ; Tauri's template closes the main exe and knows nothing about `python.exe`.
+  ; Once it lands the job object takes the backend down with the app the
+  ; uninstaller just closed, and this becomes a near-no-op that only earns its
+  ; keep if that guarantee did not hold. Either way, without it the uninstall
+  ; leaves the tree behind and the user is back to Task Manager.
   !insertmacro KillProcessesUnder "$INSTDIR"
 !macroend

--- a/src-tauri/installer-hooks.nsi
+++ b/src-tauri/installer-hooks.nsi
@@ -65,6 +65,16 @@
 ; install. See #324 for the options; left as the status quo pending that call
 ; rather than picked silently here.
 ;
+; PowerShell is invoked by absolute path under `$SYSDIR`, never by bare name.
+; CreateProcess searches the launching binary's own directory before System32,
+; and installers are typically run straight out of Downloads — a directory the
+; browser writes to — so a bare `powershell.exe` would hand an attacker who
+; dropped one there arbitrary code execution inside the installer. In a 32-bit
+; installer (makensis' default, and no `Target` is set) WOW64 redirects `$SYSDIR`
+; to SysWOW64 and this resolves to the 32-bit PowerShell, which is equally fine:
+; the point is that both paths are system-owned rather than user-writable, and
+; WMI is out-of-process so a 32-bit host still enumerates 64-bit processes.
+;
 ; Best effort throughout. If PowerShell is missing or wedged the timeout gives
 ; up and the install continues; the worst case is the leftover files users
 ; already get today.
@@ -108,7 +118,7 @@
     ; kill.
     System::Call 'kernel32::SetEnvironmentVariableW(w "ESPHOME_KILL_ROOT", n)'
     System::Call 'kernel32::SetEnvironmentVariableW(w "ESPHOME_KILL_ROOT", w "${Dir}")'
-    nsExec::ExecToLog /TIMEOUT=60000 `powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "$$ErrorActionPreference = 'SilentlyContinue'; $$root = $$env:ESPHOME_KILL_ROOT; if (-not $$root) { exit }; $$root = [System.IO.Path]::GetFullPath($$root + '\'); if ($$root -eq [System.IO.Path]::GetPathRoot($$root)) { exit }; $$ids = @(Get-CimInstance Win32_Process | Where-Object { $$_.ExecutablePath -and $$_.ExecutablePath.StartsWith($$root, [System.StringComparison]::OrdinalIgnoreCase) }).ProcessId; if ($$ids) { Stop-Process -Id $$ids -Force; Wait-Process -Id $$ids -Timeout 20 }"`
+    nsExec::ExecToLog /TIMEOUT=60000 `"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "$$ErrorActionPreference = 'SilentlyContinue'; $$root = $$env:ESPHOME_KILL_ROOT; if (-not $$root) { exit }; $$root = [System.IO.Path]::GetFullPath($$root + '\'); if ($$root -eq [System.IO.Path]::GetPathRoot($$root)) { exit }; $$ids = @(Get-CimInstance Win32_Process | Where-Object { $$_.ExecutablePath -and $$_.ExecutablePath.StartsWith($$root, [System.StringComparison]::OrdinalIgnoreCase) }).ProcessId; if ($$ids) { Stop-Process -Id $$ids -Force; Wait-Process -Id $$ids -Timeout 20 }"`
     ; Discard nsExec's status, then restore the caller's $0.
     Pop $0
     Pop $0

--- a/src-tauri/installer-hooks.nsi
+++ b/src-tauri/installer-hooks.nsi
@@ -50,20 +50,20 @@
 ; $TEMP so they can delete their own install dir, so the running uninstaller's
 ; path is not under `Dir` and it does not match itself.
 ;
-; KNOWN INTERACTION, not yet decided: Tauri's template runs these hooks *before*
-; its own `CheckIfAppIsRunning` (installer.nsi:642 then :645; :779 then :782 for
-; uninstall). The main binary lives directly in `$INSTDIR`, so a `$INSTDIR` sweep
-; matches and force-kills it first, and `CheckIfAppIsRunning`'s
-; "app is running, OK to close it?" MessageBox — whose Cancel aborts the install
-; — never fires. So on a manual install over a running app the user silently
-; loses the chance to cancel. (Updater-driven installs set passive mode, which
-; suppresses that prompt anyway, so this only affects hand-run installers.)
+; KNOWN INTERACTION, tracked in #324: Tauri's template runs these hooks *before*
+; its own `CheckIfAppIsRunning` (true as of the v2.11.4 template; both the
+; install and uninstall sections have that order). The main binary lives directly
+; in `$INSTDIR`, so a `$INSTDIR` sweep matches and force-kills it first, and
+; `CheckIfAppIsRunning`'s "app is running, OK to close it?" MessageBox — whose
+; Cancel aborts the install — never fires. So on a manual install over a running
+; app the user silently loses the chance to cancel. (Updater-driven installs set
+; passive mode, which suppresses that prompt anyway, so this only affects
+; hand-run installers.)
 ;
 ; Excluding the main binary here is not the fix: it would kill the backend first
 ; and prompt second, so cancelling would cost the user their compile *and* the
-; install. The real options are to skip the sweep while the app is live and let
-; the template own that case, or to accept the preemption deliberately. Left as
-; the status quo pending that call rather than picked silently here.
+; install. See #324 for the options; left as the status quo pending that call
+; rather than picked silently here.
 ;
 ; Best effort throughout. If PowerShell is missing or wedged the timeout gives
 ; up and the install continues; the worst case is the leftover files users
@@ -92,10 +92,11 @@
   ${If} "${Dir}" == ""
     DetailPrint "Skipping process sweep: no directory to scope it to."
   ${Else}
+    ; Names the directory rather than a product: one call site sweeps the legacy
+    ; "ESPHome Builder" tree, so a fixed product name would be wrong there.
     ; Worded for the common case, where nothing is running and this finds
-    ; nothing; every call site sweeps the same way, so the message lives here
-    ; rather than being repeated (and drifting) at each one.
-    DetailPrint "Checking for running ESPHome Device Builder processes..."
+    ; nothing. Lives here rather than being repeated (and drifting) per site.
+    DetailPrint "Checking for running processes under ${Dir}..."
     ; Save $0 rather than clobbering it; the register is shared with whatever
     ; Tauri's generated template is using around these hooks.
     Push $0


### PR DESCRIPTION
# What does this implement/fix?

A backend still running from the install directory holds files open, so the installer can't overwrite them and the uninstaller can't remove them; that's the "failed to update several files including git.exe" upgrade failure and the uninstall that leaves `%LOCALAPPDATA%\ESPHome Device Builder\` behind.

Closing the backend is the app's job and #321 makes it automatic, so these hooks are the backstop for what that cannot reach. The structural gap is upgrading off a build that predates the job object: those builds can still orphan a backend, and `NSIS_HOOK_PREINSTALL` runs before the newly installed app has ever launched, so nothing on the app side is in a position to clear it. Everyone on 0.15.0 today is in that state. The `NSIS_HOOK_PREUNINSTALL` side should be a no-op once #321 ships and is here as belt and braces, since job object setup is best effort in the app.

Killing is scoped by executable path rather than image name; a bare `taskkill /IM python.exe` would take the user's own Python installs with it. The directory goes through the environment rather than being interpolated into the script text, so a path containing a quote (a username like O'Brien) can't break out of the command. Safe to run from the uninstaller because NSIS uninstallers re-exec from a copy in `$TEMP`, so they don't match themselves.

The legacy `ESPHome Builder` cleanup gets the same sweep; `RMDir /r` silently skips open files, so that tree could be left behind for the same reason.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes https://github.com/esphome/esphome-desktop/issues/322

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).

Not checked off deliberately; I wrote this on macOS and can't run a Windows installer. What I did verify: the hooks compile under `makensis` in a harness that inserts them the way Tauri does, and I decoded the built installer to confirm the `$$` escaping emits the intended PowerShell command line rather than NSIS eating the variables. The real proof is a manual pass: install 0.15.0, leave it running, install a build with this over it, confirm no locked file errors, then uninstall and confirm the tree is gone. Worth a check that a user's own `python.exe` outside the install dir survives both.
