### PR TITLE
e2e: exercise the pinned-version restore through a real pip install

### DIFF
--- a/.github/workflows/python-tree-repair.yml
+++ b/.github/workflows/python-tree-repair.yml
@@ -11,8 +11,11 @@ name: Python Tree Repair
 # What it proves, in one pass: the first-run copy of a freshly built bundle is
 # self-contained and healthy; an orphaned component directory (exactly what the
 # removed `--ignore-installed` fallback left behind, and what broke every
-# compile on 2026.7) fails the health probe; and the repair re-copy removes it
-# with no network.
+# compile on 2026.7) fails the health probe; the repair re-copy removes it with
+# no network; and a refresh from an older bundle does not silently downgrade a
+# newer esphome the tree already had — the restore reinstalls it through a real
+# `pip install` (#353). That last leg is why the job needs PyPI; the repair
+# itself stays offline.
 #
 # A venv would be cheaper but would not do: on Windows a venv puts python.exe in
 # Scripts\ while the real bundle has it at the tree root, so the layout the copy

--- a/.github/workflows/python-tree-repair.yml
+++ b/.github/workflows/python-tree-repair.yml
@@ -102,10 +102,16 @@ jobs:
         # would turn this job green while proving nothing — the whole point of it
         # being here; this job is the only evidence that a real command sees the
         # orphan.
+        #
+        # The match stops before the verdict: the restore leg's pip child
+        # inherits the job's stdout (production pipes only its stderr), so its
+        # output lands between the harness's "test ... " prefix and the closing
+        # "ok" and the two never share a line. Running-but-failing is already
+        # covered — the pipeline's exit code fails the step before the grep.
         run: |
           set -o pipefail
           cargo test --all-features -- --ignored --test-threads=1 --nocapture 2>&1 | tee result.log
-          grep -q 'test platform::tests::e2e_repair_cycle ... ok' result.log || {
+          grep -qF 'test platform::tests::e2e_repair_cycle ...' result.log || {
             echo "::error::e2e_repair_cycle did not run; this job proved nothing"
             exit 1
           }

--- a/.github/workflows/python-tree-repair.yml
+++ b/.github/workflows/python-tree-repair.yml
@@ -115,3 +115,9 @@ jobs:
             echo "::error::e2e_repair_cycle did not run; this job proved nothing"
             exit 1
           }
