### PR TITLE
Add an 800 line file size cap, enforced in CI

### DIFF
--- a/.github/scripts/check_file_size.py
+++ b/.github/scripts/check_file_size.py
@@ -147,18 +147,29 @@ def tracked_rust_files(root: Path) -> list[str]:
     Python tree carries 20k-line vendored sources and a working tree may hold
     an untracked nested checkout of this repo. Neither is ours to measure and
     neither is tracked.
+
+    One pathspec, not two: in a default pathspec git's `*` matches across `/`,
+    so this already covers nested files. (It is `:(glob)` magic that sets
+    FNM_PATHNAME and stops that; `src-tauri/src/**/*.rs` would match only the
+    14 nested files and miss lib.rs, main.rs and dialog.rs.)
     """
-    # One pathspec, not two: git's fnmatch lets `*` cross `/`, so this already
-    # matches nested files. (`src-tauri/src/**/*.rs` would match only the 14
-    # nested ones, missing lib.rs, main.rs and dialog.rs.)
-    out = subprocess.run(
-        ["git", "ls-files", "-z", "src-tauri/src/*.rs"],
-        cwd=root,
-        check=True,
-        capture_output=True,
-        text=True,
-    ).stdout
-    return sorted(entry for entry in out.split("\0") if entry)
+    try:
+        completed = subprocess.run(
+            ["git", "ls-files", "-z", "src-tauri/src/*.rs"],
+            cwd=root,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as error:
+        # capture_output hides git's stderr, and CalledProcessError does not
+        # include it in its message, so without this a failure here (not a
+        # repo, no git on PATH, bad pathspec) reaches the log as a bare
+        # traceback saying only that the exit status was non-zero.
+        raise RuntimeError(
+            f"git ls-files failed ({error.returncode}): {error.stderr.strip()}"
+        ) from error
+    return sorted(entry for entry in completed.stdout.split("\0") if entry)
 
 
 def check(root: Path, files: Iterable[str], exempt: Iterable[str]) -> list[str]:

--- a/.github/scripts/check_file_size.py
+++ b/.github/scripts/check_file_size.py
@@ -70,6 +70,11 @@ def code_line_count(source: str) -> int:
         a 5000-line file scores 1 and passes. That is not hypothetical
         gaming — grouping a test module beside the code it covers, rather than
         at the bottom, is a normal thing to do.
+      * A declaration line can close its own block. rustfmt collapses an empty
+        body onto it, so `mod tests {}` is the only spelling `cargo fmt` will
+        emit (compare `control/server.rs`, which has `pub fn cleanup() {}` at
+        column 0). Scanning below it for a `}` finds the *next* item's brace,
+        or none, and swallows the file: it scores 0.
 
     Finding the end of a block by the next column-0 `}` leans on rustfmt
     putting the closing brace of a top-level item at column 0, which holds
@@ -77,10 +82,14 @@ def code_line_count(source: str) -> int:
     is a line-based heuristic, not a Rust parser, which is proportionate for a
     navigability guardrail.
 
-    Nested (indented) test modules are not matched and so count as code, which
-    overcounts platform/mod.rs by the ~560 lines of its two inner test
-    modules. That is the safe direction: it can only ever report a file as
-    larger than it is, never smaller.
+    Where the heuristic cannot be sure, it counts lines as code, so a
+    surprising input reports a file as too big rather than waving it through.
+    A nested (indented) test module counts as code, which overcounts
+    platform/mod.rs by the ~560 lines of its two inner test modules; so does a
+    block whose closing brace never arrives. There is no general "never
+    undercounts" guarantee to lean on here, and an earlier version of this
+    docstring claimed one: it was written from the nested case, and both the
+    mid-file and `{}` shapes above broke it. Add a test before adding a claim.
     """
     lines = source.splitlines()
     total = 0
@@ -92,15 +101,20 @@ def code_line_count(source: str) -> int:
             while declaration < len(lines) and not lines[declaration].strip():
                 declaration += 1
             if declaration < len(lines) and lines[declaration].startswith("mod "):
-                if lines[declaration].rstrip().endswith(";"):
-                    # `#[cfg(test)] mod tests;` — the body is another file.
+                # `mod tests;` (body in another file) or `mod tests {}` (empty,
+                # the form rustfmt emits): self-contained, no body to skip.
+                if lines[declaration].rstrip().endswith((";", "}")):
                     index = declaration + 1
                     continue
                 end = declaration + 1
                 while end < len(lines) and lines[end].rstrip() != "}":
                     end += 1
-                index = end + 1
-                continue
+                if end < len(lines):
+                    index = end + 1
+                    continue
+                # Ran off the end without finding the brace. Count the rest as
+                # code rather than silently swallowing it; an over-cap file
+                # must not pass because its formatting confused the scanner.
         total += 1
         index += 1
     return total
@@ -114,8 +128,11 @@ def tracked_rust_files(root: Path) -> list[str]:
     an untracked nested checkout of this repo. Neither is ours to measure and
     neither is tracked.
     """
+    # One pathspec, not two: git's fnmatch lets `*` cross `/`, so this already
+    # matches nested files. (`src-tauri/src/**/*.rs` would match only the 14
+    # nested ones, missing lib.rs, main.rs and dialog.rs.)
     out = subprocess.run(
-        ["git", "ls-files", "-z", "src-tauri/src/*.rs", "src-tauri/src/**/*.rs"],
+        ["git", "ls-files", "-z", "src-tauri/src/*.rs"],
         cwd=root,
         check=True,
         capture_output=True,

--- a/.github/scripts/check_file_size.py
+++ b/.github/scripts/check_file_size.py
@@ -3,7 +3,11 @@
 
 Run from the repo root, with no arguments:
 
-    python3 .github/scripts/check_file_size.py
+    python3 .github/scripts/check_file_size.py   # `python` on Windows
+
+(A python.org install on Windows puts `python.exe` on PATH but no
+`python3.exe`; the pre-commit hook sidesteps this by having pre-commit
+provision the interpreter.)
 
 Wired into the `lint-test` job (.github/workflows/lint-test.yml) and mirrored
 by a pre-commit hook. Exits non-zero, with a message naming each offending
@@ -243,7 +247,13 @@ def check(root: Path, files: Iterable[str], exempt: Iterable[str]) -> list[str]:
 
 def main() -> int:
     root = Path(__file__).resolve().parents[2]
-    failures = check(root, tracked_rust_files(root), EXEMPT)
+    try:
+        failures = check(root, tracked_rust_files(root), EXEMPT)
+    except RuntimeError as error:
+        # Those raises exist to replace a traceback with a sentence; letting
+        # one escape here would deliver the sentence wrapped in the traceback.
+        print(f"error: {error}", file=sys.stderr)
+        return 1
     for failure in failures:
         print(f"error: {failure}", file=sys.stderr)
     return 1 if failures else 0

--- a/.github/scripts/check_file_size.py
+++ b/.github/scripts/check_file_size.py
@@ -49,6 +49,22 @@ EXEMPT: frozenset[str] = frozenset(
 )
 
 
+def _code_before_comment(line: str) -> str:
+    """`line` with any trailing comment and whitespace removed.
+
+    Only ever applied to the three line shapes this scanner matches on (the
+    attribute, a `mod` declaration, a closing brace), none of which carry a
+    string literal that could contain a `//`. `} // end tests` is valid Rust
+    that rustfmt preserves, so matching the bare shapes alone misses it.
+    """
+    cut = len(line)
+    for marker in ("//", "/*"):
+        found = line.find(marker)
+        if found != -1:
+            cut = min(cut, found)
+    return line[:cut].rstrip()
+
+
 def code_line_count(source: str) -> int:
     """Count the lines of `source` that are not inside a test module.
 
@@ -75,6 +91,9 @@ def code_line_count(source: str) -> int:
         emit (compare `control/server.rs`, which has `pub fn cleanup() {}` at
         column 0). Scanning below it for a `}` finds the *next* item's brace,
         or none, and swallows the file: it scores 0.
+      * A matched line can carry a trailing comment. `} // end tests` is valid
+        Rust and rustfmt keeps it, so an exact `}` match walks past the real
+        terminator to the next one and swallows everything between: another 0.
 
     Finding the end of a block by the next column-0 `}` leans on rustfmt
     putting the closing brace of a top-level item at column 0, which holds
@@ -95,19 +114,20 @@ def code_line_count(source: str) -> int:
     total = 0
     index = 0
     while index < len(lines):
