### PR TITLE
Tie the update and switch pip child to the kill-on-close job on Windows

### DIFF
--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -23,8 +23,8 @@ pub use health::{
 #[cfg(target_os = "windows")]
 pub use process::{assign_to_kill_on_close_job, send_ctrl_break};
 pub use process::{
-    configure_daemon_tokio_command, isolate_python_tokio_command, pip_command, run_python_capture,
-    run_python_capture_stdout,
+    configure_daemon_tokio_command, isolate_python_tokio_command, pip_command, run_pip,
+    run_python_capture, run_python_capture_stdout,
 };
 pub use python_env::{ensure_user_python, interpreter_is_usable, RefreshReason};
 

--- a/src-tauri/src/platform/process.rs
+++ b/src-tauri/src/platform/process.rs
@@ -453,6 +453,41 @@ pub fn pip_command(python: &Path) -> tokio::process::Command {
     cmd
 }
 
+/// Run a prepared bundled-interpreter command (e.g. from [`pip_command`]) to
+/// completion, capturing its output and — on Windows — tying the child to the
+/// desktop's lifetime via the kill-on-close job. Without this, an install-dir
+/// `python.exe` spawned during an update or channel switch is orphaned if the
+/// desktop is force-killed mid-run, holding the install tree open and leaving
+/// `site-packages` half-written (issue #333, the #320 failure by a route #320
+/// does not cover).
+///
+/// Replicates [`tokio::process::Command::output`]'s capture (stdin closed,
+/// stdout/stderr piped) rather than calling it, because the child must be
+/// spawned before it can be assigned to the job. Callers parse both streams, so
+/// they must not be inherited.
+///
+/// Best-effort assignment, exactly like the backend spawn in
+/// [`crate::daemon`]: the graceful `CTRL_BREAK`/`TerminateProcess` paths still
+/// apply, so a failed assignment warns and carries on rather than failing the
+/// install. Job membership is a per-child policy, which is why this is a named
+/// seam the pip sites opt into rather than something every spawn inherits.
+pub async fn run_pip(mut cmd: tokio::process::Command) -> std::io::Result<std::process::Output> {
+    cmd.stdin(std::process::Stdio::null());
+    cmd.stdout(std::process::Stdio::piped());
+    cmd.stderr(std::process::Stdio::piped());
+    let child = cmd.spawn()?;
+
+    #[cfg(windows)]
+    if !child.raw_handle().is_some_and(assign_to_kill_on_close_job) {
+        tracing::warn!(
+            "pip is not covered by the kill-on-close job; it may outlive the \
+             desktop if this process is killed without running its shutdown path"
+        );
+    }
+
+    child.wait_with_output().await
+}
+
 /// Configure the daemon child's creation flags on Windows: no console window
 /// AND a new process group. The new process group makes the child its own
 /// group leader (pgid == pid) so we can later deliver a graceful
@@ -765,6 +800,36 @@ mod tests {
         assert!(set.contains(&("PYTHONNOUSERSITE".to_string(), "1".to_string())));
         assert!(set.contains(&("PIP_USER".to_string(), "0".to_string())));
         assert!(removed.contains(&"PYTHONPATH".to_string()));
+    }
+
+    /// run_pip must reproduce `Command::output`'s capture. `pip_command` sets no
+    /// stdio, so a bare `spawn().wait_with_output()` would inherit the streams
+    /// and return them empty, silently blanking the output the update callers
+    /// parse for RECORD recovery and error tails. A plain shell command (not
+    /// `pip_command`) exercises the wrapper's spawn/capture directly.
+    #[tokio::test]
+    async fn run_pip_captures_stdout_and_stderr() {
+        let (program, args) = if cfg!(windows) {
+            ("cmd", ["/c", "echo out& echo err 1>&2& exit 1"])
+        } else {
+            ("sh", ["-c", "echo out; echo err 1>&2; exit 1"])
+        };
+        let mut cmd = tokio::process::Command::new(program);
+        cmd.args(args);
+
+        let output = run_pip(cmd).await.expect("run_pip should spawn and wait");
+        assert!(
+            !output.status.success(),
+            "the non-zero exit must be reported"
+        );
+        assert!(
+            String::from_utf8_lossy(&output.stdout).contains("out"),
+            "stdout was not captured"
+        );
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains("err"),
+            "stderr was not captured"
+        );
     }
 
     /// pip isolation is a superset of Python isolation: a pip install that

