### PR TITLE
Fix two silent failure modes in the macOS CLI wrapper install

### DIFF
--- a/src-tauri/src/platform/macos.rs
+++ b/src-tauri/src/platform/macos.rs
@@ -52,8 +52,14 @@ enum CommandOutcome {
 /// without a shell command. Skipped for non-bundled dev builds, whose
 /// `target/` path would go stale.
 fn install_cli_command() {
-    let Ok(exe) = std::env::current_exe() else {
-        return;
+    let exe = match std::env::current_exe() {
+        Ok(exe) => exe,
+        Err(e) => {
+            tracing::debug!(
+                "Could not determine current executable; skipping CLI command install: {e}"
+            );
+            return;
+        }
     };
     if app_bundle_path().is_none() {
         tracing::debug!("Not running from an .app bundle; skipping CLI command install");
@@ -129,15 +135,25 @@ fn try_install_command_in(dir: &std::path::Path, script: &str) -> std::io::Resul
             // Dangling link: litter nothing can use; reclaim the name.
             std::fs::remove_file(&path)?;
         }
-        Ok(meta) if meta.is_file() => {
-            let existing = std::fs::read_to_string(&path).unwrap_or_default();
-            if !existing.contains(CLI_MARKER) {
+        Ok(meta) if meta.is_file() => match std::fs::read_to_string(&path) {
+            Ok(existing) => {
+                if !existing.contains(CLI_MARKER) {
+                    return Ok(CommandOutcome::Foreign);
+                }
+                if existing == script {
+                    return Ok(CommandOutcome::AlreadyInstalled);
+                }
+            }
+            // Not valid UTF-8: it can't be our ASCII wrapper, so it is
+            // genuinely someone else's file; leave it alone.
+            Err(e) if e.kind() == std::io::ErrorKind::InvalidData => {
                 return Ok(CommandOutcome::Foreign);
             }
-            if existing == script {
-                return Ok(CommandOutcome::AlreadyInstalled);
-            }
-        }
+            // A transient failure (permissions, EIO) on a file that may
+            // well be ours: propagate so the caller logs it and tries the
+            // next candidate dir, instead of misreporting it as foreign.
+            Err(e) => return Err(e),
+        },
         Ok(_) => return Ok(CommandOutcome::Foreign),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
         Err(e) => return Err(e),
@@ -335,6 +351,54 @@ mod tests {
             fs::read_to_string(bin.join(CLI_NAME)).expect("read"),
             "someone else's binary"
         );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn non_utf8_file_is_left_alone() {
+        // A real foreign binary is not valid UTF-8; it still can't be our
+        // ASCII wrapper, so it must be treated as foreign and untouched.
+        let dir = unique_temp_dir("non_utf8");
+        let bin = bin_dir(&dir);
+        let bytes = [0xffu8, 0xfe, 0x00];
+        fs::write(bin.join(CLI_NAME), bytes).expect("foreign binary");
+        let script = wrapper_script(Path::new(
+            "/Applications/A.app/Contents/MacOS/esphome-desktop",
+        ));
+
+        assert!(matches!(
+            try_install_command_in(&bin, &script),
+            Ok(CommandOutcome::Foreign)
+        ));
+        assert_eq!(fs::read(bin.join(CLI_NAME)).expect("read"), bytes);
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn unreadable_wrapper_is_propagated_not_foreign() {
+        // A transient read failure on a same-named file must propagate as an
+        // error, not collapse to Foreign (which would abandon the remaining
+        // candidate dirs on a misleading "not this app's wrapper" log).
+        use std::os::unix::fs::PermissionsExt;
+        let dir = unique_temp_dir("unreadable");
+        let bin = bin_dir(&dir);
+        let path = bin.join(CLI_NAME);
+        fs::write(&path, "anything").expect("write");
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o000)).expect("chmod");
+        let script = wrapper_script(Path::new(
+            "/Applications/A.app/Contents/MacOS/esphome-desktop",
+        ));
+
+        // Root bypasses the mode bits, so the unreadable scenario can't be
+        // exercised there; skip rather than fail.
+        if fs::read_to_string(&path).is_ok() {
+            let _ = fs::remove_dir_all(&dir);
+            return;
+        }
+
+        assert!(try_install_command_in(&bin, &script).is_err());
 
         let _ = fs::remove_dir_all(&dir);
     }


### PR DESCRIPTION
# What does this implement/fix?

Two silent failure modes in the macOS `esphome-desktop` shell command install.

When an existing same-named file was read, a transient failure (permissions, EIO) was collapsed to an empty string via `unwrap_or_default`; that misses the marker, so it was classified `Foreign`, the caller logged the misleading "exists and is not this app's wrapper", and it gave up on the remaining candidate dirs. The read result is now matched; non UTF-8 content is still treated as `Foreign` (a real foreign binary), while any other IO error propagates so the caller logs it and moves on to the next dir.

The `current_exe()` bail-out at the top of the install returned with nothing in the log, unlike every other early return in that function; it now logs at debug before returning.

Added tests cover the non UTF-8 case and the unreadable-file propagation; the unreadable test self skips when run as root, where the mode bits are bypassed.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes https://github.com/esphome/esphome-desktop/issues/349

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).
