### PR TITLE
build: let prepare_bundle.sh stop after the Python tree

### DIFF
--- a/.github/workflows/python-tree-repair.yml
+++ b/.github/workflows/python-tree-repair.yml
@@ -82,10 +82,15 @@ jobs:
         uses: ./.github/actions/stub-bundle-dirs
 
       # The real thing: downloads python-build-standalone and installs esphome
-      # and esphome-device-builder into it. This is the release path, not a
-      # stand-in for it.
+      # and esphome-device-builder into it, through the same code path a
+      # release build runs. PREPARE_PYTHON_ONLY skips only the release tail
+      # the test never reads (the copy into src-tauri/python; the MinGit,
+      # patch.exe and ccache downloads on Windows) and leaves the stubbed
+      # resource dirs above alone (#336).
       - name: Build a real bundled Python tree
         shell: bash
+        env:
+          PREPARE_PYTHON_ONLY: 1
         run: ./build-scripts/prepare_bundle.sh ${{ matrix.target }}
 
       - name: Run the repair cycle

--- a/build-scripts/prepare_bundle.sh
+++ b/build-scripts/prepare_bundle.sh
@@ -10,6 +10,9 @@
 # Note: No venv is used to avoid absolute path issues in bundled executables
 #
 # Usage: ./prepare_bundle.sh [platform]
+#
+# PREPARE_PYTHON_ONLY=1 stops after step 2, leaving the tree in
+# build/python-<platform> and src-tauri/ untouched; see the check below.
 
 set -e
 
@@ -548,9 +551,24 @@ fi
 
 echo "=== Preparing ESPHome bundle for ${PLATFORM} ==="
 
+mkdir -p "$BUILD_DIR"
+
+# PREPARE_PYTHON_ONLY=1 stops once build/python-<platform> is ready: the same
+# tree, from the same code path, but without the release-only tail (the copy
+# into src-tauri/python; MinGit, patch.exe and ccache on Windows). Used by
+# python-tree-repair.yml, whose e2e reads only the build/ tree and which stubs
+# the src-tauri resource dirs itself; this path must not touch src-tauri/ at
+# all, or it would delete those stubs out from under the crate build (#336).
+if [[ "${PREPARE_PYTHON_ONLY:-0}" == "1" ]]; then
+    prepare_python_for_platform "$PLATFORM"
+    echo ""
+    echo "=== Python tree ready (PREPARE_PYTHON_ONLY) ==="
+    echo "Location: $BUILD_DIR/python-${PLATFORM}"
+    exit 0
+fi
+
 # Clean up previous builds
 rm -rf "$BUNDLE_DIR"
-mkdir -p "$BUILD_DIR"
 
 prepare_python_for_platform "$PLATFORM"
 prepare_git_for_platform "$PLATFORM"


### PR DESCRIPTION
# What does this implement/fix?

The python-tree-repair job runs `prepare_bundle.sh` but its e2e reads only `build/python-<target>`; everything after `prepare_python_for_platform` is dead weight there. On all runners that is the ~286 MB, 15k-file copy into `src-tauri/python` (minutes under Git-Bash on Windows); on Windows it is also the MinGit, PortableGit (7z-extracted for patch.exe) and ccache downloads.

`PREPARE_PYTHON_ONLY=1` now stops the script once the build/ tree is ready. The tree comes from the same code path, so the job loses no fidelity; the branch sits before the leading `rm -rf` of the bundle dir, so the job's stubbed resource dirs survive on purpose rather than being recreated by accident (the ordering trap called out in the issue). The full release path is unchanged; its bundle-dir cleanup just moved below the new branch with nothing in between that reads or writes it.

Verified locally on macos-arm64: a sentinel placed in `src-tauri/python` survives a `PREPARE_PYTHON_ONLY=1` run, and the full repair e2e (restore leg included) passes against the tree it produces. The full-mode path is exercised by the Build jobs on this PR; the repair job here runs the flagged path on all three OSes, with the Windows leg's 10m32s as the baseline to beat.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue (if applicable):**

- fixes https://github.com/esphome/esphome-desktop/issues/336

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tested on the relevant platform(s) (macOS, Windows, Linux).
