### PR TITLE
Point bundled git at its own CA bundle for HTTPS clones

### DIFF
--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -216,13 +216,18 @@ pub fn get_bundled_patch_dir(app_handle: &AppHandle) -> Result<PathBuf> {
     Ok(resource_dir.join("git").join("patch"))
 }
 
-/// MinGit's CA-bundle locations relative to the `git` resource dir, in the order
-/// MinGit's own `etc/gitconfig` and layout prefer. `prepare_bundle.sh` extracts
-/// the MinGit tree whole, so one of these is always shipped. `Path::join` treats
-/// `/` as a separator on Windows too, so these resolve correctly on every OS.
-const GIT_CA_BUNDLE_RELATIVE: [&str; 2] = [
-    "mingw64/etc/ssl/certs/ca-bundle.crt",
-    "mingw64/ssl/certs/ca-bundle.crt",
+/// MinGit's CA-bundle locations under the `git` resource dir, as path
+/// components in the order MinGit's own `etc/gitconfig` and layout prefer.
+/// `prepare_bundle.sh` extracts the MinGit tree whole, so one is always shipped.
+///
+/// Stored as components, not a `/`-joined literal, so [`first_existing_ca_bundle`]
+/// can join them onto the resource dir with the native separator. On Windows the
+/// resource dir is a backslash path (`C:\...\git`); a `/`-joined literal would
+/// yield a mixed `C:\...\git\mingw64/etc/...`, and the value ends up in
+/// `GIT_SSL_CAINFO`, so it must be a clean native path git can consume.
+const GIT_CA_BUNDLE_RELATIVE: [&[&str]; 2] = [
+    &["mingw64", "etc", "ssl", "certs", "ca-bundle.crt"],
+    &["mingw64", "ssl", "certs", "ca-bundle.crt"],
 ];
 
 /// First of MinGit's CA-bundle locations that exists under `git_dir`.
@@ -234,8 +239,8 @@ const GIT_CA_BUNDLE_RELATIVE: [&str; 2] = [
 #[cfg_attr(not(target_os = "windows"), allow(dead_code))]
 fn first_existing_ca_bundle(git_dir: &Path) -> Option<PathBuf> {
     GIT_CA_BUNDLE_RELATIVE
-        .into_iter()
-        .map(|relative| git_dir.join(relative))
+        .iter()
+        .map(|components| git_dir.join(components.iter().collect::<PathBuf>()))
         .find(|candidate| candidate.exists())
 }
 
@@ -733,8 +738,10 @@ mod tests {
     #[test]
     fn first_existing_ca_bundle_prefers_etc_then_falls_back() {
         let git_dir = unique_temp_dir("ca-bundle");
-        let etc = git_dir.join("mingw64/etc/ssl/certs/ca-bundle.crt");
-        let plain = git_dir.join("mingw64/ssl/certs/ca-bundle.crt");
+        // Build the fixtures from the same component lists the code joins, so the
+        // test tracks the constant and mirrors the native-separator join.
+        let etc = git_dir.join(GIT_CA_BUNDLE_RELATIVE[0].iter().collect::<PathBuf>());
+        let plain = git_dir.join(GIT_CA_BUNDLE_RELATIVE[1].iter().collect::<PathBuf>());
 
         // Neither present: nothing to point GIT_SSL_CAINFO at.
         assert_eq!(first_existing_ca_bundle(&git_dir), None);
@@ -748,6 +755,32 @@ mod tests {
         std::fs::create_dir_all(etc.parent().unwrap()).unwrap();
         std::fs::write(&etc, b"").unwrap();
         assert_eq!(first_existing_ca_bundle(&git_dir), Some(etc));
+    }
+
+    /// On Windows the resource dir is a backslash path (`C:\...\git`) and the
+    /// result is handed to `GIT_SSL_CAINFO`, so the join must come back a clean
+    /// native path, not a mixed `C:\...\git\mingw64/etc/...` one. `unique_temp_dir`
+    /// gives a real backslash base here, exercising exactly that join; a
+    /// `/`-joined candidate literal would fail the tail assertion. Runs only in
+    /// the `windows-latest` CI job (lint-test-cross), the sole place Windows-gated
+    /// code is compiled and tested.
+    #[cfg(windows)]
+    #[test]
+    fn first_existing_ca_bundle_yields_native_windows_path() {
+        let git_dir = unique_temp_dir("ca-bundle-native");
+        let etc = git_dir.join(GIT_CA_BUNDLE_RELATIVE[0].iter().collect::<PathBuf>());
+        std::fs::create_dir_all(etc.parent().unwrap()).unwrap();
+        std::fs::write(&etc, b"").unwrap();
+
+        let found =
+            first_existing_ca_bundle(&git_dir).expect("bundle resolves under a backslash base");
+        assert!(
+            found
+                .to_str()
+                .unwrap()
+                .ends_with(r"mingw64\etc\ssl\certs\ca-bundle.crt"),
+            "GIT_SSL_CAINFO must use native separators, got {found:?}"
+        );
     }
 
     #[test]

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -230,7 +230,12 @@ const GIT_CA_BUNDLE_RELATIVE: [&[&str]; 2] = [
     &["mingw64", "ssl", "certs", "ca-bundle.crt"],
 ];
 
-/// First of MinGit's CA-bundle locations that exists under `git_dir`.
+/// First of MinGit's CA-bundle locations that exists as a regular file under
+/// `git_dir`.
+///
+/// `is_file`, not `exists`: the result is pinned into `GIT_SSL_CAINFO`, and a
+/// directory (or other non-file) at that path would be a value MinGit's OpenSSL
+/// backend can't load, so it must not be treated as a usable bundle.
 ///
 /// Split out from [`bundled_git_ca_bundle`] so the candidate order can be
 /// unit-tested without a Tauri `AppHandle` or a real bundle on disk, the same
@@ -241,7 +246,7 @@ fn first_existing_ca_bundle(git_dir: &Path) -> Option<PathBuf> {
     GIT_CA_BUNDLE_RELATIVE
         .iter()
         .map(|components| git_dir.join(components.iter().collect::<PathBuf>()))
-        .find(|candidate| candidate.exists())
+        .find(|candidate| candidate.is_file())
 }
 
 /// The bundled MinGit CA bundle, if present.
@@ -446,20 +451,30 @@ pub fn ensure_git_on_path(app_handle: &AppHandle) -> Result<()> {
         // ca-bundle.crt that no longer exists; MinGit's OpenSSL backend then
         // fails every fetch with "error adding trust anchors from file". The env
         // var overrides every config file, so the bundled git always finds the
-        // bundled bundle. Log-and-continue if it is somehow absent; an ambient
-        // config may still work.
-        match bundled_git_ca_bundle(app_handle)? {
-            Some(ca_bundle) => {
-                std::env::set_var("GIT_SSL_CAINFO", &ca_bundle);
-                info!(
-                    "Pinned GIT_SSL_CAINFO to bundled CA bundle at {:?}",
-                    ca_bundle
-                );
+        // bundled bundle.
+        //
+        // Only set it when it is not already in the environment: the #350
+        // breakage lives in git *config files*, which an unset env var doesn't
+        // come from, so this still fixes it, while an explicit GIT_SSL_CAINFO
+        // from the user or launcher (e.g. a corporate CA) is left untouched.
+        // Log-and-continue if the bundle is somehow absent; an ambient config
+        // may still work.
+        if std::env::var_os("GIT_SSL_CAINFO").is_some() {
+            info!("GIT_SSL_CAINFO already set in the environment; leaving it in place");
+        } else {
+            match bundled_git_ca_bundle(app_handle)? {
+                Some(ca_bundle) => {
+                    std::env::set_var("GIT_SSL_CAINFO", &ca_bundle);
+                    info!(
+                        "Pinned GIT_SSL_CAINFO to bundled CA bundle at {:?}",
+                        ca_bundle
+                    );
+                }
+                None => warn!(
+                    "Bundled MinGit CA bundle not found; HTTPS clones will rely on \
+                     the ambient git SSL configuration"
+                ),
             }
-            None => warn!(
-                "Bundled MinGit CA bundle not found; HTTPS clones will rely on \
-                 the ambient git SSL configuration"
-            ),
         }
     }
 
@@ -755,6 +770,22 @@ mod tests {
         std::fs::create_dir_all(etc.parent().unwrap()).unwrap();
         std::fs::write(&etc, b"").unwrap();
         assert_eq!(first_existing_ca_bundle(&git_dir), Some(etc));
+    }
+
+    #[test]
+    fn first_existing_ca_bundle_ignores_a_directory() {
+        // is_file, not exists: a directory sitting where the bundle would be is
+        // not a value GIT_SSL_CAINFO can load, so it must be skipped, not pinned.
+        let git_dir = unique_temp_dir("ca-bundle-dir");
+        let dir_at_etc = git_dir.join(GIT_CA_BUNDLE_RELATIVE[0].iter().collect::<PathBuf>());
+        std::fs::create_dir_all(&dir_at_etc).unwrap();
+        assert_eq!(first_existing_ca_bundle(&git_dir), None);
+
+        // A real file at the fallback is still picked over the directory.
+        let plain = git_dir.join(GIT_CA_BUNDLE_RELATIVE[1].iter().collect::<PathBuf>());
+        std::fs::create_dir_all(plain.parent().unwrap()).unwrap();
+        std::fs::write(&plain, b"").unwrap();
+        assert_eq!(first_existing_ca_bundle(&git_dir), Some(plain));
     }
 
     /// On Windows the resource dir is a backslash path (`C:\...\git`) and the

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -216,6 +216,42 @@ pub fn get_bundled_patch_dir(app_handle: &AppHandle) -> Result<PathBuf> {
     Ok(resource_dir.join("git").join("patch"))
 }
 
+/// MinGit's CA-bundle locations relative to the `git` resource dir, in the order
+/// MinGit's own `etc/gitconfig` and layout prefer. `prepare_bundle.sh` extracts
+/// the MinGit tree whole, so one of these is always shipped.
+const GIT_CA_BUNDLE_RELATIVE: [&[&str]; 2] = [
+    &["mingw64", "etc", "ssl", "certs", "ca-bundle.crt"],
+    &["mingw64", "ssl", "certs", "ca-bundle.crt"],
+];
+
+/// First of MinGit's CA-bundle locations that exists under `git_dir`.
+///
+/// Split out from [`bundled_git_ca_bundle`] so the candidate order can be
+/// unit-tested without a Tauri `AppHandle` or a real bundle on disk, the same
+/// split-the-logic pattern [`path_with_prepended`] uses. Joined component by
+/// component so the path is correct (and the test runs) on any OS.
+// Reached outside tests only through bundled_git_ca_bundle, which is Windows only.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+fn first_existing_ca_bundle(git_dir: &Path) -> Option<PathBuf> {
+    GIT_CA_BUNDLE_RELATIVE.iter().find_map(|components| {
+        let mut candidate = git_dir.to_path_buf();
+        candidate.extend(*components);
+        candidate.exists().then_some(candidate)
+    })
+}
+
+/// The bundled MinGit CA bundle, if present.
+///
+/// MinGit ships a CA bundle at `mingw64/etc/ssl/certs/ca-bundle.crt` (with a
+/// duplicate at `mingw64/ssl/certs/ca-bundle.crt`). [`ensure_git_on_path`] pins
+/// `GIT_SSL_CAINFO` at it so HTTPS clones validate against the bundled bundle
+/// instead of whatever `http.sslCAInfo` the ambient git config names (#350).
+#[cfg(target_os = "windows")]
+fn bundled_git_ca_bundle(app_handle: &AppHandle) -> Result<Option<PathBuf>> {
+    let resource_dir = get_bundled_resource_dir(app_handle)?;
+    Ok(first_existing_ca_bundle(&resource_dir.join("git")))
+}
+
 /// Directory inside the bundled `ccache` resource that holds `ccache.exe`.
 ///
 /// `prepare_bundle.sh` extracts a single static `ccache.exe` into `ccache/`.
@@ -364,11 +400,17 @@ fn prepend_bundled_tool(
 /// add the complexity of preferring (and validating) whatever git a user
 /// happens to have.
 ///
+/// It also pins `GIT_SSL_CAINFO` at MinGit's own bundled CA bundle so HTTPS
+/// clones don't depend on the ambient git SSL configuration (issue #350),
+/// inherited by the daemon the same way `PATH` is.
+///
 /// No-op on macOS (the Command Line Tools prompt covers a missing git) and
 /// Linux (git ships on all but the most minimal installs).
 pub fn ensure_git_on_path(app_handle: &AppHandle) -> Result<()> {
     #[cfg(target_os = "windows")]
     {
+        use tracing::{info, warn};
+
         let git_dir = get_bundled_git_dir(app_handle)?;
         if !prepend_bundled_tool(
             &git_dir,
@@ -391,6 +433,30 @@ pub fn ensure_git_on_path(app_handle: &AppHandle) -> Result<()> {
             "patch",
             "micro-opus and other components that need `patch` will fail to build",
         )?;
+
+        // Pin GIT_SSL_CAINFO to MinGit's own bundled CA bundle so HTTPS clones
+        // validate against it rather than whatever `http.sslCAInfo` the ambient
+        // git config happens to name (issue #350). A machine-wide config left
+        // by a previously-installed, since-removed Git for Windows survives the
+        // uninstall and can point sslCAInfo at a `C:/Program Files/Git/...`
+        // ca-bundle.crt that no longer exists; MinGit's OpenSSL backend then
+        // fails every fetch with "error adding trust anchors from file". The env
+        // var overrides every config file, so the bundled git always finds the
+        // bundled bundle. Log-and-continue if it is somehow absent; an ambient
+        // config may still work.
+        match bundled_git_ca_bundle(app_handle)? {
+            Some(ca_bundle) => {
+                std::env::set_var("GIT_SSL_CAINFO", &ca_bundle);
+                info!(
+                    "Pinned GIT_SSL_CAINFO to bundled CA bundle at {:?}",
+                    ca_bundle
+                );
+            }
+            None => warn!(
+                "Bundled MinGit CA bundle not found; HTTPS clones will rely on \
+                 the ambient git SSL configuration"
+            ),
+        }
     }
 
     #[cfg(not(target_os = "windows"))]
@@ -663,6 +729,26 @@ mod tests {
                 PathBuf::from("/usr/bin"),
             ],
         );
+    }
+
+    #[test]
+    fn first_existing_ca_bundle_prefers_etc_then_falls_back() {
+        let git_dir = unique_temp_dir("ca-bundle");
+        let etc = git_dir.join("mingw64/etc/ssl/certs/ca-bundle.crt");
+        let plain = git_dir.join("mingw64/ssl/certs/ca-bundle.crt");
+
+        // Neither present: nothing to point GIT_SSL_CAINFO at.
+        assert_eq!(first_existing_ca_bundle(&git_dir), None);
+
+        // Only the non-`etc` variant: fall back to it.
+        std::fs::create_dir_all(plain.parent().unwrap()).unwrap();
+        std::fs::write(&plain, b"").unwrap();
+        assert_eq!(first_existing_ca_bundle(&git_dir), Some(plain.clone()));
+
+        // Both present: the `etc` variant MinGit's own gitconfig names wins.
+        std::fs::create_dir_all(etc.parent().unwrap()).unwrap();
+        std::fs::write(&etc, b"").unwrap();
+        assert_eq!(first_existing_ca_bundle(&git_dir), Some(etc));
     }
 
     #[test]

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -218,26 +218,25 @@ pub fn get_bundled_patch_dir(app_handle: &AppHandle) -> Result<PathBuf> {
 
 /// MinGit's CA-bundle locations relative to the `git` resource dir, in the order
 /// MinGit's own `etc/gitconfig` and layout prefer. `prepare_bundle.sh` extracts
-/// the MinGit tree whole, so one of these is always shipped.
-const GIT_CA_BUNDLE_RELATIVE: [&[&str]; 2] = [
-    &["mingw64", "etc", "ssl", "certs", "ca-bundle.crt"],
-    &["mingw64", "ssl", "certs", "ca-bundle.crt"],
+/// the MinGit tree whole, so one of these is always shipped. `Path::join` treats
+/// `/` as a separator on Windows too, so these resolve correctly on every OS.
+const GIT_CA_BUNDLE_RELATIVE: [&str; 2] = [
+    "mingw64/etc/ssl/certs/ca-bundle.crt",
+    "mingw64/ssl/certs/ca-bundle.crt",
 ];
 
 /// First of MinGit's CA-bundle locations that exists under `git_dir`.
 ///
 /// Split out from [`bundled_git_ca_bundle`] so the candidate order can be
 /// unit-tested without a Tauri `AppHandle` or a real bundle on disk, the same
-/// split-the-logic pattern [`path_with_prepended`] uses. Joined component by
-/// component so the path is correct (and the test runs) on any OS.
+/// split-the-logic pattern [`path_with_prepended`] uses.
 // Reached outside tests only through bundled_git_ca_bundle, which is Windows only.
 #[cfg_attr(not(target_os = "windows"), allow(dead_code))]
 fn first_existing_ca_bundle(git_dir: &Path) -> Option<PathBuf> {
-    GIT_CA_BUNDLE_RELATIVE.iter().find_map(|components| {
-        let mut candidate = git_dir.to_path_buf();
-        candidate.extend(*components);
-        candidate.exists().then_some(candidate)
-    })
+    GIT_CA_BUNDLE_RELATIVE
+        .into_iter()
+        .map(|relative| git_dir.join(relative))
+        .find(|candidate| candidate.exists())
 }
 
 /// The bundled MinGit CA bundle, if present.


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

On Windows the bundled MinGit does HTTPS clones (remote_package, external components, ESP-IDF managed components) with its OpenSSL backend, which needs a CA bundle. MinGit ships one and its own gitconfig points at it, but that pointer is overridable; a machine wide git config left behind by a since removed Git for Windows install (it survives the uninstall) can set `http.sslCAInfo` to a `C:/Program Files/Git/...ca-bundle.crt` that no longer exists, and then every clone fails with "error adding trust anchors from file" (issue #350).

The fix sets `GIT_SSL_CAINFO` to MinGit's own bundled CA bundle in `ensure_git_on_path`, next to where the bundled git is already put on PATH; the env var overrides every config file, so the bundled git validates against the bundled bundle no matter what the ambient config says. The daemon inherits it the same way it inherits PATH.

One trade off worth calling out; `GIT_SSL_CAINFO` also overrides a user's own global `http.sslCAInfo`, so someone who intentionally points git at a corporate CA in a config file would now be pinned to the bundled bundle. Those setups normally install the CA into the Windows cert store, which the schannel backend uses and which this does not touch, so the common broken leftover case this fixes is far more likely than that edge case.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes https://github.com/esphome/esphome-desktop/issues/350

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).
