### PR TITLE
fix: make clippy actually run on Windows again, and fail when it doesn't

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -81,16 +81,21 @@ jobs:
   # Win32 console/process-group code, the macOS app-cleanup and CLT git probe,
   # the platform-specific Python paths, …) is invisible to the required gate.
   # `cargo fmt` is the exception — it formats stripped-out branches regardless
-  # of target — so formatting is checked here just like on Linux (advisory on
-  # this job).
+  # of target — so formatting is checked here just like on Linux.
   #
-  # Every step here is ADVISORY: these checks run for the first time on these
-  # platforms and have no established green baseline, so a real lint, a Windows
-  # newline quirk, or a path-separator assumption in a test would otherwise
-  # block unrelated PRs. A failure surfaces as a `::warning::` annotation
-  # instead of a red check. This mirrors exactly how the Linux clippy/fmt gates
-  # were introduced (advisory first, promoted once green). To promote: drop the
-  # `|| echo "::warning::…"` tails and add these checks to branch protection.
+  # These steps were ADVISORY while they had no established green baseline, on
+  # the reasoning that a Windows newline quirk or a path-separator assumption
+  # shouldn't block unrelated PRs. That baseline now exists, and the advisory
+  # tails cost more than they saved: clippy failed on windows-latest from the
+  # day this job landed and the job reported success the whole time, so the
+  # Windows-only code — which is exactly what this job exists to cover, and
+  # which the required Linux gate can never see — was never linted at all. A
+  # check that is green whether or not it passes is worse than no check, because
+  # it reads as coverage. See #325.
+  #
+  # So they now fail the job. Note that a red check only *blocks a merge* if it
+  # is also a required check in branch protection; that is a repo setting, not
+  # something this file can do.
   lint-test-cross:
     name: Rust lint & test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -104,10 +109,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      # Same pinned toolchain as the Linux job so the advisory clippy/fmt lints
-      # match what a maintainer would promote later. No webkit/appindicator
-      # deps are needed: Tauri uses the system WebView2 (Windows) / WKWebView
-      # (macOS), not the GTK/webkit stack.
+      # Same pinned toolchain as the Linux job, so a lint is a lint regardless
+      # of which job caught it. No webkit/appindicator deps are needed: Tauri
+      # uses the system WebView2 (Windows) / WKWebView (macOS), not the
+      # GTK/webkit stack.
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
         with:
@@ -121,19 +126,25 @@ jobs:
       - name: Stub bundle resource dirs
         uses: ./.github/actions/stub-bundle-dirs
 
-      # fmt is cfg-agnostic and already green on Linux; advisory here only to
-      # guard against a Windows newline quirk on this first run.
-      - name: Formatting (advisory)
+      # fmt is cfg-agnostic and already green on Linux, so this is belt and
+      # braces against a platform newline quirk rather than a real second check.
+      - name: Formatting
         working-directory: src-tauri
         shell: bash
-        run: cargo fmt --all --check || echo "::warning::cargo fmt --check failed on ${{ matrix.os }} (advisory — not blocking)"
+        run: cargo fmt --all --check
 
-      - name: Clippy (advisory)
+      # The whole point of this job: the required Linux gate only ever
+      # evaluates the host cfg, so this is the only thing that lints the
+      # `#[cfg(target_os = "windows")]` / `#[cfg(target_os = "macos")]` code.
+      - name: Clippy
         working-directory: src-tauri
         shell: bash
-        run: cargo clippy --all-targets --all-features -- -D warnings || echo "::warning::clippy found issues on ${{ matrix.os }} (advisory — not blocking)"
+        run: cargo clippy --all-targets --all-features -- -D warnings
 
-      - name: Tests (advisory)
+      # Same reasoning as clippy: the platform-gated tests (e.g. the Windows
+      # job-object test) only ever run here, so an advisory tail would mean a
+      # green check proving nothing about the code it is meant to cover.
+      - name: Tests
         working-directory: src-tauri
         shell: bash
-        run: cargo test --all-features --verbose || echo "::warning::cargo test failed on ${{ matrix.os }} (advisory — not blocking)"
+        run: cargo test --all-features --verbose