+          # The prefix also matches the "... ignored" listing a run without
+          # `--ignored` would print, so reject that verdict explicitly.
+          if grep -qF 'test platform::tests::e2e_repair_cycle ... ignored' result.log; then
+            echo "::error::e2e_repair_cycle was listed as ignored, not run"
+            exit 1
+          fi

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -983,7 +983,8 @@ mod tests {
 
     /// The whole repair lifecycle against a real bundled Python tree: the
     /// first-run copy, detect the orphan, wipe and re-copy from the pristine
-    /// bundle, prove it is fixed.
+    /// bundle, prove it is fixed, then prove a refresh from an older bundle
+    /// restores the newer version the user tree already had.
     ///
     /// Ignored by default because it needs the genuine article — the
     /// python-build-standalone tree with esphome in it that
@@ -996,10 +997,13 @@ mod tests {
     /// [`interpreter_in_tree`]/[`python_tree_root`] would go untested against
     /// what we actually ship. This uses the shipped layout.
     ///
-    /// No leg forces the pinned-version restore through pip: that would need a
-    /// PyPI release newer than the tree the workflow just built, which
-    /// generally does not exist. The snapshot and the compare-and-skip half of
-    /// the restore still run for real in the repair leg below.
+    /// The final leg forces the pinned-version restore through a real
+    /// `pip install` (#353). Nothing newer than the tree the workflow just
+    /// built exists on PyPI to pin the user tree to, so the version asymmetry
+    /// is built from the other side: a second bundle source, copied from the
+    /// first and pip-downgraded, so the snapshot beats the incoming bundle and
+    /// the restore must reinstall. The repair leg itself stays offline; the
+    /// downgrade and the restore are where this test reaches PyPI.
     ///
     /// One test rather than several because each step depends on the last
     /// leaving the tree in a particular state, and Rust does not order tests.
@@ -1101,6 +1105,73 @@ mod tests {
         );
         let (ok, out) = e2e_run(&python, &["-m", "esphome", "version"]);
         assert!(ok, "esphome does not run after the repair: {out}");
+
+        // 8. Build a second bundle source that is older than the user tree:
+        //    copy the pristine bundle, then downgrade esphome inside the copy.
+        //    `--no-deps` keeps the copy on the current dependency set, so the
+        //    restore in step 9 resolves against already-satisfied deps and
+        //    fetches exactly one wheel.
+        let current = python_env::read_package_version(&python, "esphome")
+            .expect("could not probe the user tree's esphome version")
+            .expect("esphome missing from the user tree");
+        let old_bundle = base.join("old-bundle");
+        python_env::copy_dir_recursive(&bundle, &old_bundle)
+            .expect("could not copy the bundle to a second source");
+        let old_python = interpreter_in_tree(&old_bundle);
+        let downgrade_spec = format!("esphome<{current}");
+        let (ok, out) = e2e_run(
+            &old_python,
+            &["-m", "pip", "install", "--no-deps", downgrade_spec.as_str()],
+        );
+        assert!(
+            ok,
+            "could not downgrade esphome in the second source: {out}"
+        );
+        let downgraded = python_env::read_package_version(&old_python, "esphome")
+            .expect("could not probe the downgraded source")
+            .expect("esphome missing from the downgraded source");
+        // The test's premise, checked with the comparator the restore uses.
+        assert!(
+            crate::update::is_newer_version(&current, &downgraded),
+            "the downgrade produced {downgraded}, which is not older than {current}"
+        );
+
+        // 9. Refresh from the older source. The snapshot reads the newer
+        //    version from the user tree, the copy lands the older one, and the
+        //    restore must notice the downgrade and pip-reinstall the newer
+        //    from PyPI — the one branch of the refresh the offline legs above
+        //    cannot reach.
+        python_env::refresh_python_tree(
+            &user_tree,
+            || Ok(old_bundle.clone()),
+            RefreshReason::Repair,
+        )
+        .expect("refresh from the downgraded source failed");
+
+        // 10. No silent downgrade. The restore is deliberately best-effort in
+        //     production (a failed pip install only warns and keeps the
+        //     bundled version), so this read is the only place a restore
+        //     failure can surface.
+        let restored = python_env::read_package_version(&python, "esphome")
+            .expect("could not probe the user tree after the restore")
+            .expect("esphome missing after the restore");
+        assert_eq!(
+            restored, current,
+            "the refresh downgraded esphome; if this reads {downgraded}, the pip \
+             reinstall of {current} failed (PyPI unreachable?) and the restore \
+             warning above says why"
+        );
+        assert_eq!(
+            esphome_config_probe(&python).expect("probe could not run"),
+            None,
+            "the tree is broken after the restore"
+        );
+        let (ok, out) = e2e_run(&python, &["-m", "esphome", "version"]);
+        assert!(ok, "esphome does not run after the restore: {out}");
+        assert!(
+            out.contains(&current),
+            "esphome reports a version other than {current} after the restore: {out}"
+        );
 
         let _ = std::fs::remove_dir_all(&base);
     }

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -963,6 +963,25 @@ mod tests {
     fn e2e_run(python: &Path, args: &[&str]) -> (bool, String) {
         let output = run_python_capture(python, args)
             .unwrap_or_else(|e| panic!("failed to run {python:?} {args:?}: {e}"));
+        e2e_verdict(output)
+    }
+
+    /// [`e2e_run`] with the pip env isolation production pip calls layer on
+    /// top ([`process::isolate_pip_command`]). The interpreter isolation alone
+    /// is not enough for a pip invocation: an ambient `PIP_REQUIRE_VIRTUALENV`
+    /// would fail the install, and a `PIP_TARGET`/`PIP_PREFIX` would aim it
+    /// outside the tree under test.
+    fn e2e_pip(python: &Path, args: &[&str]) -> (bool, String) {
+        let mut cmd = process::python_command(python, args);
+        process::isolate_pip_command(&mut cmd);
+        let output = cmd
+            .output()
+            .unwrap_or_else(|e| panic!("failed to run {python:?} {args:?}: {e}"));
+        e2e_verdict(output)
+    }
+
+    /// Collapse a finished child to (success, stdout+stderr).
+    fn e2e_verdict(output: std::process::Output) -> (bool, String) {
         let mut combined = String::from_utf8_lossy(&output.stdout).into_owned();
         combined.push_str(&String::from_utf8_lossy(&output.stderr));
         (output.status.success(), combined)
@@ -1119,7 +1138,7 @@ mod tests {
             .expect("could not copy the bundle to a second source");
         let old_python = interpreter_in_tree(&old_bundle);
         let downgrade_spec = format!("esphome<{current}");
-        let (ok, out) = e2e_run(
+        let (ok, out) = e2e_pip(
             &old_python,
             &["-m", "pip", "install", "--no-deps", downgrade_spec.as_str()],
         );

--- a/src-tauri/src/platform/process.rs
+++ b/src-tauri/src/platform/process.rs
@@ -272,7 +272,7 @@ pub(super) fn run_python_capture_bounded<S: AsRef<OsStr>>(
 ///
 /// One home for that setup, so "every Python we spawn is isolated" is a property
 /// of the builder rather than something each caller has to remember.
-fn python_command<S: AsRef<OsStr>>(
+pub(super) fn python_command<S: AsRef<OsStr>>(
     python: &Path,
     args: impl IntoIterator<Item = S>,
 ) -> std::process::Command {

--- a/src-tauri/src/platform/python_env.rs
+++ b/src-tauri/src/platform/python_env.rs
@@ -385,7 +385,7 @@ fn restore_preserved_versions(python_bin: &Path, preserved: &PreservedVersions) 
 ///   from "not installed": callers that snapshot versions before a destructive
 ///   refresh must not treat a flaky probe as "absent" — see
 ///   [`snapshot_preserved_versions`].
-fn read_package_version(python_bin: &Path, package: &str) -> Result<Option<String>> {
+pub(super) fn read_package_version(python_bin: &Path, package: &str) -> Result<Option<String>> {
     // Written as a single-line literal with explicit `\n` so each Python
     // statement starts at column zero — avoids any ambiguity about whether
     // a Rust line-continuation strips the source-line indentation. A clean
@@ -438,7 +438,7 @@ fn parse_probe_output(
 /// copy, flattened the framework layout, and — for a *dangling* link — made
 /// `fs::copy` fail with "No such file", aborting the entire copy and leaving the
 /// app unable to start.
-fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
+pub(super) fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
     use std::fs;
 
     if !dst.exists() {


### PR DESCRIPTION
# What does this implement/fix?

The repair e2e now exercises the pinned-version restore through a real `pip install`, the one branch of `refresh_python_tree` no CI leg reached after #352 (the code that decides whether a user gets silently downgraded).

Nothing newer than the tree the workflow just built exists on PyPI to pin the user tree to, so the version asymmetry is built from the other side: the test copies the pristine bundle to a second source, pip-downgrades esphome inside it with `--no-deps`, then refreshes the user tree from that older source. The snapshot reads the newer version, the copy lands the older one, and the restore must reinstall the newer from PyPI. Reading the version back afterwards is the assert; the restore deliberately only warns on failure, so that read is the only place a silent downgrade could surface.

Production changes are limited to two helpers going `pub(super)` (`copy_dir_recursive`, `read_package_version`) so the test drives the same code the app runs; the test keeps its exact name, which the workflow grep pins; the workflow header now scopes the "no network" claim to the repair re-copy, since the downgrade and restore legs reach PyPI.

Local run on macos-arm64 against a fresh `prepare_bundle.sh` tree: the downgraded source held esphome 2026.6.5, the refresh copied it in, and the restore reinstalled 2026.7.0; the leg adds about 20s.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes https://github.com/esphome/esphome-desktop/issues/353

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tested on the relevant platform(s) (macOS, Windows, Linux).
