### PR TITLE
Skip the build matrix and Rust checks on docs only pull requests

### DIFF
--- a/.github/scripts/determine_jobs.py
+++ b/.github/scripts/determine_jobs.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Determine which CI jobs to run for a pull request from its changed files.
+
+Emits JSON to stdout, e.g. ``{"build": true, "lint_test": true}``. Both
+``build.yml`` and ``lint-test.yml`` read this to skip their expensive jobs on a
+pull request that only touches documentation or repo meta files, so a docs-only
+PR no longer spends ~60 minutes in the Tauri build matrix. The four required
+``Build *`` checks are replaced in branch protection by a single ``CI Status``
+aggregate that treats a skipped build as a pass, so skipping never blocks the
+merge.
+
+The bias is one-directional on purpose: a job is skipped only when *every*
+changed file is provably CI-irrelevant (the conservative allowlist below), and
+any error determining the changed set falls back to running everything. A real
+code change can therefore never be skipped by mistake; the worst case is running
+CI that was not strictly needed.
+
+Usage:
+  python determine_jobs.py
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_HERE = str(Path(__file__).resolve().parent)
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
+
+from _gha import warn  # noqa: E402
+
+# fnmatch globs (matched against a POSIX, repo-relative path) whose sole
+# presence in a PR's diff means the Rust build and the lint/test gate add no
+# signal. fnmatch's ``*`` spans ``/``, so ``*.md`` matches markdown at any depth.
+#
+# Deliberately conservative. Image and icon assets are omitted because
+# src-tauri/icons feeds the build; workflow and dependabot files are omitted
+# because a CI or dependency change must still build and test. When in doubt a
+# path is NOT listed here, so it counts as code and runs CI.
+META_ONLY_GLOBS = (
+    "*.md",
+    "LICENSE",
+    ".gitignore",
+    ".github/FUNDING.yml",
+    ".github/ISSUE_TEMPLATE/*",
+)
+
+
+def is_meta_only(path: str) -> bool:
+    """True if this single path is a documentation or repo-meta file."""
+    return any(fnmatch.fnmatch(path, glob) for glob in META_ONLY_GLOBS)
+
+
+def determine(changed: list[str]) -> dict[str, bool]:
+    """Classify a set of changed repo-relative paths into per-job booleans.
+
+    Pure so it can be unit tested without git or the GitHub API. An empty set
+    (nothing detected) runs everything, matching the fail-safe bias.
+    """
+    run = (not changed) or any(not is_meta_only(path) for path in changed)
+    # build.yml and lint-test.yml read these independently; keeping them as
+    # separate keys lets the two gates diverge later without a workflow change.
+    return {"build": run, "lint_test": run}
+
+
+def _pr_number() -> str | None:
+    """The pull request number from the GitHub Actions event payload, if any."""
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    if not event_path or not os.path.exists(event_path):
+        return None
+    with open(event_path, encoding="utf-8") as handle:
+        event = json.load(handle)
+    number = event.get("pull_request", {}).get("number")
+    return str(number) if number is not None else None
+
+
+def _run(cmd: list[str]) -> list[str]:
+    out = subprocess.run(cmd, capture_output=True, text=True, check=True).stdout
+    return [line for line in out.splitlines() if line]
+
+
+def changed_files() -> list[str]:
+    """Best-effort list of the PR's changed files, repo-relative POSIX paths.
+
+    Uses ``gh pr diff`` in Actions (with the paginated files API as a fallback
+    for very large PRs), and a local ``git`` merge-base diff otherwise. Any
+    failure raises to the caller, which turns it into a run-everything result.
+    """
+    if os.environ.get("GITHUB_ACTIONS") == "true" and (pr := _pr_number()):
+        try:
+            return _run(["gh", "pr", "diff", pr, "--name-only"])
+        except subprocess.CalledProcessError as err:
+            # gh refuses diffs over 300 files; fall back to the files API.
+            if "maximum" not in (err.stderr or ""):
+                raise
+            repo = os.environ["GITHUB_REPOSITORY"]
+            return _run(
+                [
+                    "gh",
+                    "api",
+                    f"repos/{repo}/pulls/{pr}/files",
+                    "--paginate",
+                    "--jq",
+                    ".[].filename",
+                ]
+            )
+
+    base = os.environ.get("GITHUB_BASE_REF") or "main"
+    merge_base = _run(["git", "merge-base", f"origin/{base}", "HEAD"])[0]
+    return _run(["git", "diff", "--name-only", f"{merge_base}...HEAD"])
+
+
+def main() -> int:
+    try:
+        changed = changed_files()
+    except Exception as err:  # noqa: BLE001 - detection must fail safe
+        warn(f"Could not determine changed files ({err}); running all CI jobs")
+        changed = []
+    print(json.dumps(determine(changed)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/determine_jobs.py
+++ b/.github/scripts/determine_jobs.py
@@ -15,6 +15,14 @@ any error determining the changed set falls back to running everything. A real
 code change can therefore never be skipped by mistake; the worst case is running
 CI that was not strictly needed.
 
+Trust boundary: the workflow runs THIS script from the pull request's own
+checkout, so a diff that edits the classifier or widens ``META_ONLY_GLOBS`` can
+make CI Status pass without building. The fail-safe guarantee above holds only
+for the unmodified script; a diff touching this file is exactly what deserves
+extra scrutiny in review. That is acceptable because pull_request runs with a
+read-only token and no secrets, and the classifier change is always visible in
+the reviewed diff, which is the real backstop (same posture as esphome/esphome).
+
 Usage:
   python determine_jobs.py
 """

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,33 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # On pull requests, decide whether the build matrix needs to run at all. A PR
+  # that only touches documentation or repo meta files skips it (the logic and
+  # its fail-safe bias live in .github/scripts/determine_jobs.py). The CI Status
+  # job below turns a skipped build into a passing required check, so a docs-only
+  # PR merges without paying for the ~60 minute matrix. Non-PR events (the
+  # release workflow_run, a manual dispatch) skip this job and build regardless.
+  determine-jobs:
+    name: Determine jobs
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      build: ${{ steps.determine.outputs.build }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Determine jobs
+        id: determine
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          output=$(python3 .github/scripts/determine_jobs.py)
+          echo "$output" | jq
+          echo "build=$(echo "$output" | jq -r '.build')" >> "$GITHUB_OUTPUT"
+
   # Release builds embed every translated locale (src-tauri/build.rs picks up
   # whatever JSON files sit in src-tauri/translations/ at compile time). The
   # download runs in its own small job so the Lokalise API token is only ever
@@ -80,10 +107,11 @@ jobs:
     # must block the release rather than silently shipping English-only
     # binaries. PR/dispatch builds run regardless (translations is skipped
     # there, hence the `always()`).
-    needs: translations
+    needs: [translations, determine-jobs]
     if: >-
       always() && (
-        (github.event_name != 'workflow_run' && needs.translations.result == 'skipped') ||
+        (github.event_name == 'pull_request' && needs.translations.result == 'skipped' && needs.determine-jobs.outputs.build == 'true') ||
+        (github.event_name == 'workflow_dispatch' && needs.translations.result == 'skipped') ||
         (github.event.workflow_run.conclusion == 'success' && needs.translations.result == 'success')
       )
     permissions:
@@ -571,6 +599,30 @@ jobs:
         with:
           path: pr-info.json
           archive: false
+
+  # The single required status check for pull requests. Branch protection
+  # requires this instead of the individual "Build *" matrix legs: a docs-only PR
+  # skips the build job entirely (see determine-jobs), and a skipped matrix leg
+  # never reports its own named check, so requiring those names directly would
+  # leave a docs-only PR waiting forever. This aggregates the PR jobs and passes
+  # only when each one succeeded or was skipped, so a skipped build still merges
+  # while a real build failure (or a cancelled run) blocks the merge.
+  ci-status:
+    name: CI Status
+    if: always() && github.event_name == 'pull_request'
+    needs:
+      - determine-jobs
+      - build
+      - pr-info
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Check job results
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          echo "$NEEDS_JSON" | jq
+          echo "$NEEDS_JSON" | jq -e 'all(.result == "success" or .result == "skipped")'
 
   release:
     needs: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # determine_jobs.py reads the PR's changed files via `gh pr diff`; without
+      # pull-requests:read the token is denied, the script fails safe to
+      # run-everything, and the docs-only skip silently never happens.
+      pull-requests: read
     outputs:
       build: ${{ steps.determine.outputs.build }}
     steps:

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -59,7 +59,11 @@ jobs:
     name: Rust lint & test
     needs: determine-jobs
     # Run on a manual dispatch regardless; on a PR, only when code changed.
-    if: github.event_name != 'pull_request' || needs.determine-jobs.outputs.lint_test == 'true'
+    # always() is required: determine-jobs is PR-only, so on workflow_dispatch it
+    # is skipped, and without a status function the needs edge would skip this
+    # job too (GitHub skips a dependent when a needed job is skipped unless its
+    # if uses always()/!cancelled()).
+    if: always() && (github.event_name != 'pull_request' || needs.determine-jobs.outputs.lint_test == 'true')
     runs-on: ubuntu-22.04
     permissions:
       contents: read
@@ -146,7 +150,9 @@ jobs:
     name: Rust lint & test (${{ matrix.os }})
     needs: determine-jobs
     # Run on a manual dispatch regardless; on a PR, only when code changed.
-    if: github.event_name != 'pull_request' || needs.determine-jobs.outputs.lint_test == 'true'
+    # always() is required (see the note on the lint-test job above): without it,
+    # the skipped PR-only determine-jobs would skip this job on workflow_dispatch.
+    if: always() && (github.event_name != 'pull_request' || needs.determine-jobs.outputs.lint_test == 'true')
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -21,8 +21,36 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # On pull requests, skip the Rust lint/test jobs when the PR only touches
+  # documentation or repo meta files (see .github/scripts/determine_jobs.py).
+  # These jobs are not required checks, so a skip simply reports nothing and
+  # never blocks a merge; non-PR events skip this job and run unconditionally.
+  determine-jobs:
+    name: Determine jobs
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      lint_test: ${{ steps.determine.outputs.lint_test }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Determine jobs
+        id: determine
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          output=$(python3 .github/scripts/determine_jobs.py)
+          echo "$output" | jq
+          echo "lint_test=$(echo "$output" | jq -r '.lint_test')" >> "$GITHUB_OUTPUT"
+
   lint-test:
     name: Rust lint & test
+    needs: determine-jobs
+    # Run on a manual dispatch regardless; on a PR, only when code changed.
+    if: github.event_name != 'pull_request' || needs.determine-jobs.outputs.lint_test == 'true'
     runs-on: ubuntu-22.04
     permissions:
       contents: read
@@ -107,6 +135,9 @@ jobs:
   # something this file can do.
   lint-test-cross:
     name: Rust lint & test (${{ matrix.os }})
+    needs: determine-jobs
+    # Run on a manual dispatch regardless; on a PR, only when code changed.
+    if: github.event_name != 'pull_request' || needs.determine-jobs.outputs.lint_test == 'true'
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -23,8 +23,13 @@ env:
 jobs:
   # On pull requests, skip the Rust lint/test jobs when the PR only touches
   # documentation or repo meta files (see .github/scripts/determine_jobs.py).
-  # These jobs are not required checks, so a skip simply reports nothing and
-  # never blocks a merge; non-PR events skip this job and run unconditionally.
+  #
+  # INVARIANT: these jobs must stay non-required checks. Unlike build.yml there
+  # is deliberately no CI Status aggregate here, so a docs-only PR (or a
+  # determine-jobs gate-job failure) just skips them with nothing reported. If
+  # any of these names is ever made a required check, that silent skip would
+  # hang the merge; add a CI Status style aggregate (as build.yml has) first.
+  # Non-PR events skip this gate and run the jobs unconditionally.
   determine-jobs:
     name: Determine jobs
     if: github.event_name == 'pull_request'

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -31,6 +31,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # determine_jobs.py reads the PR's changed files via `gh pr diff`; without
+      # pull-requests:read the token is denied, the script fails safe to
+      # run-everything, and the docs-only skip silently never happens.
+      pull-requests: read
     outputs:
       lint_test: ${{ steps.determine.outputs.lint_test }}
     steps:

--- a/tests/test_determine_jobs.py
+++ b/tests/test_determine_jobs.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Tests for .github/scripts/determine_jobs.py.
+
+This gate decides whether a pull request runs the ~60 minute Tauri build
+matrix and the Rust lint/test job, so the classifier's fail-safe bias is the
+property that matters: it may only report "skip" when every changed file is a
+documentation or repo-meta file, and must default to running CI for anything
+else (including an empty or undetectable change set).
+
+pytest suite, fully typed, no classes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from script_loader import load_script_module
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = load_script_module(REPO_ROOT / ".github" / "scripts" / "determine_jobs.py")
+
+
+def test_docs_only_pr_skips_both_jobs() -> None:
+    result = SCRIPT.determine(["CONTRIBUTING.md"])
+    assert result == {"build": False, "lint_test": False}
+
+
+def test_markdown_at_any_depth_counts_as_meta() -> None:
+    assert SCRIPT.is_meta_only("src-tauri/README.md")
+    assert not SCRIPT.determine(["docs/guide.md", "README.md"])["build"]
+
+
+def test_license_and_meta_files_are_docs_only() -> None:
+    for path in ("LICENSE", ".gitignore", ".github/FUNDING.yml"):
+        assert SCRIPT.is_meta_only(path), path
+    assert not SCRIPT.determine([".github/ISSUE_TEMPLATE/bug.yml"])["build"]
+
+
+def test_any_code_file_forces_a_run() -> None:
+    result = SCRIPT.determine(["src-tauri/src/platform/macos.rs"])
+    assert result == {"build": True, "lint_test": True}
+
+
+def test_mixed_docs_and_code_runs() -> None:
+    # A PR touching a real source file must run even alongside docs edits.
+    assert SCRIPT.determine(["CONTRIBUTING.md", "src-tauri/src/lib.rs"]) == {
+        "build": True,
+        "lint_test": True,
+    }
+
+
+def test_icon_and_workflow_files_are_not_treated_as_docs() -> None:
+    # src-tauri/icons feeds the build, and a workflow/dependabot change must
+    # still build and test, so none of these may be classified meta-only.
+    for path in (
+        "src-tauri/icons/icon.png",
+        ".github/workflows/build.yml",
+        ".github/dependabot.yml",
+    ):
+        assert not SCRIPT.is_meta_only(path), path
+        assert SCRIPT.determine([path])["build"], path
+
+
+def test_empty_change_set_fails_safe_to_running() -> None:
+    assert SCRIPT.determine([]) == {"build": True, "lint_test": True}


### PR DESCRIPTION
# What does this implement/fix?

A docs only pull request (like #355) still ran the full ~60 minute Tauri build matrix plus the Rust lint and test jobs, which is pure waste for a one line documentation change. This borrows the determine-jobs approach from esphome/esphome: a small `.github/scripts/determine_jobs.py` classifies the PR's changed files, and both `build.yml` and `lint-test.yml` gate their expensive jobs on its output.

The classifier is deliberately one directional; it reports skip only when every changed file is provably a docs or meta file (`*.md`, `LICENSE`, `.gitignore`, `.github/FUNDING.yml`, `.github/ISSUE_TEMPLATE/*`), and defaults to running everything on any other path, an empty change set, or any error resolving the diff. A real code change can therefore never be skipped by mistake; the worst case is running CI that was not strictly needed. Icon assets and workflow or dependabot files are intentionally not treated as docs since they affect the build.

Because a skipped matrix leg never reports its own named check, the four required `Build *` checks cannot stay required as is; a docs only PR would wait on them forever. They are replaced by a single `CI Status` job that aggregates the pull request jobs and passes when each one succeeded or was skipped, so a skipped build still merges while a real build failure or a cancelled run blocks it.

The `lint-test.yml` jobs (`Rust lint & test` and its cross platform variants) are intentionally not required checks, so gating them to skip cannot block a merge; they need no `CI Status` style aggregate, only the build side does. This is confirmed against the current ruleset, whose only required checks are the four `Build *` legs.

## Branch protection follow up

This needs a one time ruleset change after merge; require `CI Status` and drop the four `Build linux-x64`, `Build macos-arm64`, `Build macos-x64`, `Build windows-x64` checks. Until then a docs only PR would still be blocked on those four never reporting. This PR itself is not docs only, so the build runs and the current required checks pass normally.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue (if applicable):**

- N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).