--- a/src-tauri/src/platform/process.rs
+++ b/src-tauri/src/platform/process.rs
@@ -558,7 +558,7 @@ pub fn assign_to_kill_on_close_job(process: std::os::windows::io::RawHandle) -> 
     match unsafe { AssignProcessToJobObject(job, HANDLE(process)) } {
         Ok(()) => true,
         Err(e) => {
-            tracing::warn!("Failed to assign backend to kill-on-close job object: {e}");
+            tracing::warn!("Failed to assign child process to the kill-on-close job object: {e}");
             false
         }
     }
@@ -605,7 +605,7 @@ fn kill_on_close_job() -> Option<::windows::Win32::Foundation::HANDLE> {
             let job = match CreateJobObjectW(None, PCWSTR::null()) {
                 Ok(job) => job,
                 Err(e) => {
-                    tracing::warn!("Failed to create job object for the backend: {e}");
+                    tracing::warn!("Failed to create the kill-on-close job object: {e}");
                     return None;
                 }
             };
@@ -619,7 +619,7 @@ fn kill_on_close_job() -> Option<::windows::Win32::Foundation::HANDLE> {
                 &info as *const _ as *const std::ffi::c_void,
                 std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
             ) {
-                tracing::warn!("Failed to set kill-on-close limit on the backend job object: {e}");
+                tracing::warn!("Failed to set the kill-on-close limit on the job object: {e}");
                 let _ = CloseHandle(job);
                 return None;
             }

--- a/src-tauri/src/update/mod.rs
+++ b/src-tauri/src/update/mod.rs
@@ -1131,7 +1131,9 @@ async fn run_device_builder_install(
     let args = device_builder_install_args(backend, version);
     let mut cmd = platform::pip_command(python_path);
     cmd.args(&args);
-    cmd.output().await.context("Failed to run pip install")
+    platform::run_pip(cmd)
+        .await
+        .context("Failed to run pip install")
 }
 
 /// URL of the ESPHome dev-branch source archive installed on the Dev channel.
@@ -1145,7 +1147,9 @@ const ESPHOME_DEV_ZIP_URL: &str = "https://github.com/esphome/esphome/archive/de
 async fn run_dev_install(python_path: &std::path::Path) -> Result<std::process::Output> {
     let mut cmd = platform::pip_command(python_path);
     cmd.args(["--force-reinstall", ESPHOME_DEV_ZIP_URL]);
-    cmd.output().await.context("Failed to run pip install")
+    platform::run_pip(cmd)
+        .await
+        .context("Failed to run pip install")
 }
 
 /// Run `pip install` for a pinned stable/beta ESPHome release (`esphome==X`).
@@ -1160,7 +1164,9 @@ async fn run_esphome_install(
 ) -> Result<std::process::Output> {
     let mut cmd = platform::pip_command(python_path);
     cmd.arg(format!("esphome=={version}"));
-    cmd.output().await.context("Failed to run pip install")
+    platform::run_pip(cmd)
+        .await
+        .context("Failed to run pip install")
 }
 
 /// What the user can actually do about a tree we could not repair.


### PR DESCRIPTION
# What does this implement/fix?

#320 tied the backend to the desktop with a kill-on-close job object so it cannot be orphaned by an exit that skips our code (uninstaller force-kill, crash, End Task); pip was not covered and reaches the same failure by a route #320 does not touch. The three pip installs in `update/mod.rs` (`run_device_builder_install`, `run_dev_install`, `run_esphome_install`) run the bundled interpreter, which on Windows resolves into the install directory, with `cmd.output().await`, which spawns the child without ever assigning it to the job. So during an ESPHome update or a channel switch a force-kill of the desktop strands an install-dir `python.exe` holding the install tree open, and leaves `site-packages` half written.

The three sites now go through a shared `platform::run_pip` that spawns, assigns the child to the kill-on-close job on Windows (best effort, warning on failure just like the backend spawn in `daemon::start_inner`), and captures output. A blanket assign-every-child helper would be wrong; `launch_app_detached` and the macOS relaunch watcher deliberately spawn children that must outlive us, so job membership stays a per-child policy the pip sites opt into.

One detail worth flagging; `run_pip` reproduces `Command::output`'s capture (stdin closed, stdout and stderr piped) rather than calling `.output()`, because the child has to be spawned before it can be assigned to the job, and the callers parse both streams for RECORD recovery and error tails. A test pins that the wrapper captures both streams so the piping cannot regress to inherited-and-empty.

Not covered by the e2e in #321, which force-kills a steady-state backend rather than mid-pip; the assignment itself reuses the seam already proven by the existing job-object tests. Windows-only behavior; verified with `cargo fmt`, `clippy --all-targets --all-features`, and `cargo test --all-features` on this machine (the `#[cfg(windows)]` path builds and runs in the lint-test-cross windows-latest job).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes https://github.com/esphome/esphome-desktop/issues/333

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).