--- a/src-tauri/src/control/client.rs
+++ b/src-tauri/src/control/client.rs
@@ -95,6 +95,12 @@ enum ConnectError {
     /// The socket path itself is unusable (e.g. too long for `sun_path`).
     /// "Not running" would mislead here — the app may well be running with
     /// its own server disabled for the same reason.
+    ///
+    /// Unix only: `sun_path` is a Unix domain socket limit, and the Windows
+    /// client opens a fixed-name pipe that has no equivalent failure. Gated
+    /// rather than left dead so the Windows build doesn't carry a variant it
+    /// can never construct.
+    #[cfg(unix)]
     BadPath(String),
     /// Connecting failed — the usual "app is not running" case.
     NotRunning,
@@ -111,6 +117,7 @@ fn simple(request: Request, timeout: Duration) -> ExitCode {
 
 fn connect_failed(error: ConnectError) -> ExitCode {
     match error {
+        #[cfg(unix)]
         ConnectError::BadPath(message) => fail(message),
         ConnectError::NotRunning => not_running(),
     }
@@ -619,6 +626,7 @@ fn api_stream(request: &Request, timeout: Duration) -> u8 {
         Err(ConnectError::NotRunning) => {
             return api_err_line("not_running", "the app is not running", EXIT_NOT_RUNNING)
         }
+        #[cfg(unix)]
         Err(ConnectError::BadPath(message)) => {
             return api_err_line("bad_path", &message, EXIT_FAILED)
         }

--- a/src-tauri/src/control/client.rs
+++ b/src-tauri/src/control/client.rs
@@ -96,11 +96,15 @@ enum ConnectError {
     /// "Not running" would mislead here — the app may well be running with
     /// its own server disabled for the same reason.
     ///
-    /// Unix only: `sun_path` is a Unix domain socket limit, and the Windows
-    /// client opens a fixed-name pipe that has no equivalent failure. Gated
-    /// rather than left dead so the Windows build doesn't carry a variant it
-    /// can never construct.
-    #[cfg(unix)]
+    /// Only ever constructed on Unix: `sun_path` is a Unix domain socket
+    /// limit, and the Windows `connect()` opens a fixed-name pipe that can
+    /// only fail as `NotRunning`. Kept on both platforms and allowed to be
+    /// dead on Windows rather than `#[cfg(unix)]`-gated, because gating it
+    /// leaves `ConnectError` single-variant there, which makes every
+    /// `Err(ConnectError::NotRunning) => …` arm exhaustive and every catch-all
+    /// `Err(e) => …` after it an unreachable-pattern error. A uniform enum
+    /// shape keeps the matches identical on both platforms.
+    #[cfg_attr(windows, allow(dead_code))]
     BadPath(String),
     /// Connecting failed — the usual "app is not running" case.
     NotRunning,
@@ -117,7 +121,6 @@ fn simple(request: Request, timeout: Duration) -> ExitCode {
 
 fn connect_failed(error: ConnectError) -> ExitCode {
     match error {
-        #[cfg(unix)]
         ConnectError::BadPath(message) => fail(message),
         ConnectError::NotRunning => not_running(),
     }
@@ -626,7 +629,6 @@ fn api_stream(request: &Request, timeout: Duration) -> u8 {
         Err(ConnectError::NotRunning) => {
             return api_err_line("not_running", "the app is not running", EXIT_NOT_RUNNING)
         }
-        #[cfg(unix)]
         Err(ConnectError::BadPath(message)) => {
             return api_err_line("bad_path", &message, EXIT_FAILED)
         }

--- a/src-tauri/src/control/client.rs
+++ b/src-tauri/src/control/client.rs
@@ -99,11 +99,15 @@ enum ConnectError {
     /// Only ever constructed on Unix: `sun_path` is a Unix domain socket
     /// limit, and the Windows `connect()` opens a fixed-name pipe that can
     /// only fail as `NotRunning`. Kept on both platforms and allowed to be
-    /// dead on Windows rather than `#[cfg(unix)]`-gated, because gating it
-    /// leaves `ConnectError` single-variant there, which makes every
-    /// `Err(ConnectError::NotRunning) => …` arm exhaustive and every catch-all
-    /// `Err(e) => …` after it an unreachable-pattern error. A uniform enum
-    /// shape keeps the matches identical on both platforms.
+    /// dead on Windows rather than `#[cfg(unix)]`-gated.
+    ///
+    /// Gating was tried and does not work: it leaves `ConnectError`
+    /// single-valued on Windows, so the `Err(ConnectError::NotRunning)` arms in
+    /// `open_cmd` and `status_cmd` become exhaustive and the catch-all
+    /// `Err(e) => connect_failed(e)` after each one is an unreachable-pattern
+    /// error. Those two arms never name `BadPath`, so they don't turn up when
+    /// you grep for it. A uniform enum shape keeps every match identical on
+    /// both platforms and doesn't leave the same trap for the next catch-all.
     #[cfg_attr(windows, allow(dead_code))]
     BadPath(String),
     /// Connecting failed — the usual "app is not running" case.

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -487,7 +487,7 @@ pub fn ensure_user_python(app_handle: &AppHandle, force_device_builder: bool) ->
             anyhow::bail!("Bundled Python not found at {:?}", bundled_python);
         }
 
-        return Ok(());
+        Ok(())
     }
 
     #[cfg(not(target_os = "windows"))]


### PR DESCRIPTION
# What does this implement/fix?

The `Rust lint & test (windows-latest)` job reports success while clippy inside it fails. Every step there ends in `|| echo "::warning::..."`, so the failure surfaces as a green check with an annotation. Clippy aborts at lib compile on two errors and never lints anything:

```
error: variant `BadPath` is never constructed          --> src\control\client.rs:98:5
error: unneeded `return` statement                     --> src\platform\mod.rs:490:9
error: could not compile `esphome-desktop` (lib) due to 2 previous errors
```

Both are Windows only, which is why the required Linux gate stays green; clippy only ever evaluates the host cfg. That means none of the Windows only code is linted, and that is a growing share of the crate: the console and `CTRL_BREAK_EVENT` machinery, the named pipe control channel, and the job object in #321. A Win32 mistake there currently shows up as a green check.

`BadPath` is only ever constructed by the `#[cfg(unix)]` `connect()`, and describes `sun_path` being too long; the Windows client opens a fixed name pipe and can only ever return `NotRunning`. It stays on both platforms and is allowed to be dead on Windows, rather than gated to unix.

I tried gating it first and it was wrong. Removing the variant leaves `ConnectError` single valued on Windows, so `Err(ConnectError::NotRunning)` becomes exhaustive and the catch all `Err(e) => connect_failed(e)` arms in `open_cmd` and the status command turn into unreachable pattern errors. Neither of those arms names `BadPath`, so grepping for the variant does not find them; the now blocking job did. Keeping the enum shape identical on both platforms keeps every match identical too, and does not leave the same trap for the next catch all someone adds.

The `return Ok(())` sits in `ensure_user_python`'s `#[cfg(target_os = "windows")]` block, where the block is already the tail expression once the other branch is stripped.

It also makes that job fail on failure. Every step ended in `|| echo "::warning::..."`, and the advisory tails were justified by not having an established green baseline yet. That baseline exists now: macos-15 is clean on all three steps, and windows-latest is clean on fmt and tests, with clippy the only red one and fixed above.

fmt, clippy and tests are promoted together rather than clippy alone. An advisory `cargo test` has the same defect for the same reason: the platform gated tests only ever run on this job, so the Windows job object test in #321 would be reporting green whether or not it passed. A check that is green regardless is worse than no check, because it reads as coverage.

Note this only makes the check red. For it to block a merge it also has to be a required check in branch protection, which is a repo setting and not something the workflow file can do; that part is yours.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes https://github.com/esphome/esphome-desktop/issues/325

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).

Not checked off: this is Windows only and I am on macOS. `fmt`, `clippy` and `cargo test` are clean on the host (186 pass), and I verified the `cfg`'d tail block shape compiles and lints clean for `x86_64-pc-windows-msvc` in isolation, since `ring` blocks cross compiling the real crate. The proof is the Windows CI job on this PR, and I will read its log rather than the check colour, since the colour is the thing being fixed here.

Worth flagging: clippy aborted at these two errors, so it never linted the rest. There may be further Windows only findings behind them that only appear once it gets past compile — and now that the job is blocking, they show up as a red check on this PR rather than a warning nobody reads. If any appear I will fix them here.
