### PR TITLE
Force cancel superseded Build runs on a new PR push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,42 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # Belt-and-braces over GitHub's built-in `cancel-in-progress` (above), which
+  # under runner contention does not reliably cancel a Build for a superseded
+  # commit once that Build has already claimed runners: the stale run keeps its
+  # scarce macOS/Windows/ARM runners while this run queues behind it, and the
+  # required `CI Status` check stalls (observed 15+ minutes). Explicitly cancel
+  # any strictly-older still-active Build run for the same PR branch so its
+  # runners free up for this one. Best-effort and never fails the run; it is not
+  # a `CI Status` dependency, so a hiccup here cannot block a merge.
+  cancel-superseded:
+    name: Cancel superseded runs
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      actions: write
+    steps:
+      - name: Cancel older in-progress Build runs for this PR branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_REF: ${{ github.head_ref }}
+          THIS_NUM: ${{ github.run_number }}
+        run: |
+          set -euo pipefail
+          # Only strictly-older (lower run_number) still-active runs of THIS
+          # workflow for THIS PR's head branch — never this run or a newer one,
+          # so a rapid second push can't have the older run cancel the newer.
+          gh api "repos/$REPO/actions/workflows/build.yml/runs?event=pull_request&branch=$HEAD_REF&per_page=100" \
+            --jq '.workflow_runs[]
+                  | select(.status != "completed" and .run_number < (env.THIS_NUM | tonumber))
+                  | .id' \
+          | while read -r id; do
+              echo "Cancelling superseded Build run $id"
+              gh run cancel "$id" --repo "$REPO" || true
+            done
+
   # On pull requests, decide whether the build matrix needs to run at all. A PR
   # that only touches documentation or repo meta files skips it (the logic and
   # its fail-safe bias live in .github/scripts/determine_jobs.py). The CI Status

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,15 +41,23 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           HEAD_REF: ${{ github.head_ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           THIS_NUM: ${{ github.run_number }}
         run: |
           set -euo pipefail
-          # Only strictly-older (lower run_number) still-active runs of THIS
-          # workflow for THIS PR's head branch — never this run or a newer one,
-          # so a rapid second push can't have the older run cancel the newer.
-          gh api "repos/$REPO/actions/workflows/build.yml/runs?event=pull_request&branch=$HEAD_REF&per_page=100" \
+          # Older still-active Build runs for THIS PR. head_branch alone is not
+          # unique across forks (two forks can share a branch name), so match the
+          # head repository too, or we could cancel a different PR's run. The
+          # run_number bound keeps it to strictly-older runs, never this one or a
+          # newer one (so a rapid second push can't have the older cancel the
+          # newer). `gh -f` url-encodes the branch filter for exotic names.
+          gh api -X GET "repos/$REPO/actions/workflows/build.yml/runs" \
+            -f event=pull_request -f branch="$HEAD_REF" -f per_page=100 \
             --jq '.workflow_runs[]
-                  | select(.status != "completed" and .run_number < (env.THIS_NUM | tonumber))
+                  | select(.head_repository.full_name == env.HEAD_REPO
+                           and .head_branch == env.HEAD_REF
+                           and .status != "completed"
+                           and .run_number < (env.THIS_NUM | tonumber))
                   | .id' \
           | while read -r id; do
               echo "Cancelling superseded Build run $id"


### PR DESCRIPTION
# What does this implement/fix?

Under the shared Actions runner contention this repo sees, GitHub's built in `cancel-in-progress` does not reliably cancel a Build for a superseded commit once that Build has already claimed runners. The stale run keeps its scarce macOS, Windows and ARM runners while the new run queues behind it, so the required `CI Status` check sits pending for many minutes (observed 15+) and a new commit looks stuck.

Diagnosis; the `concurrency` block itself is correct and cancels a still pending run cleanly, but it does not promptly cancel one that is already in progress under load. Recent runs across several branches sat pending 500 to 1200 seconds before dispatching, including a release build that waited 543 seconds with nothing holding its group, and GitHub status was operational, so this is runner starvation plus a lagging in progress cancel rather than a config error.

This adds a small first job that explicitly cancels any strictly older still active Build run for the same PR branch, freeing those runners for the current run. It compares `run_number` so it can never cancel this run or a newer one, uses the built in `gh` CLI and `GITHUB_TOKEN` rather than a third party action to match the repo's pinned, least privilege posture (`actions: write` only), is best effort with `continue-on-error`, and is deliberately not a `CI Status` dependency so a hiccup here cannot block a merge.

Scoped to `build.yml`, which carries the required check and the heavy matrix; `lint-test.yml` finishes in a couple of minutes so its superseded runs do not linger, but the same job could be added there if wanted.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue (if applicable):**

- N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).