-        # rstrip only, so a leading space disqualifies a nested attribute.
-        if lines[index].rstrip() == "#[cfg(test)]":
+        # No lstrip anywhere here: a leading space means the item is nested
+        # inside another, and only top-level test modules are skipped.
+        if _code_before_comment(lines[index]) == "#[cfg(test)]":
             declaration = index + 1
             while declaration < len(lines) and not lines[declaration].strip():
                 declaration += 1
             if declaration < len(lines) and lines[declaration].startswith("mod "):
                 # `mod tests;` (body in another file) or `mod tests {}` (empty,
                 # the form rustfmt emits): self-contained, no body to skip.
-                if lines[declaration].rstrip().endswith((";", "}")):
+                if _code_before_comment(lines[declaration]).endswith((";", "}")):
                     index = declaration + 1
                     continue
                 end = declaration + 1
-                while end < len(lines) and lines[end].rstrip() != "}":
+                while end < len(lines) and _code_before_comment(lines[end]) != "}":
                     end += 1
                 if end < len(lines):
                     index = end + 1
@@ -161,8 +181,8 @@ def check(root: Path, files: Iterable[str], exempt: Iterable[str]) -> list[str]:
             failures.append(
                 f"{relative} has {count} code lines, over the {CAP} cap. Split "
                 f"it into submodules; see CONTRIBUTING.md (Code structure "
-                f"policies). The cap does not count the trailing "
-                f"#[cfg(test)] mod block."
+                f"policies). The cap does not count top-level #[cfg(test)] mod "
+                f"blocks, wherever in the file they sit."
             )
 
     for stale in sorted(exempt - seen):

