### PR TITLE
Document the Windows python spelling for the script tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,9 @@ ruff format --check .
 python3 -m pytest tests/ -v
 ```
 
+On Windows, spell these `python` or `py -m` rather than `python3` — a python.org
+install puts `python.exe` and `py.exe` on PATH but no `python3.exe`.
+
 ---
 
 [![ESPHome - A project from the Open Home Foundation](https://www.openhomefoundation.org/badges/esphome.png)](https://www.openhomefoundation.org/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,8 +66,9 @@ ruff format --check .
 python3 -m pytest tests/ -v
 ```
 
-On Windows, spell these `python` or `py -m` rather than `python3` — a python.org
-install puts `python.exe` and `py.exe` on PATH but no `python3.exe`.
+On Windows, use `py -m` rather than `python3`; a python.org install never ships a
+`python3.exe`, and the `py` launcher is the reliable spelling there (plain
+`python` works only if you added it to PATH during install).
 
 ---
 


### PR DESCRIPTION
# What does this implement/fix?

The "Running the Python script tests locally" section told contributors to run `python3`, but a python.org install on Windows puts `python.exe` and `py.exe` on PATH and no `python3.exe`; a Windows contributor hits "command not found" on the first line and reads it as having no Python rather than as the docs naming the wrong binary. This adds a short note that on Windows the commands are spelled `python` or `py -m`, matching the python on Windows hint already on the file size check line. Docs only; CI is unaffected since `Scripts Test` uses actions/setup-python which provides a real `python3` on every runner.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue (if applicable):**

- fixes https://github.com/esphome/esphome-desktop/issues/345

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).