--- a/.github/scripts/check_file_size.py
+++ b/.github/scripts/check_file_size.py
@@ -50,14 +50,14 @@ EXEMPT: frozenset[str] = frozenset(
 
 
 def code_line_count(source: str) -> int:
-    """Count the lines of `source` above its trailing test module.
+    """Count the lines of `source` that are not inside a test module.
 
-    The test region starts at the first column-0 `#[cfg(test)]` attribute
-    whose next non-blank line declares a `mod`, and runs to end of file. A
-    file with no such marker counts whole.
+    A test module is a column-0 `#[cfg(test)]` attribute whose next non-blank
+    line declares a `mod`; it ends at the next column-0 `}`. Every such block
+    is skipped and everything else counts, *including* code that follows one.
 
-    Both halves of that rule are load-bearing, and the obvious simpler
-    versions are wrong on this tree:
+    Each part of that is load-bearing, and the simpler versions are all wrong
+    on this tree:
 
       * `mod`, not just the attribute. `i18n/mod.rs` and `util/mod.rs` gate a
         *function* on `#[cfg(test)]` partway up the file; keying on the
@@ -65,28 +65,45 @@ def code_line_count(source: str) -> int:
       * Column 0. `platform/mod.rs` nests `#[cfg(test)] mod tests` blocks
         inside its per-OS `mod macos` / `mod windows` blocks; keying on any
         `mod tests` scores it as 1722.
+      * Skip the block, do not stop at it. Truncating at the first test module
+        means one placed mid-file silently exempts the whole rest of the file:
+        a 5000-line file scores 1 and passes. That is not hypothetical
+        gaming — grouping a test module beside the code it covers, rather than
+        at the bottom, is a normal thing to do.
 
-    Nested test modules therefore count as code, which overcounts
-    platform/mod.rs by the ~560 lines of its two inner test modules. That is
-    the safe direction: the rule can never undercount, so tests cannot be
-    nested to sneak a large file under the cap.
+    Finding the end of a block by the next column-0 `}` leans on rustfmt
+    putting the closing brace of a top-level item at column 0, which holds
+    because `cargo fmt --check` is a blocking gate here (CONTRIBUTING.md). It
+    is a line-based heuristic, not a Rust parser, which is proportionate for a
+    navigability guardrail.
 
-    This is a line-based heuristic, not a Rust parser, which is proportionate
-    for a navigability guardrail; brace matching would add failure modes (raw
-    strings, braces in comments) for accuracy the cap does not need.
+    Nested (indented) test modules are not matched and so count as code, which
+    overcounts platform/mod.rs by the ~560 lines of its two inner test
+    modules. That is the safe direction: it can only ever report a file as
+    larger than it is, never smaller.
     """
     lines = source.splitlines()
-    for index, line in enumerate(lines):
+    total = 0
+    index = 0
+    while index < len(lines):
         # rstrip only, so a leading space disqualifies a nested attribute.
-        if line.rstrip() != "#[cfg(test)]":
-            continue
-        for following in lines[index + 1 :]:
-            if not following.strip():
+        if lines[index].rstrip() == "#[cfg(test)]":
+            declaration = index + 1
+            while declaration < len(lines) and not lines[declaration].strip():
+                declaration += 1
+            if declaration < len(lines) and lines[declaration].startswith("mod "):
+                if lines[declaration].rstrip().endswith(";"):
+                    # `#[cfg(test)] mod tests;` — the body is another file.
+                    index = declaration + 1
+                    continue
+                end = declaration + 1
+                while end < len(lines) and lines[end].rstrip() != "}":
+                    end += 1
+                index = end + 1
                 continue
-            if following.startswith("mod "):
-                return index
-            break  # attribute on something else; keep looking.
-    return len(lines)
+        total += 1
+        index += 1
+    return total
 
 
 def tracked_rust_files(root: Path) -> list[str]:

--- a/.github/scripts/check_file_size.py
+++ b/.github/scripts/check_file_size.py
@@ -54,19 +54,35 @@ EXEMPT: frozenset[str] = frozenset(
 
 
 def _code_before_comment(line: str) -> str:
-    """`line` with any trailing comment and whitespace removed.
+    """`line` with its comments and trailing whitespace removed.
 
-    Only ever applied to the three line shapes this scanner matches on (the
-    attribute, a `mod` declaration, a closing brace), none of which carry a
-    string literal that could contain a `//`. `} // end tests` is valid Rust
-    that rustfmt preserves, so matching the bare shapes alone misses it.
+    `} // end tests` is valid Rust that rustfmt preserves, so matching the
+    bare shapes alone misses the terminator and swallows the rest of the file.
+
+    A `/* ... */` span is closed and removed rather than treated as running to
+    end of line, because it can be followed by real code: truncating at the
+    opener turns `mod tests { /* todo */ }` into `mod tests {`, throwing away
+    the brace that closes the body and losing the terminator the same way.
+    rustfmt happens to break that exact line in two, so this tree cannot hold
+    it while `cargo fmt --check` blocks, but the helper should not depend on
+    that to be right.
+
+    This is applied to every line, not only to the shapes matched on. That is
+    safe for the two callers comparing the result to a constant, and it is why
+    the third — the self-contained check, which reads the result as content —
+    needs the span closed rather than truncated. A `//` inside a string
+    literal would be mangled here; that costs nothing on the shapes actually
+    compared, and a raw string holding a column-0 `}` only ever ends a block
+    early, which counts more lines rather than fewer.
     """
-    cut = len(line)
-    for marker in ("//", "/*"):
-        found = line.find(marker)
-        if found != -1:
-            cut = min(cut, found)
-    return line[:cut].rstrip()
+    while (start := line.find("/*")) != -1:
+        end = line.find("*/", start + 2)
+        if end == -1:
+            line = line[:start]
+            break
+        line = f"{line[:start]} {line[end + 2 :]}"
+    cut = line.find("//")
+    return (line if cut == -1 else line[:cut]).rstrip()
 
 
 def code_line_count(source: str) -> int:
@@ -95,9 +111,10 @@ def code_line_count(source: str) -> int:
         emit (compare `control/server.rs`, which has `pub fn cleanup() {}` at
         column 0). Scanning below it for a `}` finds the *next* item's brace,
         or none, and swallows the file: it scores 0.
-      * A matched line can carry a trailing comment. `} // end tests` is valid
-        Rust and rustfmt keeps it, so an exact `}` match walks past the real
-        terminator to the next one and swallows everything between: another 0.
+      * A matched line can carry a comment. `} // end tests` is valid Rust and
+        rustfmt keeps it, so an exact `}` match walks past the real terminator
+        to the next one and swallows everything between: another 0. A closed
+        `/* ... */` span can likewise be followed by the brace that matters.
 
     Finding the end of a block by the next column-0 `}` leans on rustfmt
     putting the closing brace of a top-level item at column 0, which holds

--- a/.github/scripts/check_file_size.py
+++ b/.github/scripts/check_file_size.py
@@ -152,6 +152,10 @@ def tracked_rust_files(root: Path) -> list[str]:
     so this already covers nested files. (It is `:(glob)` magic that sets
     FNM_PATHNAME and stops that; `src-tauri/src/**/*.rs` would match only the
     14 nested files and miss lib.rs, main.rs and dialog.rs.)
+
+    Raises RuntimeError rather than returning an empty list or a bare
+    traceback, because every way this can go wrong is a way for the gate to
+    pass while measuring nothing.
     """
     try:
         completed = subprocess.run(
@@ -164,12 +168,31 @@ def tracked_rust_files(root: Path) -> list[str]:
     except subprocess.CalledProcessError as error:
         # capture_output hides git's stderr, and CalledProcessError does not
         # include it in its message, so without this a failure here (not a
-        # repo, no git on PATH, bad pathspec) reaches the log as a bare
-        # traceback saying only that the exit status was non-zero.
+        # repo, a bad pathspec) reaches the log as a bare traceback saying
+        # only that the exit status was non-zero.
         raise RuntimeError(
             f"git ls-files failed ({error.returncode}): {error.stderr.strip()}"
         ) from error
-    return sorted(entry for entry in completed.stdout.split("\0") if entry)
+    except OSError as error:
+        # A missing git raises FileNotFoundError from the exec, never
+        # CalledProcessError, so it does not go through the branch above.
+        raise RuntimeError(f"could not run git: {error}") from error
+
+    files = sorted(entry for entry in completed.stdout.split("\0") if entry)
+    if not files:
+        # `git ls-files` exits 0 and prints nothing when a pathspec matches
+        # nothing; only --error-unmatch makes it fail. So if src-tauri/src is
+        # renamed, the gate would scan zero files and pass, which is the exact
+        # thing this check exists to prevent (see lint-test.yml on #325: a
+        # check that is green whether or not it passes reads as coverage while
+        # providing none). Stale EXEMPT entries would mask it today, but EXEMPT
+        # is meant to shrink to nothing.
+        raise RuntimeError(
+            "git ls-files matched no .rs files under src-tauri/src. Either the "
+            "tree moved and this script's pathspec needs updating, or this is "
+            "not the repo root."
+        )
+    return files
 
 
 def check(root: Path, files: Iterable[str], exempt: Iterable[str]) -> list[str]:
@@ -179,7 +202,19 @@ def check(root: Path, files: Iterable[str], exempt: Iterable[str]) -> list[str]:
     seen: set[str] = set()
 
     for relative in files:
-        count = code_line_count((root / relative).read_text(encoding="utf-8"))
+        try:
+            source = (root / relative).read_text(encoding="utf-8")
+        except FileNotFoundError as error:
+            # git ls-files reads the index, so it lists a file deleted from the
+            # working tree but not staged. CI is a fresh checkout and
+            # pre-commit stashes, so this only reaches someone running the
+            # script by hand in a dirty tree — which is what CONTRIBUTING.md
+            # tells them to do.
+            raise RuntimeError(
+                f"{relative} is tracked but missing from the working tree; "
+                f"`git status` should say why."
+            ) from error
+        count = code_line_count(source)
         if relative in exempt:
             seen.add(relative)
             if count <= CAP:

--- a/.github/scripts/check_file_size.py
+++ b/.github/scripts/check_file_size.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Enforce a line cap on the Rust sources under src-tauri/src.
+
+Run from the repo root, with no arguments:
+
+    python3 .github/scripts/check_file_size.py
+
+Wired into the `lint-test` job (.github/workflows/lint-test.yml) and mirrored
+by a pre-commit hook. Exits non-zero, with a message naming each offending
+file, on any of:
+
+  * a non-exempt file over the cap;
+  * an exempt file that has dropped to the cap or below (remove it from
+    EXEMPT so it can never regress);
+  * an EXEMPT entry naming a file that no longer exists.
+
+The cap counts *code* lines: the trailing `#[cfg(test)] mod` block does not
+count against it. Rust inlines its unit tests, so counting them would mean a
+700-line file with 200 lines of tests is "over" and the cheapest way back
+under is to delete tests. See CONTRIBUTING.md ("Code structure policies") for
+the rule as contributors read it.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+
+CAP = 800
+
+# Files that were already over the cap when it was introduced. They are
+# grandfathered, not pinned: an exempt file may grow, because #331 rewrites
+# 2080 lines of platform/mod.rs and must not be blocked by a cap it predates.
+#
+# The list only shrinks. Once a file drops to the cap or below, the check
+# fails until its entry is deleted, and from then on the cap holds it there.
+EXEMPT: frozenset[str] = frozenset(
+    {
+        # ~84 top-level items and no siblings; #342 splits this one.
+        "src-tauri/src/platform/mod.rs",
+        "src-tauri/src/update/mod.rs",
+        "src-tauri/src/tray/mod.rs",
+        "src-tauri/src/control/client.rs",
+        "src-tauri/src/control/ops.rs",
+        "src-tauri/src/lib.rs",
+    }
+)
+
+
+def code_line_count(source: str) -> int:
+    """Count the lines of `source` above its trailing test module.
+
+    The test region starts at the first column-0 `#[cfg(test)]` attribute
+    whose next non-blank line declares a `mod`, and runs to end of file. A
+    file with no such marker counts whole.
+
+    Both halves of that rule are load-bearing, and the obvious simpler
+    versions are wrong on this tree:
+
+      * `mod`, not just the attribute. `i18n/mod.rs` and `util/mod.rs` gate a
+        *function* on `#[cfg(test)]` partway up the file; keying on the
+        attribute alone scores i18n/mod.rs as 52 lines.
+      * Column 0. `platform/mod.rs` nests `#[cfg(test)] mod tests` blocks
+        inside its per-OS `mod macos` / `mod windows` blocks; keying on any
+        `mod tests` scores it as 1722.
+
+    Nested test modules therefore count as code, which overcounts
+    platform/mod.rs by the ~560 lines of its two inner test modules. That is
+    the safe direction: the rule can never undercount, so tests cannot be
+    nested to sneak a large file under the cap.
+
+    This is a line-based heuristic, not a Rust parser, which is proportionate
+    for a navigability guardrail; brace matching would add failure modes (raw
+    strings, braces in comments) for accuracy the cap does not need.
+    """
+    lines = source.splitlines()
+    for index, line in enumerate(lines):
+        # rstrip only, so a leading space disqualifies a nested attribute.
+        if line.rstrip() != "#[cfg(test)]":
+            continue
+        for following in lines[index + 1 :]:
+            if not following.strip():
+                continue
+            if following.startswith("mod "):
+                return index
+            break  # attribute on something else; keep looking.
+    return len(lines)
+
+
+def tracked_rust_files(root: Path) -> list[str]:
+    """List the tracked .rs files under src-tauri/src, via git.
+
+    `git ls-files` rather than a filesystem walk, deliberately: the bundled
+    Python tree carries 20k-line vendored sources and a working tree may hold
+    an untracked nested checkout of this repo. Neither is ours to measure and
+    neither is tracked.
+    """
+    out = subprocess.run(
+        ["git", "ls-files", "-z", "src-tauri/src/*.rs", "src-tauri/src/**/*.rs"],
+        cwd=root,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    return sorted(entry for entry in out.split("\0") if entry)
+
+
+def check(root: Path, files: Iterable[str], exempt: Iterable[str]) -> list[str]:
+    """Return a message for every violation; empty means the tree is clean."""
+    exempt = set(exempt)
+    failures: list[str] = []
+    seen: set[str] = set()
+
+    for relative in files:
+        count = code_line_count((root / relative).read_text(encoding="utf-8"))
+        if relative in exempt:
+            seen.add(relative)
+            if count <= CAP:
+                failures.append(
+                    f"{relative} is down to {count} code lines, at or under the "
+                    f"{CAP} cap. Remove it from EXEMPT in "
+                    f".github/scripts/check_file_size.py so it stays there."
+                )
+        elif count > CAP:
+            failures.append(
+                f"{relative} has {count} code lines, over the {CAP} cap. Split "
+                f"it into submodules; see CONTRIBUTING.md (Code structure "
+                f"policies). The cap does not count the trailing "
+                f"#[cfg(test)] mod block."
+            )
+
+    for stale in sorted(exempt - seen):
+        failures.append(
+            f"{stale} is in EXEMPT but is not a tracked file under "
+            f"src-tauri/src. Remove the stale entry from "
+            f".github/scripts/check_file_size.py."
+        )
+
+    return failures
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[2]
+    failures = check(root, tracked_rust_files(root), EXEMPT)
+    for failure in failures:
+        print(f"error: {failure}", file=sys.stderr)
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/check_file_size.py
+++ b/.github/scripts/check_file_size.py
@@ -63,26 +63,39 @@ def _code_before_comment(line: str) -> str:
     end of line, because it can be followed by real code: truncating at the
     opener turns `mod tests { /* todo */ }` into `mod tests {`, throwing away
     the brace that closes the body and losing the terminator the same way.
-    rustfmt happens to break that exact line in two, so this tree cannot hold
-    it while `cargo fmt --check` blocks, but the helper should not depend on
-    that to be right.
+
+    Rust's block comments nest, so the span is tracked by depth rather than
+    closed at the first `*/`: `} /* a /* b */ */` is one comment and a brace,
+    and stopping at the inner `*/` leaves `}   */`, which is not a terminator
+    either. rustfmt keeps that line as written, unlike `mod tests { /* todo */
+    }` which it breaks in two, so it is a shape this tree can actually hold.
 
     This is applied to every line, not only to the shapes matched on. That is
     safe for the two callers comparing the result to a constant, and it is why
     the third — the self-contained check, which reads the result as content —
-    needs the span closed rather than truncated. A `//` inside a string
-    literal would be mangled here; that costs nothing on the shapes actually
-    compared, and a raw string holding a column-0 `}` only ever ends a block
-    early, which counts more lines rather than fewer.
+    needs the spans removed accurately rather than approximately. A `//` or
+    `/*` inside a string literal would be mangled here; that costs nothing on
+    the shapes actually compared, and a raw string holding a column-0 `}` only
+    ever ends a block early, which counts more lines rather than fewer.
     """
-    while (start := line.find("/*")) != -1:
-        end = line.find("*/", start + 2)
-        if end == -1:
-            line = line[:start]
-            break
-        line = f"{line[:start]} {line[end + 2 :]}"
-    cut = line.find("//")
-    return (line if cut == -1 else line[:cut]).rstrip()
+    kept: list[str] = []
+    depth = 0
+    index = 0
+    while index < len(line):
+        if line.startswith("/*", index):
+            depth += 1
+            index += 2
+        elif depth and line.startswith("*/", index):
+            depth -= 1
+            index += 2
+        elif depth:
+            index += 1
+        elif line.startswith("//", index):
+            break  # line comment: the rest really does run to end of line.
+        else:
+            kept.append(line[index])
+            index += 1
+    return "".join(kept).rstrip()
 
 
 def code_line_count(source: str) -> int:

--- a/.github/scripts/check_file_size.py
+++ b/.github/scripts/check_file_size.py
@@ -14,11 +14,11 @@ file, on any of:
     EXEMPT so it can never regress);
   * an EXEMPT entry naming a file that no longer exists.
 
-The cap counts *code* lines: the trailing `#[cfg(test)] mod` block does not
-count against it. Rust inlines its unit tests, so counting them would mean a
-700-line file with 200 lines of tests is "over" and the cheapest way back
-under is to delete tests. See CONTRIBUTING.md ("Code structure policies") for
-the rule as contributors read it.
+The cap counts *code* lines: a top-level `#[cfg(test)] mod` block does not
+count against it, wherever in the file it sits. Rust inlines its unit tests,
+so counting them would mean a 700-line file with 200 lines of tests is "over"
+and the cheapest way back under is to delete tests. See CONTRIBUTING.md
+("Code structure policies") for the rule as contributors read it.
 """
 
 from __future__ import annotations

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -30,6 +30,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      # Structural gate: no file under src-tauri/src may cross the line cap.
+      # Needs no Rust toolchain, so it runs before the setup steps and fails
+      # fast. The rule is in CONTRIBUTING.md ("Code structure policies"); the
+      # grandfathered files are listed in the script itself. Runs here rather
+      # than in lint-test-cross because it is platform independent and would
+      # otherwise report the same result three times.
+      - name: File size cap
+        run: python3 .github/scripts/check_file_size.py
+
       # Tauri links against the system webkit/appindicator stack on Linux, so
       # even a plain `cargo test` needs these to compile. Same dependency set
       # as the Build workflow's Linux jobs (shared composite action).

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,6 +47,18 @@ repos:
         entry: "\\x00"
         types: [text]
 
+      # Mirrors the "File size cap" gate in lint-test.yml. Unlike the cargo
+      # hooks below this is pure Python with no toolchain to find, so it is
+      # absent from the `ci: skip` list above and runs on pre-commit.ci too.
+      # The script enumerates its own files with `git ls-files`, so it takes
+      # no filenames.
+      - id: check-file-size
+        name: file size cap (src-tauri/src)
+        entry: python3 .github/scripts/check_file_size.py
+        language: system
+        types: [rust]
+        pass_filenames: false
+
       # Run inside src-tauri so rustup discovers src-tauri/rust-toolchain.toml
       # and resolves the same pinned toolchain CI uses (requires git-bash on
       # Windows).

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,11 +52,20 @@ repos:
       # absent from the `ci: skip` list above and runs on pre-commit.ci too.
       # The script enumerates its own files with `git ls-files`, so it takes
       # no filenames.
+      #
+      # always_run rather than `types: [rust]`, to mirror lint-test.yml, which
+      # has no paths filter and so gates every PR. pre-commit builds its file
+      # list from staged adds and modifies and drops deletions, so a commit
+      # that only *deletes* a .rs file stages no Rust file and would skip the
+      # hook — and that is exactly the commit that strands an EXEMPT entry.
+      # Editing the script or its list would not trigger it either. It is a
+      # whole-tree check that reads no filenames, so there is nothing to gain
+      # by scoping it.
       - id: check-file-size
         name: file size cap (src-tauri/src)
         entry: python3 .github/scripts/check_file_size.py
         language: system
-        types: [rust]
+        always_run: true
         pass_filenames: false
 
       # Run inside src-tauri so rustup discovers src-tauri/rust-toolchain.toml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,10 +61,18 @@ repos:
       # Editing the script or its list would not trigger it either. It is a
       # whole-tree check that reads no filenames, so there is nothing to gain
       # by scoping it.
+      #
+      # `language: python` rather than `system`, so pre-commit provisions the
+      # interpreter and `python` resolves inside its venv on every platform. A
+      # python.org install on Windows puts `python.exe` and `py.exe` on PATH
+      # but no `python3.exe`; only the Microsoft Store build ships that shim.
+      # Under `system` the entry comes straight off PATH, so `python3` would
+      # fail to launch there — and because this hook is always_run, it would
+      # fail every commit, not just the ones touching Rust.
       - id: check-file-size
         name: file size cap (src-tauri/src)
-        entry: python3 .github/scripts/check_file_size.py
-        language: system
+        entry: python .github/scripts/check_file_size.py
+        language: python
         always_run: true
         pass_filenames: false
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,8 +19,15 @@ The high-leverage ones to keep in working memory while editing:
   add an entry to the `EXEMPT` list in `.github/scripts/check_file_size.py`;
   that list is the record of files that predate the cap and it is meant to
   shrink, not grow.
-- **`cargo fmt`, `cargo clippy -- -D warnings`, and `cargo test` all block the
-  merge.** Run them from `src-tauri/` before pushing. CI pins the toolchain, so
-  match that version if a local result differs.
+- **These three block the merge.** Run them from `src-tauri/` before pushing,
+  with these exact flags; a bare `cargo clippy` lints neither the test targets
+  nor the feature-gated code, so it passes on things CI then fails on. CI pins
+  the toolchain, so match that version if a local result differs.
+
+  ```bash
+  cargo fmt --all --check
+  cargo clippy --all-targets --all-features -- -D warnings
+  cargo test --all-features
+  ```
 - **Don't add `Co-Authored-By: Claude` to commits**, and don't mention Claude
   in PR descriptions or commit messages.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,10 @@ can be brought back into line.
 
 The high-leverage ones to keep in working memory while editing:
 
-- **File size cap: 800 lines**, counting code and not the trailing
-  `#[cfg(test)] mod` block. Split into submodules before crossing it. Do not
+- **File size cap: 800 lines**, counting code and not a top-level
+  `#[cfg(test)] mod` block, wherever in the file it sits. Code following a
+  test module counts, as does a test module nested inside another `mod`.
+  Split into submodules before crossing it. Do not
   add an entry to the `EXEMPT` list in `.github/scripts/check_file_size.py`;
   that list is the record of files that predate the cap and it is meant to
   shrink, not grow.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,24 @@
+# Notes for Claude
+
+A short orientation file for an LLM working in this repo.
+
+**Before writing code, read [CONTRIBUTING.md → "Code structure
+policies"](CONTRIBUTING.md#code-structure-policies) and ["Running the Rust
+checks locally"](CONTRIBUTING.md#running-the-rust-checks-locally).** Those rules
+are the authoritative coding standard, set and maintained by the human
+maintainers; anything here sits on top of them. When a rule there and a rule
+here disagree, CONTRIBUTING.md wins; flag the conflict in the PR so this file
+can be brought back into line.
+
+The high-leverage ones to keep in working memory while editing:
+
+- **File size cap: 800 lines**, counting code and not the trailing
+  `#[cfg(test)] mod` block. Split into submodules before crossing it. Do not
+  add an entry to the `EXEMPT` list in `.github/scripts/check_file_size.py`;
+  that list is the record of files that predate the cap and it is meant to
+  shrink, not grow.
+- **`cargo fmt`, `cargo clippy -- -D warnings`, and `cargo test` all block the
+  merge.** Run them from `src-tauri/` before pushing. CI pins the toolchain, so
+  match that version if a local result differs.
+- **Don't add `Co-Authored-By: Claude` to commits**, and don't mention Claude
+  in PR descriptions or commit messages.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,10 +16,10 @@ the cap; there are no exemptions for new files. `Lint & Test` enforces this
 (`.github/scripts/check_file_size.py`), and a pre-commit hook runs the same
 check locally.
 
-The cap counts code, not tests. The trailing `#[cfg(test)] mod` block does not
-count against it, so a well tested file is never pushed over the cap by its own
-tests. Everything above that block does count, including test modules nested
-inside another `mod`.
+The cap counts code, not tests. A top-level `#[cfg(test)] mod` block does not
+count against it, wherever in the file it sits, so a well tested file is never
+pushed over the cap by its own tests. Everything else does count: code that
+follows a test module, and a test module nested inside another `mod`.
 
 Six files were already over the cap when it landed and are grandfathered in the
 script's `EXEMPT` list. They are allowed to grow, so no in-flight work is

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,32 @@ project and be sure to join us on [Discord](https://discord.gg/KhAMKrd).
 
 [Documentation](https://esphome.io) -- [Issues](https://github.com/esphome/esphome-desktop/issues) -- [Feature requests](https://github.com/orgs/esphome/discussions)
 
+## Code structure policies
+
+**File size cap: 800 lines.** Split a file into submodules before it crosses
+the cap; there are no exemptions for new files. `Lint & Test` enforces this
+(`.github/scripts/check_file_size.py`), and a pre-commit hook runs the same
+check locally.
+
+The cap counts code, not tests. The trailing `#[cfg(test)] mod` block does not
+count against it, so a well tested file is never pushed over the cap by its own
+tests. Everything above that block does count, including test modules nested
+inside another `mod`.
+
+Six files were already over the cap when it landed and are grandfathered in the
+script's `EXEMPT` list. They are allowed to grow, so no in-flight work is
+blocked by a rule it predates. The list only shrinks: once one of them drops to
+the cap or below, the check fails until its entry is removed, and the cap holds
+it there from then on. `src-tauri/src/platform/mod.rs` is the worst of them at
+roughly 2300 code lines; see
+[#342](https://github.com/esphome/esphome-desktop/issues/342) for the split.
+
+To check before pushing:
+
+```bash
+python3 .github/scripts/check_file_size.py
+```
+
 ## Running the Rust checks locally
 
 The `src-tauri` crate is gated in CI by a `Lint & Test` workflow. Run the same

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ roughly 2300 code lines; see
 To check before pushing:
 
 ```bash
-python3 .github/scripts/check_file_size.py
+python3 .github/scripts/check_file_size.py   # `python` on Windows
 ```
 
 ## Running the Rust checks locally

--- a/tests/test_check_file_size.py
+++ b/tests/test_check_file_size.py
@@ -173,6 +173,47 @@ def test_test_module_with_an_empty_body_is_self_contained() -> None:
     assert check_file_size.code_line_count(source) == 4
 
 
+@pytest.mark.parametrize(
+    "closing",
+    ["}", "} // end tests", "} // end tests ", "} /* end tests */"],
+)
+def test_a_comment_on_the_closing_brace_still_ends_the_block(closing: str) -> None:
+    """`} // end tests` is valid Rust and rustfmt keeps it.
+
+    Matching a bare `}` walks past the real terminator to the next one and
+    swallows everything between, scoring a 2006-line file as 0.
+    """
+    source = (
+        "#[cfg(test)]\nmod tests {\n    fn t() {}\n"
+        f"{closing}\n"
+        "fn a() {}\nfn b() {\n}\n"
+    )
+    assert check_file_size.code_line_count(source) == 3
+
+
+def test_a_commented_closing_brace_cannot_hide_an_over_cap_file(
+    tmp_path: Path,
+) -> None:
+    source = (
+        "#[cfg(test)]\nmod tests {\n    fn t() {}\n} // end tests\n"
+        + "".join(f"// code {n}\n" for n in range(CAP + 1))
+        + "fn tail() {\n}\n"
+    )
+    write(tmp_path, "a.rs", source)
+    assert len(check_file_size.check(tmp_path, ["a.rs"], set())) == 1
+
+
+def test_a_comment_on_the_declaration_still_reads_as_self_contained() -> None:
+    """Only `fn a` and `fn b`; the attribute and declaration are both skipped."""
+    source = "fn a() {}\n#[cfg(test)]\nmod tests {} // nothing yet\nfn b() {}\n"
+    assert check_file_size.code_line_count(source) == 2
+
+
+def test_a_comment_on_the_attribute_still_matches() -> None:
+    source = "fn a() {}\n#[cfg(test)] // unit tests\nmod tests {\n    fn t() {}\n}\n"
+    assert check_file_size.code_line_count(source) == 1
+
+
 def test_test_module_declared_in_another_file_is_skipped() -> None:
     """`mod tests;` has no braces to match."""
     source = "fn a() {}\n#[cfg(test)]\nmod tests;\nfn b() {}\n"

--- a/tests/test_check_file_size.py
+++ b/tests/test_check_file_size.py
@@ -375,6 +375,19 @@ def test_no_matching_files_is_an_error_not_a_pass(tmp_path: Path) -> None:
         check_file_size.tracked_rust_files(tmp_path)
 
 
+def test_main_prints_the_diagnostic_rather_than_a_traceback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A RuntimeError escaping main() arrives wrapped in the traceback it replaces."""
+
+    def broken(_root: Path) -> list[str]:
+        raise RuntimeError("the tree moved")
+
+    monkeypatch.setattr(check_file_size, "tracked_rust_files", broken)
+    assert check_file_size.main() == 1
+    assert capsys.readouterr().err.strip() == "error: the tree moved"
+
+
 def test_a_tracked_file_missing_from_the_worktree_says_why(tmp_path: Path) -> None:
     """git ls-files reads the index, which can name a file that is not there."""
     with pytest.raises(RuntimeError, match="missing from the working tree"):

--- a/tests/test_check_file_size.py
+++ b/tests/test_check_file_size.py
@@ -204,6 +204,33 @@ def test_a_commented_closing_brace_cannot_hide_an_over_cap_file(
     assert len(check_file_size.check(tmp_path, ["a.rs"], set())) == 1
 
 
+@pytest.mark.parametrize(
+    "declaration",
+    [
+        "mod tests { /* todo */ }",  # truncating at `/*` loses the `}`
+        "mod tests { /* todo */\n}",  # what rustfmt rewrites the above into
+        "mod tests {} /* todo */",
+    ],
+)
+def test_a_block_comment_does_not_lose_the_closing_brace(declaration: str) -> None:
+    """`/* ... */` closes and can be followed by code; it is not to end of line.
+
+    Truncating at the opener leaves `mod tests {`, which fails the
+    self-contained check, so the scanner hunts below for a brace, finds the
+    next item's, and swallows everything between: a 9-line file scores 0.
+
+    rustfmt splits the first spelling across two lines, so this tree cannot
+    hold it, but the helper should not be right only by luck.
+    """
+    source = f"#[cfg(test)]\n{declaration}\n" + "fn a() {}\nfn b() {\n}\n"
+    assert check_file_size.code_line_count(source) == 3
+
+
+def test_an_unclosed_block_comment_truncates() -> None:
+    """No `*/` on the line means the comment really does run on."""
+    assert check_file_size._code_before_comment("} /* unfinished") == "}"
+
+
 def test_a_comment_on_the_declaration_still_reads_as_self_contained() -> None:
     """Only `fn a` and `fn b`; the attribute and declaration are both skipped."""
     source = "fn a() {}\n#[cfg(test)]\nmod tests {} // nothing yet\nfn b() {}\n"

--- a/tests/test_check_file_size.py
+++ b/tests/test_check_file_size.py
@@ -331,6 +331,18 @@ def test_repo_is_clean() -> None:
     assert check_file_size.check(REPO_ROOT, files, check_file_size.EXEMPT) == []
 
 
+def test_a_git_failure_says_why(tmp_path: Path) -> None:
+    """`check=True` + `capture_output` hides git's stderr from the message.
+
+    Without re-raising, a failure here (not a repo, no git on PATH, a bad
+    pathspec) reaches the CI log as a bare traceback saying only that the exit
+    status was non-zero.
+    """
+    with pytest.raises(RuntimeError, match="git ls-files failed") as caught:
+        check_file_size.tracked_rust_files(tmp_path)
+    assert "not a git repository" in str(caught.value)
+
+
 def test_tracked_rust_files_reaches_nested_modules() -> None:
     """`*` crosses `/` in a default git pathspec, so one spec covers the tree.
 

--- a/tests/test_check_file_size.py
+++ b/tests/test_check_file_size.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Tests for .github/scripts/check_file_size.py.
 
-The cap is only as good as its line count, and the two obvious ways to write
-that count are both wrong on this tree. Every shape below was found in
-src-tauri/src, not invented:
+The cap is only as good as its line count, and every obvious way to write
+that count has been wrong. Two of these shapes were found in src-tauri/src
+rather than invented, and the other two shipped as bugs in review:
 
   * `i18n/mod.rs` gates a *function* on `#[cfg(test)]` at column 0, partway up
     the file. Keying on the attribute alone scores the file as 52 lines, and
@@ -11,17 +11,22 @@ src-tauri/src, not invented:
   * `platform/mod.rs` nests `#[cfg(test)] mod tests` inside its per-OS `mod
     macos` / `mod windows` blocks. Keying on any `mod tests` scores it as
     1722.
+  * A test module *mid-file*, with code after it. Truncating at the first one
+    scored a 5005-line file as 1.
+  * `mod tests {}`, the empty body rustfmt produces. Scanning below the
+    declaration for a closing brace finds the next item's, or none, and
+    scored a 2004-line file as 0.
 
-So `test_cfg_gated_function_is_not_the_test_module` and
-`test_nested_test_module_is_not_the_marker` are the regression net for the
-whole rule; the rest cover the exempt-list transitions that let the list
-shrink but never grow back.
+Fixtures here use the spelling `cargo fmt` would actually emit. The `{}` bug
+survived a first fix precisely because the regression test for it pinned
+`{\n}`, which rustfmt rewrites, so no realistic file ever took that path.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from script_loader import load_script_module
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -138,9 +143,19 @@ def test_every_test_module_is_skipped_not_just_the_first() -> None:
     assert check_file_size.code_line_count(source) == 2
 
 
-def test_a_mid_file_test_module_cannot_hide_an_over_cap_file(tmp_path: Path) -> None:
-    """The end-to-end form of the bug: the cap must still fire."""
-    source = "#[cfg(test)]\nmod early {\n}\n" + "".join(
+@pytest.mark.parametrize("empty_body", ["mod early {\n}", "mod early {}"])
+def test_a_mid_file_test_module_cannot_hide_an_over_cap_file(
+    tmp_path: Path, empty_body: str
+) -> None:
+    """The end-to-end form of the bug: the cap must still fire.
+
+    Both spellings, because rustfmt rewrites the first into the second: an
+    empty body is collapsed onto the declaration line, so `mod early {}` is
+    the only form that can exist in this tree (`cargo fmt --check` blocks).
+    Testing only the `{\\n}` form pins the one spelling rustfmt will not
+    produce, which is how the `{}` shape survived the first fix.
+    """
+    source = f"#[cfg(test)]\n{empty_body}\n" + "".join(
         f"// code {n}\n" for n in range(CAP + 1)
     )
     write(tmp_path, "a.rs", source)
@@ -149,24 +164,48 @@ def test_a_mid_file_test_module_cannot_hide_an_over_cap_file(tmp_path: Path) -> 
     assert str(CAP + 1) in failures[0]
 
 
+def test_test_module_with_an_empty_body_is_self_contained() -> None:
+    """`mod tests {}` closes itself; there is no brace below to scan for.
+
+    Scanning below it swallows everything to the next column-0 `}` or EOF.
+    """
+    source = "fn a() {}\n#[cfg(test)]\nmod tests {}\nfn b() {}\nfn c() {\n}\n"
+    assert check_file_size.code_line_count(source) == 4
+
+
 def test_test_module_declared_in_another_file_is_skipped() -> None:
     """`mod tests;` has no braces to match."""
     source = "fn a() {}\n#[cfg(test)]\nmod tests;\nfn b() {}\n"
     assert check_file_size.code_line_count(source) == 2
 
 
-def test_unterminated_test_module_does_not_run_away() -> None:
+def test_unterminated_test_module_counts_as_code() -> None:
+    """No closing brace means the scanner is lost; fail loud, not silent.
+
+    Swallowing to EOF would collapse the count and wave an over-cap file
+    through on nothing but odd formatting.
+    """
     source = "fn a() {}\n#[cfg(test)]\nmod tests {\n    fn t() {}\n"
-    assert check_file_size.code_line_count(source) == 1
+    assert check_file_size.code_line_count(source) == 4
+
+
+def test_unterminated_test_module_cannot_hide_an_over_cap_file(
+    tmp_path: Path,
+) -> None:
+    source = "#[cfg(test)]\nmod tests {\n" + "".join(
+        f"    // code {n}\n" for n in range(CAP + 1)
+    )
+    write(tmp_path, "a.rs", source)
+    assert len(check_file_size.check(tmp_path, ["a.rs"], set())) == 1
 
 
 def test_blank_lines_between_attribute_and_mod_are_skipped() -> None:
-    source = "fn a() {}\n#[cfg(test)]\n\n\nmod tests {\n}\n"
+    source = "fn a() {}\n#[cfg(test)]\n\n\nmod tests {\n    fn t() {}\n}\n"
     assert check_file_size.code_line_count(source) == 1
 
 
 def test_trailing_whitespace_on_the_attribute_still_matches() -> None:
-    source = "fn a() {}\n#[cfg(test)]  \nmod tests {\n}\n"
+    source = "fn a() {}\n#[cfg(test)]  \nmod tests {\n    fn t() {}\n}\n"
     assert check_file_size.code_line_count(source) == 1
 
 

--- a/tests/test_check_file_size.py
+++ b/tests/test_check_file_size.py
@@ -329,3 +329,18 @@ def test_repo_is_clean() -> None:
     files = check_file_size.tracked_rust_files(REPO_ROOT)
     assert files, "expected tracked .rs files under src-tauri/src"
     assert check_file_size.check(REPO_ROOT, files, check_file_size.EXEMPT) == []
+
+
+def test_tracked_rust_files_reaches_nested_modules() -> None:
+    """`*` crosses `/` in a default git pathspec, so one spec covers the tree.
+
+    That is the opposite of `:(glob)` magic, which sets FNM_PATHNAME and would
+    match only the three files sitting directly in src-tauri/src. Asserting
+    merely that the list is non-empty would pass either way, while the cap
+    silently stopped covering 14 of the 17 files.
+    """
+    files = check_file_size.tracked_rust_files(REPO_ROOT)
+    assert "src-tauri/src/lib.rs" in files, "expected the top-level files"
+    assert "src-tauri/src/platform/mod.rs" in files, "expected nested modules"
+    nested = [f for f in files if f.count("/") > 2]
+    assert len(nested) > 3, f"expected many nested files, found {len(nested)}"

--- a/tests/test_check_file_size.py
+++ b/tests/test_check_file_size.py
@@ -102,6 +102,64 @@ def test_nested_test_module_is_not_the_marker() -> None:
     assert check_file_size.code_line_count(source) == 7
 
 
+def test_code_after_a_test_module_still_counts() -> None:
+    """A mid-file test module must not exempt the rest of the file.
+
+    Truncating at the first test module instead of skipping over it scores
+    this at 1, so a 5000-line file would pass the cap. Grouping tests beside
+    the code they cover rather than at the bottom is ordinary, so this is a
+    correctness bug before it is ever a way to game the cap.
+    """
+    source = (
+        "fn a() {}\n"
+        "#[cfg(test)]\n"
+        "mod a_tests {\n"
+        "    fn t() {}\n"
+        "}\n"
+        "fn b() {}\n"
+        "fn c() {}\n"
+    )
+    assert check_file_size.code_line_count(source) == 3
+
+
+def test_every_test_module_is_skipped_not_just_the_first() -> None:
+    source = (
+        "fn a() {}\n"
+        "#[cfg(test)]\n"
+        "mod a_tests {\n"
+        "    fn t() {}\n"
+        "}\n"
+        "fn b() {}\n"
+        "#[cfg(test)]\n"
+        "mod b_tests {\n"
+        "    fn t() {}\n"
+        "}\n"
+    )
+    assert check_file_size.code_line_count(source) == 2
+
+
+def test_a_mid_file_test_module_cannot_hide_an_over_cap_file(tmp_path: Path) -> None:
+    """The end-to-end form of the bug: the cap must still fire."""
+    source = "#[cfg(test)]\nmod early {\n}\n" + "".join(
+        f"// code {n}\n" for n in range(CAP + 1)
+    )
+    write(tmp_path, "a.rs", source)
+    failures = check_file_size.check(tmp_path, ["a.rs"], set())
+    assert len(failures) == 1
+    assert str(CAP + 1) in failures[0]
+
+
+def test_test_module_declared_in_another_file_is_skipped() -> None:
+    """`mod tests;` has no braces to match."""
+    source = "fn a() {}\n#[cfg(test)]\nmod tests;\nfn b() {}\n"
+    assert check_file_size.code_line_count(source) == 2
+
+
+def test_unterminated_test_module_does_not_run_away() -> None:
+    source = "fn a() {}\n#[cfg(test)]\nmod tests {\n    fn t() {}\n"
+    assert check_file_size.code_line_count(source) == 1
+
+
 def test_blank_lines_between_attribute_and_mod_are_skipped() -> None:
     source = "fn a() {}\n#[cfg(test)]\n\n\nmod tests {\n}\n"
     assert check_file_size.code_line_count(source) == 1

--- a/tests/test_check_file_size.py
+++ b/tests/test_check_file_size.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Tests for .github/scripts/check_file_size.py.
+
+The cap is only as good as its line count, and the two obvious ways to write
+that count are both wrong on this tree. Every shape below was found in
+src-tauri/src, not invented:
+
+  * `i18n/mod.rs` gates a *function* on `#[cfg(test)]` at column 0, partway up
+    the file. Keying on the attribute alone scores the file as 52 lines, and
+    a 3000-line file could then pass by opening with a cfg-gated helper.
+  * `platform/mod.rs` nests `#[cfg(test)] mod tests` inside its per-OS `mod
+    macos` / `mod windows` blocks. Keying on any `mod tests` scores it as
+    1722.
+
+So `test_cfg_gated_function_is_not_the_test_module` and
+`test_nested_test_module_is_not_the_marker` are the regression net for the
+whole rule; the rest cover the exempt-list transitions that let the list
+shrink but never grow back.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from script_loader import load_script_module
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT_PATH = REPO_ROOT / ".github" / "scripts" / "check_file_size.py"
+
+check_file_size = load_script_module(SCRIPT_PATH)
+
+CAP = check_file_size.CAP
+
+
+def write(root: Path, relative: str, source: str) -> None:
+    """Materialise `source` at `relative` under `root`."""
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(source, encoding="utf-8")
+
+
+def rust_file(code_lines: int, test_lines: int = 0) -> str:
+    """A Rust source with `code_lines` of code and a test module."""
+    body = "\n".join(f"// code {n}" for n in range(code_lines))
+    if not test_lines:
+        return body + "\n"
+    tests = "\n".join(f"    // test {n}" for n in range(test_lines))
+    return f"{body}\n#[cfg(test)]\nmod tests {{\n{tests}\n}}\n"
+
+
+# --- the line-count rule -------------------------------------------------
+
+
+def test_counts_whole_file_when_there_is_no_test_module() -> None:
+    """tray/mod.rs has no `#[cfg(test)]` at all; it counts whole."""
+    assert check_file_size.code_line_count("fn a() {}\nfn b() {}\n") == 2
+
+
+def test_trailing_test_module_does_not_count() -> None:
+    source = "fn a() {}\n#[cfg(test)]\nmod tests {\n    fn t() {}\n}\n"
+    assert check_file_size.code_line_count(source) == 1
+
+
+def test_cfg_gated_function_is_not_the_test_module() -> None:
+    """The i18n/mod.rs and util/mod.rs shape: `#[cfg(test)] fn`, not `mod`.
+
+    Keying on the attribute alone would return 1 here instead of 5.
+    """
+    source = (
+        "fn a() {}\n"
+        "#[cfg(test)]\n"
+        "fn test_pinned() {}\n"
+        "#[cfg(not(test))]\n"
+        "fn pinned() {}\n"
+        "#[cfg(test)]\n"
+        "mod tests {\n"
+        "    fn t() {}\n"
+        "}\n"
+    )
+    assert check_file_size.code_line_count(source) == 5
+
+
+def test_nested_test_module_is_not_the_marker() -> None:
+    """The platform/mod.rs shape: an indented `#[cfg(test)] mod tests`.
+
+    Nested test modules count as code. That overcounts, which is the safe
+    direction; the point is that it does not stop at line 1.
+    """
+    source = (
+        "mod macos {\n"
+        "    fn a() {}\n"
+        "    #[cfg(test)]\n"
+        "    mod tests {\n"
+        "        fn t() {}\n"
+        "    }\n"
+        "}\n"
+        "#[cfg(test)]\n"
+        "mod tests {\n"
+        "    fn t() {}\n"
+        "}\n"
+    )
+    assert check_file_size.code_line_count(source) == 7
+
+
+def test_blank_lines_between_attribute_and_mod_are_skipped() -> None:
+    source = "fn a() {}\n#[cfg(test)]\n\n\nmod tests {\n}\n"
+    assert check_file_size.code_line_count(source) == 1
+
+
+def test_trailing_whitespace_on_the_attribute_still_matches() -> None:
+    source = "fn a() {}\n#[cfg(test)]  \nmod tests {\n}\n"
+    assert check_file_size.code_line_count(source) == 1
+
+
+def test_rust_file_helper_produces_the_line_count_it_claims() -> None:
+    """Guard the helper the cap tests below depend on."""
+    assert check_file_size.code_line_count(rust_file(10)) == 10
+    assert check_file_size.code_line_count(rust_file(10, test_lines=50)) == 10
+
+
+# --- the cap -------------------------------------------------------------
+
+
+def test_file_at_the_cap_passes(tmp_path: Path) -> None:
+    write(tmp_path, "a.rs", rust_file(CAP))
+    assert check_file_size.check(tmp_path, ["a.rs"], set()) == []
+
+
+def test_file_over_the_cap_fails(tmp_path: Path) -> None:
+    write(tmp_path, "a.rs", rust_file(CAP + 1))
+    failures = check_file_size.check(tmp_path, ["a.rs"], set())
+    assert len(failures) == 1
+    assert "a.rs" in failures[0]
+    assert str(CAP + 1) in failures[0]
+
+
+def test_huge_test_module_does_not_push_a_file_over(tmp_path: Path) -> None:
+    """The whole point of counting code only."""
+    write(tmp_path, "a.rs", rust_file(CAP, test_lines=5000))
+    assert check_file_size.check(tmp_path, ["a.rs"], set()) == []
+
+
+# --- the exempt list -----------------------------------------------------
+
+
+def test_exempt_file_may_grow(tmp_path: Path) -> None:
+    """#331 takes platform/mod.rs to 4320 lines; that must not fail."""
+    write(tmp_path, "a.rs", rust_file(CAP * 4))
+    assert check_file_size.check(tmp_path, ["a.rs"], {"a.rs"}) == []
+
+
+def test_exempt_file_under_the_cap_must_be_delisted(tmp_path: Path) -> None:
+    write(tmp_path, "a.rs", rust_file(CAP - 1))
+    failures = check_file_size.check(tmp_path, ["a.rs"], {"a.rs"})
+    assert len(failures) == 1
+    assert "EXEMPT" in failures[0]
+    assert "a.rs" in failures[0]
+
+
+def test_exempt_file_exactly_at_the_cap_must_be_delisted(tmp_path: Path) -> None:
+    """At the cap is not over it, so the entry has done its job."""
+    write(tmp_path, "a.rs", rust_file(CAP))
+    failures = check_file_size.check(tmp_path, ["a.rs"], {"a.rs"})
+    assert len(failures) == 1
+    assert "EXEMPT" in failures[0]
+
+
+def test_stale_exempt_entry_fails(tmp_path: Path) -> None:
+    """A renamed or deleted file must not linger on the list."""
+    failures = check_file_size.check(tmp_path, [], {"gone.rs"})
+    assert len(failures) == 1
+    assert "gone.rs" in failures[0]
+    assert "stale" in failures[0]
+
+
+def test_reports_every_violation_not_just_the_first(tmp_path: Path) -> None:
+    write(tmp_path, "a.rs", rust_file(CAP + 1))
+    write(tmp_path, "b.rs", rust_file(CAP + 1))
+    assert len(check_file_size.check(tmp_path, ["a.rs", "b.rs"], set())) == 2
+
+
+# --- the real tree -------------------------------------------------------
+
+
+def test_repo_is_clean() -> None:
+    """The committed tree passes, and EXEMPT has no stale entries.
+
+    This is the check CI runs; having it here means a stale entry surfaces
+    from `pytest` locally rather than only on a pushed branch.
+    """
+    files = check_file_size.tracked_rust_files(REPO_ROOT)
+    assert files, "expected tracked .rs files under src-tauri/src"
+    assert check_file_size.check(REPO_ROOT, files, check_file_size.EXEMPT) == []

--- a/tests/test_check_file_size.py
+++ b/tests/test_check_file_size.py
@@ -24,6 +24,7 @@ survived a first fix precisely because the regression test for it pinned
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -334,13 +335,50 @@ def test_repo_is_clean() -> None:
 def test_a_git_failure_says_why(tmp_path: Path) -> None:
     """`check=True` + `capture_output` hides git's stderr from the message.
 
-    Without re-raising, a failure here (not a repo, no git on PATH, a bad
-    pathspec) reaches the CI log as a bare traceback saying only that the exit
-    status was non-zero.
+    Without re-raising, a failure here (not a repo, a bad pathspec) reaches
+    the CI log as a bare traceback saying only that the exit status was
+    non-zero.
+
+    Asserts the prefix and exit code this script controls, plus that *some*
+    stderr came through — not git's own wording, which gettext localizes, so
+    pinning the English would fail this suite in another locale while the
+    behaviour was perfectly correct.
     """
-    with pytest.raises(RuntimeError, match="git ls-files failed") as caught:
+    with pytest.raises(RuntimeError, match=r"git ls-files failed \(128\)") as caught:
         check_file_size.tracked_rust_files(tmp_path)
-    assert "not a git repository" in str(caught.value)
+    _, _, reason = str(caught.value).partition("): ")
+    assert reason.strip(), "expected git's stderr to be carried into the message"
+
+
+def test_a_missing_git_says_why(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A missing git raises FileNotFoundError, not CalledProcessError.
+
+    So it does not go through the branch that handles a git *failure*, and
+    without a second handler it is a bare traceback naming an errno.
+    """
+    monkeypatch.setenv("PATH", str(tmp_path))
+    with pytest.raises(RuntimeError, match="could not run git"):
+        check_file_size.tracked_rust_files(tmp_path)
+
+
+def test_no_matching_files_is_an_error_not_a_pass(tmp_path: Path) -> None:
+    """An empty match must never be a quiet exit 0.
+
+    `git ls-files` exits 0 and prints nothing when a pathspec matches nothing,
+    so a renamed src-tauri/src would otherwise scan zero files and pass: a
+    green gate enforcing nothing.
+    """
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    with pytest.raises(RuntimeError, match="matched no .rs files"):
+        check_file_size.tracked_rust_files(tmp_path)
+
+
+def test_a_tracked_file_missing_from_the_worktree_says_why(tmp_path: Path) -> None:
+    """git ls-files reads the index, which can name a file that is not there."""
+    with pytest.raises(RuntimeError, match="missing from the working tree"):
+        check_file_size.check(tmp_path, ["src-tauri/src/deleted.rs"], set())
 
 
 def test_tracked_rust_files_reaches_nested_modules() -> None:

--- a/tests/test_check_file_size.py
+++ b/tests/test_check_file_size.py
@@ -231,6 +231,42 @@ def test_an_unclosed_block_comment_truncates() -> None:
     assert check_file_size._code_before_comment("} /* unfinished") == "}"
 
 
+@pytest.mark.parametrize(
+    ("line", "expected"),
+    [
+        ("} /* a /* b */ */", "}"),  # nested: one comment, then the brace
+        ("} /* a */", "}"),
+        ("} // end", "}"),
+        ("} /* unfinished", "}"),
+        ("mod tests { /* todo */ }", "mod tests {  }"),
+        ("mod tests {} /* note */", "mod tests {}"),
+        ("#[cfg(test)] /* x */", "#[cfg(test)]"),
+        ("#[cfg(test)]", "#[cfg(test)]"),
+        ("mod tests;", "mod tests;"),
+        ("mod tests {", "mod tests {"),
+    ],
+)
+def test_code_before_comment(line: str, expected: str) -> None:
+    """Rust block comments nest, so `/* a /* b */ */` is one comment.
+
+    Closing at the first `*/` leaves `}   */`, which is not a terminator, so
+    the block runs on and the file undercounts. rustfmt keeps that line as
+    written, so it is a shape this tree can hold, unlike `mod tests { /* todo
+    */ }` which it breaks in two.
+    """
+    assert check_file_size._code_before_comment(line) == expected
+
+
+def test_a_nested_block_comment_cannot_hide_an_over_cap_file(tmp_path: Path) -> None:
+    source = (
+        "#[cfg(test)]\nmod tests {\n    fn t() {}\n} /* a /* b */ */\n"
+        + "".join(f"// code {n}\n" for n in range(CAP + 1))
+        + "fn tail() {\n}\n"
+    )
+    write(tmp_path, "a.rs", source)
+    assert len(check_file_size.check(tmp_path, ["a.rs"], set())) == 1
+
+
 def test_a_comment_on_the_declaration_still_reads_as_self_contained() -> None:
     """Only `fn a` and `fn b`; the attribute and declaration are both skipped."""
     source = "fn a() {}\n#[cfg(test)]\nmod tests {} // nothing yet\nfn b() {}\n"


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Nothing in the repo said how large a file may get, so nothing ever resisted a file growing; `platform/mod.rs` is what that looks like after a while. This adds the rule and a gate that enforces it, so the next one gets caught on the way up.

The cap counts code, not tests; the trailing `#[cfg(test)] mod` block does not count against it. Rust inlines its unit tests, unlike the frontend where they live in `test/` and never count toward its own cap, so counting them here would mean a 700 line file with 200 lines of tests is over and the cheapest way back under is to delete tests.

Six files were already over the cap. They are grandfathered in the script's `EXEMPT` list and are allowed to grow, so nothing in flight is blocked by a rule it predates; #331 takes `platform/mod.rs` well past the cap and stays green. The list only shrinks; once a file drops to the cap or below the check fails until its entry is removed, and the cap holds it there from then on. A stale entry naming a file that no longer exists fails too.

Blocking rather than advisory, for the reason already written into `lint-test.yml`; a check that is green whether or not it passes reads as coverage while providing none.

This also adds a `CLAUDE.md`, which the repo does not currently have, since the cap is exactly the kind of rule an assistant should not have to rediscover. It mirrors how the frontend repo structures it: `CONTRIBUTING.md` holds the authoritative rules and `CLAUDE.md` defers to it. Beyond the cap it restates two things that already exist rather than introducing anything new, the blocking `fmt` / `clippy` / `test` gates from `CONTRIBUTING.md` and the standing no AI attribution convention. Happy to cut it back to just the cap and the pointer if you would rather it stayed narrow.

Two details worth a look. The line count keys on the first column 0 `#[cfg(test)]` whose next line declares a `mod`, and both halves are load bearing; `i18n/mod.rs` and `util/mod.rs` gate a function on `#[cfg(test)]` partway up, and `platform/mod.rs` nests test modules inside its per OS blocks, so the two obvious simpler rules score those files at 52 and 1722 lines. Nested test modules therefore count as code, which overcounts, and that is the safe direction since the rule can never undercount. The script also enumerates files with `git ls-files` rather than walking the tree, because the bundled Python carries 20k line vendored sources.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- groundwork for #342, which splits the worst of the grandfathered files; that split needs #331 to merge first, so it is not part of this PR and this does not close it

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tested on the relevant platform(s) (macOS, Windows, Linux).

Locally I only ran macOS, so I opened this with the platform box unticked; `Scripts Test` has since run the suite green on macOS, Windows and Linux, and the gate itself passed on the ubuntu job, so it is ticked now on that basis rather than on mine. Each failure mode was exercised rather than assumed: a non exempt file pushed over the cap fails, an exempt file trimmed under it fails asking to be delisted, a stale exempt entry fails, and a clean tree passes.


