### PR TITLE
fix: keep pip's conflict diagnostic in both install failure paths

### DIFF
--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -23,8 +23,8 @@ pub use health::{
 #[cfg(target_os = "windows")]
 pub use process::{assign_to_kill_on_close_job, send_ctrl_break};
 pub use process::{
-    configure_daemon_tokio_command, isolate_python_tokio_command, pip_command, run_python_capture,
-    run_python_capture_stdout,
+    configure_daemon_tokio_command, isolate_python_tokio_command, pip_command, pip_output_report,
+    run_python_capture, run_python_capture_stdout,
 };
 pub use python_env::{ensure_user_python, interpreter_is_usable, RefreshReason};
 

--- a/src-tauri/src/platform/process.rs
+++ b/src-tauri/src/platform/process.rs
@@ -18,28 +18,63 @@ use ::windows::Win32::System::Threading::{CREATE_NEW_PROCESS_GROUP, CREATE_NO_WI
 /// from hanging app startup indefinitely.
 const PIP_INSTALL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
 
-/// Maximum length of pip stderr included in a failure error message. pip's
-/// resolver and progress output can run to many kilobytes; the actionable
-/// failure reason is almost always at the tail, so we truncate to the last
-/// N bytes to keep log lines (and downstream UI surfaces) bounded.
-const PIP_STDERR_TAIL_BYTES: usize = 4096;
+/// Maximum length of a child's output included in a failure error message.
+/// pip's resolver and progress output can run to many kilobytes; the
+/// actionable failure reason is almost always at the tail, so we truncate to
+/// the last N bytes to keep log lines (and downstream UI surfaces) bounded.
+const LOG_TAIL_BYTES: usize = 4096;
 
-/// Return `s` trimmed and truncated to the last [`PIP_STDERR_TAIL_BYTES`]
-/// bytes, with a marker line if anything was dropped. Backs up to a UTF-8
-/// char boundary so the result is always valid `str`.
+/// Return `s` trimmed and truncated to the last [`LOG_TAIL_BYTES`] bytes,
+/// with a marker line if anything was dropped. Backs up to a UTF-8 char
+/// boundary so the result is always valid `str`.
 pub(super) fn tail_for_log(s: &str) -> String {
     let trimmed = s.trim();
-    if trimmed.len() <= PIP_STDERR_TAIL_BYTES {
+    if trimmed.len() <= LOG_TAIL_BYTES {
         return trimmed.to_string();
     }
-    let mut start = trimmed.len() - PIP_STDERR_TAIL_BYTES;
+    let mut start = trimmed.len() - LOG_TAIL_BYTES;
     while start < trimmed.len() && !trimmed.is_char_boundary(start) {
         start += 1;
     }
     format!(
-        "...(stderr truncated to last {} bytes)\n{}",
-        PIP_STDERR_TAIL_BYTES,
+        "...(truncated to last {} bytes)\n{}",
+        LOG_TAIL_BYTES,
         &trimmed[start..]
+    )
+}
+
+/// Start of the block in which pip explains a resolution failure.
+const PIP_CONFLICT_MARKER: &str = "The conflict is caused by:";
+
+/// Build the reported text for a failed pip install from its two streams.
+///
+/// pip splits a resolution failure across both. stderr carries the headline
+/// alone — `ERROR: Cannot install esphome and esphome==2026.7.0 because these
+/// package versions have conflicting dependencies` — because that line is the
+/// only part logged at CRITICAL. The block naming *which* requirements
+/// conflict, and whether one has no distribution for this environment at all,
+/// is logged at INFO and therefore goes to stdout. Reporting stderr alone left
+/// a bug report holding the symptom and none of the cause (#327, #339).
+///
+/// Everything from the marker onwards is that diagnostic, so append that tail
+/// and nothing else: earlier stdout is `Collecting`/`Downloading` progress that
+/// would bury it. A failure pip words differently (a build error, no network)
+/// has no marker and is reported exactly as before.
+fn pip_failure_report(stdout: &str, stderr: &str) -> String {
+    let stderr = stderr.trim_end();
+    match stdout.find(PIP_CONFLICT_MARKER) {
+        Some(start) => format!("{stderr}\n{}", stdout[start..].trim_end()),
+        None => stderr.to_string(),
+    }
+}
+
+/// [`pip_failure_report`] over a captured pip [`std::process::Output`].
+/// `pub` because the update flows report their pip failures through the same
+/// extraction (see `install_with_record_recovery`).
+pub fn pip_output_report(output: &std::process::Output) -> String {
+    pip_failure_report(
+        &String::from_utf8_lossy(&output.stdout),
+        &String::from_utf8_lossy(&output.stderr),
     )
 }
 
@@ -216,24 +251,20 @@ pub(super) fn pip_install_blocking(python_bin: &Path, package: &str, version: &s
     cmd.stdout(std::process::Stdio::piped());
     cmd.stderr(std::process::Stdio::piped());
 
-    let stderr_tail = |bytes: &[u8]| tail_for_log(&String::from_utf8_lossy(bytes));
     match run_bounded(cmd, PIP_INSTALL_TIMEOUT).context("Failed to run pip install")? {
         BoundedRun::Exited(output) if output.status.success() => Ok(()),
         BoundedRun::Exited(output) => {
             anyhow::bail!(
                 "pip install {} failed: {}",
                 spec,
-                tail_for_log(&crate::update::pip_failure_report(
-                    &String::from_utf8_lossy(&output.stdout),
-                    &String::from_utf8_lossy(&output.stderr),
-                ))
+                tail_for_log(&pip_output_report(&output))
             )
         }
         BoundedRun::TimedOut { stderr } => anyhow::bail!(
             "pip install {} timed out after {:?}; partial stderr: {}",
             spec,
             PIP_INSTALL_TIMEOUT,
-            stderr_tail(&stderr)
+            tail_for_log(&String::from_utf8_lossy(&stderr))
         ),
     }
 }
@@ -1199,7 +1230,7 @@ mod tests {
 
     #[test]
     fn tail_for_log_keeps_input_at_exactly_the_limit() {
-        let s = "a".repeat(PIP_STDERR_TAIL_BYTES);
+        let s = "a".repeat(LOG_TAIL_BYTES);
         let out = tail_for_log(&s);
         assert_eq!(out, s, "input exactly at the limit must pass through");
         assert!(!out.contains("truncated"), "no marker at the boundary");
@@ -1207,16 +1238,10 @@ mod tests {
 
     #[test]
     fn tail_for_log_truncates_to_the_tail_with_marker() {
-        let s = "x".repeat(PIP_STDERR_TAIL_BYTES + 904);
+        let s = "x".repeat(LOG_TAIL_BYTES + 904);
         let out = tail_for_log(&s);
-        assert!(
-            out.starts_with("...(stderr truncated"),
-            "marker comes first"
-        );
-        assert!(
-            out.ends_with(&s[s.len() - PIP_STDERR_TAIL_BYTES..]),
-            "keeps tail"
-        );
+        assert!(out.starts_with("...(truncated"), "marker comes first");
+        assert!(out.ends_with(&s[s.len() - LOG_TAIL_BYTES..]), "keeps tail");
     }
 
     #[test]
@@ -1229,10 +1254,7 @@ mod tests {
         let out = tail_for_log(&s);
         assert!(out.contains("truncated"), "long input must be marked");
         let tail = out.split_once('\n').unwrap().1;
-        assert!(
-            tail.len() <= PIP_STDERR_TAIL_BYTES,
-            "tail stays within bound"
-        );
+        assert!(tail.len() <= LOG_TAIL_BYTES, "tail stays within bound");
         assert!(tail.chars().all(|c| c == '€'), "no partial char survives");
     }
 
@@ -1317,38 +1339,68 @@ mod tests {
     #[cfg(target_os = "windows")]
     const TEST_PYTHON: &str = "python";
 
-    /// The failure report carries pip's stdout diagnostic through the real
-    /// pipe-and-drain path, not just the pure `pip_failure_report` function: a
-    /// stub pip prints the resolution story the way the real one splits it
-    /// (headline on stderr, "The conflict is caused by:" block on stdout) and
-    /// exits 1. Losing stdout again would reproduce #339, an error holding the
-    /// symptom and none of the cause.
+    /// pip stdout for the #327 failure: progress noise, then the diagnostic.
+    const CONFLICT_STDOUT: &str = "Collecting esphome==2026.7.0\n  Using cached esphome-2026.7.0-py3-none-any.whl\nINFO: pip is looking at multiple versions of esphome\n\nThe conflict is caused by:\n    The user requested esphome==2026.7.0\n    esphome 2026.7.0 depends on some-dep>=2\n\nAdditionally, some packages in these conflicts have no matching distributions available for your environment:\n    some-dep\n\nTo fix this you could try to:\n1. loosen the range of package versions you've specified\n";
+
+    /// pip stderr for the same failure: the headline, and nothing else.
+    const CONFLICT_STDERR: &str = "ERROR: Cannot install esphome and esphome==2026.7.0 because these package versions have conflicting dependencies.\nERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/\n";
+
+    #[test]
+    fn pip_failure_report_keeps_the_conflict_diagnostic() {
+        // #327: stderr alone says two requirements conflict but never which,
+        // so the report must carry stdout's block — including the line naming
+        // the dependency with no distribution for this environment, which is
+        // the whole reason the pinned install cannot resolve.
+        let report = pip_failure_report(CONFLICT_STDOUT, CONFLICT_STDERR);
+        assert!(report.contains("ERROR: Cannot install esphome and esphome==2026.7.0"));
+        assert!(report.contains("The conflict is caused by:"));
+        assert!(report.contains("esphome 2026.7.0 depends on some-dep>=2"));
+        assert!(report.contains("no matching distributions available for your environment"));
+    }
+
+    #[test]
+    fn pip_failure_report_drops_progress_noise_before_the_marker() {
+        // Only the diagnostic tail is wanted; the Collecting/Downloading
+        // chatter ahead of it would bury the cause in the dialog and the log.
+        let report = pip_failure_report(CONFLICT_STDOUT, CONFLICT_STDERR);
+        assert!(!report.contains("Collecting esphome==2026.7.0"));
+        assert!(!report.contains("Using cached"));
+    }
+
+    #[test]
+    fn pip_failure_report_without_a_marker_is_stderr_alone() {
+        // A failure pip words differently (a build error, no network) has no
+        // marker, and must report exactly what it did before.
+        let report = pip_failure_report(
+            "Collecting esphome==2026.7.0\n",
+            "ERROR: Could not find a version that satisfies the requirement esphome==2026.7.0\n",
+        );
+        assert_eq!(
+            report,
+            "ERROR: Could not find a version that satisfies the requirement esphome==2026.7.0"
+        );
+    }
+
+    /// The wiring the pure tests above cannot see: both streams are actually
+    /// piped and drained into the report. A stub pip prints the resolution
+    /// story the way the real one splits it (headline on stderr, marker block
+    /// on stdout) and exits 1; un-piping stdout again would reproduce #339,
+    /// an error holding the symptom and none of the cause.
     #[cfg(unix)]
     #[test]
     fn pip_install_blocking_failure_carries_the_stdout_diagnostic() {
-        use std::os::unix::fs::PermissionsExt;
         let base = crate::util::unique_temp_dir("pip-blocking-diagnostic");
-        std::fs::create_dir_all(&base).unwrap();
-        let bin = base.join("python3");
-        std::fs::write(
-            &bin,
-            "#!/bin/sh\n\
-             echo 'Collecting esphome==2026.7.0'\n\
-             echo 'The conflict is caused by:'\n\
-             echo '    esphome 2026.7.0 depends on some-dep>=2'\n\
+        let bin = crate::platform::python_env::write_stub_interpreter(
+            &base,
+            "echo 'The conflict is caused by:'\n\
              echo 'ERROR: ResolutionImpossible' >&2\n\
-             exit 1\n",
-        )
-        .unwrap();
-        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+             exit 1",
+        );
 
         let err = pip_install_blocking(&bin, "esphome", "2026.7.0").unwrap_err();
         let msg = format!("{err:#}");
         assert!(msg.contains("ERROR: ResolutionImpossible"), "{msg}");
         assert!(msg.contains("The conflict is caused by:"), "{msg}");
-        assert!(msg.contains("some-dep>=2"), "{msg}");
-        // The progress noise ahead of the marker must not reach the log.
-        assert!(!msg.contains("Collecting"), "{msg}");
         let _ = std::fs::remove_dir_all(&base);
     }
 }

--- a/src-tauri/src/platform/process.rs
+++ b/src-tauri/src/platform/process.rs
@@ -43,6 +43,25 @@ pub(super) fn tail_for_log(s: &str) -> String {
     )
 }
 
+/// [`tail_for_log`]'s counterpart for text whose interesting part comes
+/// first: `s` trimmed and truncated to the first [`LOG_TAIL_BYTES`] bytes,
+/// with a marker line if anything was dropped.
+fn head_for_log(s: &str) -> String {
+    let trimmed = s.trim();
+    if trimmed.len() <= LOG_TAIL_BYTES {
+        return trimmed.to_string();
+    }
+    let mut end = LOG_TAIL_BYTES;
+    while end > 0 && !trimmed.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!(
+        "{}\n...(truncated to first {} bytes)",
+        &trimmed[..end],
+        LOG_TAIL_BYTES
+    )
+}
+
 /// Start of the block in which pip explains a resolution failure.
 const PIP_CONFLICT_MARKER: &str = "The conflict is caused by:";
 
@@ -56,19 +75,27 @@ const PIP_CONFLICT_MARKER: &str = "The conflict is caused by:";
 /// is logged at INFO and therefore goes to stdout. Reporting stderr alone left
 /// a bug report holding the symptom and none of the cause (#327, #339).
 ///
-/// Everything from the marker onwards is that diagnostic, so append that tail
-/// and nothing else: earlier stdout is `Collecting`/`Downloading` progress that
+/// Everything from the marker onwards is that diagnostic, so append that and
+/// nothing else: earlier stdout is `Collecting`/`Downloading` progress that
 /// would bury it. A failure pip words differently (a build error, no network)
-/// has no marker and is reported exactly as before.
+/// has no marker and reports stderr alone.
+///
+/// Each half is bounded on its own, because their interesting ends differ:
+/// stderr's actionable line is last (tail), while the diagnostic opens with
+/// the conflicting requirements and trails off into generic advice (head).
+/// Bounding the joined report instead would let a long diagnostic evict the
+/// headline and its own opening — the symptom and the cause — keeping only
+/// the boilerplate.
 fn pip_failure_report(stdout: &str, stderr: &str) -> String {
-    let stderr = stderr.trim_end();
+    let stderr = tail_for_log(stderr);
     match stdout.find(PIP_CONFLICT_MARKER) {
-        Some(start) => format!("{stderr}\n{}", stdout[start..].trim_end()),
-        None => stderr.to_string(),
+        Some(start) => format!("{stderr}\n{}", head_for_log(&stdout[start..])),
+        None => stderr,
     }
 }
 
 /// [`pip_failure_report`] over a captured pip [`std::process::Output`].
+/// Already bounded, so callers put it in an error or a log line as is.
 /// `pub` because the update flows report their pip failures through the same
 /// extraction (see `install_with_record_recovery`).
 pub fn pip_output_report(output: &std::process::Output) -> String {
@@ -257,7 +284,7 @@ pub(super) fn pip_install_blocking(python_bin: &Path, package: &str, version: &s
             anyhow::bail!(
                 "pip install {} failed: {}",
                 spec,
-                tail_for_log(&pip_output_report(&output))
+                pip_output_report(&output)
             )
         }
         BoundedRun::TimedOut { stderr } => anyhow::bail!(
@@ -1365,6 +1392,39 @@ mod tests {
         let report = pip_failure_report(CONFLICT_STDOUT, CONFLICT_STDERR);
         assert!(!report.contains("Collecting esphome==2026.7.0"));
         assert!(!report.contains("Using cached"));
+    }
+
+    #[test]
+    fn pip_failure_report_bounds_a_huge_diagnostic_without_losing_its_start() {
+        // A real resolution failure can push the conflict block far past the
+        // log cap. Tailing the joined report would evict the stderr headline
+        // and the block's opening — the packages that actually conflict —
+        // keeping only pip's trailing boilerplate advice. Each half is
+        // bounded on its own instead, so both survive.
+        let huge_stdout = format!(
+            "Collecting esphome==2026.7.0\nThe conflict is caused by:\n    \
+             esphome 2026.7.0 depends on some-dep>=2\n{}",
+            "x".repeat(LOG_TAIL_BYTES * 3)
+        );
+        let report = pip_failure_report(&huge_stdout, CONFLICT_STDERR);
+        assert!(report.contains("ERROR: Cannot install esphome and esphome==2026.7.0"));
+        assert!(report.contains("The conflict is caused by:"));
+        assert!(report.contains("esphome 2026.7.0 depends on some-dep>=2"));
+        assert!(report.contains("...(truncated to first"));
+        assert!(
+            report.len() <= 2 * LOG_TAIL_BYTES + 100,
+            "report is bounded"
+        );
+    }
+
+    #[test]
+    fn head_for_log_does_not_split_a_multibyte_char() {
+        // Mirror of the tail_for_log boundary test: the cut must back up to a
+        // char boundary or the slice panics.
+        let s = "é".repeat(LOG_TAIL_BYTES);
+        let out = head_for_log(&s);
+        assert!(out.starts_with('é'));
+        assert!(out.ends_with("bytes)"));
     }
 
     #[test]

--- a/src-tauri/src/platform/process.rs
+++ b/src-tauri/src/platform/process.rs
@@ -209,8 +209,11 @@ pub(super) fn pip_install_blocking(python_bin: &Path, package: &str, version: &s
     // The builder isolates the interpreter; pip needs its own env off too, and
     // every edit is an idempotent `env`/`env_remove`, so layering is a no-op.
     isolate_pip_command(&mut cmd);
-    // stderr only: pip's diagnostics go there, and nothing reads its stdout —
-    // which also keeps its resolver output out of the capture buffer entirely.
+    // Both streams: pip logs a resolution failure's headline at CRITICAL
+    // (stderr) but the block explaining WHICH requirements conflict at INFO
+    // (stdout). This is a GUI process, so inherited stdout goes nowhere, and
+    // stderr alone reports the symptom with none of the cause (#339).
+    cmd.stdout(std::process::Stdio::piped());
     cmd.stderr(std::process::Stdio::piped());
 
     let stderr_tail = |bytes: &[u8]| tail_for_log(&String::from_utf8_lossy(bytes));
@@ -220,7 +223,10 @@ pub(super) fn pip_install_blocking(python_bin: &Path, package: &str, version: &s
             anyhow::bail!(
                 "pip install {} failed: {}",
                 spec,
-                stderr_tail(&output.stderr)
+                tail_for_log(&crate::update::pip_failure_report(
+                    &String::from_utf8_lossy(&output.stdout),
+                    &String::from_utf8_lossy(&output.stderr),
+                ))
             )
         }
         BoundedRun::TimedOut { stderr } => anyhow::bail!(
@@ -1310,4 +1316,39 @@ mod tests {
 
     #[cfg(target_os = "windows")]
     const TEST_PYTHON: &str = "python";
+
+    /// The failure report carries pip's stdout diagnostic through the real
+    /// pipe-and-drain path, not just the pure `pip_failure_report` function: a
+    /// stub pip prints the resolution story the way the real one splits it
+    /// (headline on stderr, "The conflict is caused by:" block on stdout) and
+    /// exits 1. Losing stdout again would reproduce #339, an error holding the
+    /// symptom and none of the cause.
+    #[cfg(unix)]
+    #[test]
+    fn pip_install_blocking_failure_carries_the_stdout_diagnostic() {
+        use std::os::unix::fs::PermissionsExt;
+        let base = crate::util::unique_temp_dir("pip-blocking-diagnostic");
+        std::fs::create_dir_all(&base).unwrap();
+        let bin = base.join("python3");
+        std::fs::write(
+            &bin,
+            "#!/bin/sh\n\
+             echo 'Collecting esphome==2026.7.0'\n\
+             echo 'The conflict is caused by:'\n\
+             echo '    esphome 2026.7.0 depends on some-dep>=2'\n\
+             echo 'ERROR: ResolutionImpossible' >&2\n\
+             exit 1\n",
+        )
+        .unwrap();
+        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let err = pip_install_blocking(&bin, "esphome", "2026.7.0").unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("ERROR: ResolutionImpossible"), "{msg}");
+        assert!(msg.contains("The conflict is caused by:"), "{msg}");
+        assert!(msg.contains("some-dep>=2"), "{msg}");
+        // The progress noise ahead of the marker must not reach the log.
+        assert!(!msg.contains("Collecting"), "{msg}");
+        let _ = std::fs::remove_dir_all(&base);
+    }
 }

--- a/src-tauri/src/platform/process.rs
+++ b/src-tauri/src/platform/process.rs
@@ -1157,11 +1157,15 @@ mod tests {
 
     #[test]
     fn head_for_log_does_not_split_a_multibyte_char() {
-        // Mirror of the tail_for_log boundary test: the cut must back up to a
-        // char boundary or the slice panics.
-        let s = "é".repeat(LOG_TAIL_BYTES);
+        // Mirror of the tail_for_log boundary test: 1366 * 3 bytes = 4098 >
+        // 4096, and the naive cut at byte 4096 lands mid-"€". The function
+        // backs up to the previous char boundary, so the slice stays valid
+        // UTF-8 and never panics.
+        let s = "€".repeat(1366);
         let out = head_for_log(&s);
-        assert!(out.starts_with('é'));
-        assert!(out.ends_with("bytes)"));
+        assert!(out.ends_with("bytes)"), "long input must be marked");
+        let head = out.split_once('\n').unwrap().0;
+        assert!(head.len() <= LOG_TAIL_BYTES, "head stays within bound");
+        assert!(head.chars().all(|c| c == '€'), "no partial char survives");
     }
 }

--- a/src-tauri/src/platform/python_env.rs
+++ b/src-tauri/src/platform/python_env.rs
@@ -522,6 +522,21 @@ fn copy_symlink(src: &Path, dst: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Test helper: write an executable `python3` shell script into `dir` whose
+/// body is `body`, and return its path. Module-level (like
+/// [`crate::util::unique_temp_dir`]) so sibling modules' tests can stub an
+/// interpreter without re-writing the shebang/chmod recipe.
+#[cfg(test)]
+#[cfg(unix)]
+pub(super) fn write_stub_interpreter(dir: &Path, body: &str) -> PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::create_dir_all(dir).unwrap();
+    let bin = dir.join("python3");
+    std::fs::write(&bin, format!("#!/bin/sh\n{body}\n")).unwrap();
+    std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+    bin
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -733,16 +748,6 @@ mod tests {
             err.to_string().contains("esphome"),
             "error names the package"
         );
-    }
-
-    #[cfg(unix)]
-    fn write_stub_interpreter(dir: &std::path::Path, body: &str) -> std::path::PathBuf {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::create_dir_all(dir).unwrap();
-        let bin = dir.join("python3");
-        std::fs::write(&bin, format!("#!/bin/sh\n{body}\n")).unwrap();
-        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
-        bin
     }
 
     #[cfg(unix)]

--- a/src-tauri/src/update/mod.rs
+++ b/src-tauri/src/update/mod.rs
@@ -1275,14 +1275,50 @@ fn is_missing_record_error(stderr: &str) -> bool {
     stderr.contains("uninstall-no-record-file") || stderr.contains("no RECORD file was found")
 }
 
+/// Start of the block in which pip explains a resolution failure.
+const PIP_CONFLICT_MARKER: &str = "The conflict is caused by:";
+
+/// Build the reported text for a failed pip install from its two streams.
+///
+/// pip splits a resolution failure across both. stderr carries the headline
+/// alone — `ERROR: Cannot install esphome and esphome==2026.7.0 because these
+/// package versions have conflicting dependencies` — because that line is the
+/// only part logged at CRITICAL. The block naming *which* requirements
+/// conflict, and whether one has no distribution for this environment at all,
+/// is logged at INFO and therefore goes to stdout. Reporting stderr alone left
+/// a bug report holding the symptom and none of the cause (#327).
+///
+/// Everything from the marker onwards is that diagnostic, so append that tail
+/// and nothing else: earlier stdout is `Collecting`/`Downloading` progress that
+/// would bury it. A failure pip words differently (a build error, no network)
+/// has no marker and is reported exactly as before.
+///
+/// `pub(crate)` because `platform::pip_install_blocking` reports its failures
+/// through the same extraction (#339).
+pub(crate) fn pip_failure_report(stdout: &str, stderr: &str) -> String {
+    let stderr = stderr.trim_end();
+    match stdout.find(PIP_CONFLICT_MARKER) {
+        Some(start) => format!("{stderr}\n{}", stdout[start..].trim_end()),
+        None => stderr.to_string(),
+    }
+}
+
+/// [`pip_failure_report`] over a captured pip [`std::process::Output`].
+fn pip_output_report(output: &std::process::Output) -> String {
+    pip_failure_report(
+        &String::from_utf8_lossy(&output.stdout),
+        &String::from_utf8_lossy(&output.stderr),
+    )
+}
+
 /// Run a pip install, repairing the tree if pip cannot uninstall the old copy
 /// (#155/#183/#330).
 ///
 /// `run` performs a normal install. If it aborts because a package has no
 /// `dist-info/RECORD` (`is_missing_record_error`), the tree is corrupt rather
 /// than the install being wrong, so `repair` restores it and `run` is tried once
-/// more against the clean tree. Any other failure bails immediately, surfacing
-/// the original stderr.
+/// more against the clean tree. Any other failure bails immediately, reported
+/// through [`pip_failure_report`] so a resolution failure carries its cause.
 ///
 /// The repair puts back the version the user had and `run` then installs the
 /// target over it, so this path can pip-install twice. That is deliberate, not
@@ -1324,7 +1360,7 @@ where
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     if !is_missing_record_error(&stderr) {
-        anyhow::bail!("{fail_prefix}: {stderr}");
+        anyhow::bail!("{fail_prefix}: {}", pip_output_report(&output));
     }
 
     info!("{fail_prefix}: missing RECORD file; repairing the Python tree");
@@ -1335,7 +1371,7 @@ where
         info!("{success_msg} (after repairing the Python tree)");
         Ok(())
     } else {
-        anyhow::bail!("{fail_prefix}: {}", String::from_utf8_lossy(&retry.stderr));
+        anyhow::bail!("{fail_prefix}: {}", pip_output_report(&retry));
     }
 }
 
@@ -1752,6 +1788,48 @@ mod tests {
             "Cannot uninstall esphome-device-builder ...: no RECORD file was found"
         ));
         assert!(!is_missing_record_error("some other pip failure"));
+    }
+
+    /// pip stdout for the #327 failure: progress noise, then the diagnostic.
+    const CONFLICT_STDOUT: &str = "Collecting esphome==2026.7.0\n  Using cached esphome-2026.7.0-py3-none-any.whl\nINFO: pip is looking at multiple versions of esphome\n\nThe conflict is caused by:\n    The user requested esphome==2026.7.0\n    esphome 2026.7.0 depends on some-dep>=2\n\nAdditionally, some packages in these conflicts have no matching distributions available for your environment:\n    some-dep\n\nTo fix this you could try to:\n1. loosen the range of package versions you've specified\n";
+
+    /// pip stderr for the same failure: the headline, and nothing else.
+    const CONFLICT_STDERR: &str = "ERROR: Cannot install esphome and esphome==2026.7.0 because these package versions have conflicting dependencies.\nERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/\n";
+
+    #[test]
+    fn pip_failure_report_keeps_the_conflict_diagnostic() {
+        // #327: stderr alone says two requirements conflict but never which,
+        // so the report must carry stdout's block — including the line naming
+        // the dependency with no distribution for this environment, which is
+        // the whole reason the pinned install cannot resolve.
+        let report = pip_failure_report(CONFLICT_STDOUT, CONFLICT_STDERR);
+        assert!(report.contains("ERROR: Cannot install esphome and esphome==2026.7.0"));
+        assert!(report.contains("The conflict is caused by:"));
+        assert!(report.contains("esphome 2026.7.0 depends on some-dep>=2"));
+        assert!(report.contains("no matching distributions available for your environment"));
+    }
+
+    #[test]
+    fn pip_failure_report_drops_progress_noise_before_the_marker() {
+        // Only the diagnostic tail is wanted; the Collecting/Downloading
+        // chatter ahead of it would bury the cause in the dialog and the log.
+        let report = pip_failure_report(CONFLICT_STDOUT, CONFLICT_STDERR);
+        assert!(!report.contains("Collecting esphome==2026.7.0"));
+        assert!(!report.contains("Using cached"));
+    }
+
+    #[test]
+    fn pip_failure_report_without_a_marker_is_stderr_alone() {
+        // A failure pip words differently (a build error, no network) has no
+        // marker, and must report exactly what it did before.
+        let report = pip_failure_report(
+            "Collecting esphome==2026.7.0\n",
+            "ERROR: Could not find a version that satisfies the requirement esphome==2026.7.0\n",
+        );
+        assert_eq!(
+            report,
+            "ERROR: Could not find a version that satisfies the requirement esphome==2026.7.0"
+        );
     }
 
     #[test]

--- a/src-tauri/src/update/mod.rs
+++ b/src-tauri/src/update/mod.rs
@@ -1275,42 +1275,6 @@ fn is_missing_record_error(stderr: &str) -> bool {
     stderr.contains("uninstall-no-record-file") || stderr.contains("no RECORD file was found")
 }
 
-/// Start of the block in which pip explains a resolution failure.
-const PIP_CONFLICT_MARKER: &str = "The conflict is caused by:";
-
-/// Build the reported text for a failed pip install from its two streams.
-///
-/// pip splits a resolution failure across both. stderr carries the headline
-/// alone — `ERROR: Cannot install esphome and esphome==2026.7.0 because these
-/// package versions have conflicting dependencies` — because that line is the
-/// only part logged at CRITICAL. The block naming *which* requirements
-/// conflict, and whether one has no distribution for this environment at all,
-/// is logged at INFO and therefore goes to stdout. Reporting stderr alone left
-/// a bug report holding the symptom and none of the cause (#327).
-///
-/// Everything from the marker onwards is that diagnostic, so append that tail
-/// and nothing else: earlier stdout is `Collecting`/`Downloading` progress that
-/// would bury it. A failure pip words differently (a build error, no network)
-/// has no marker and is reported exactly as before.
-///
-/// `pub(crate)` because `platform::pip_install_blocking` reports its failures
-/// through the same extraction (#339).
-pub(crate) fn pip_failure_report(stdout: &str, stderr: &str) -> String {
-    let stderr = stderr.trim_end();
-    match stdout.find(PIP_CONFLICT_MARKER) {
-        Some(start) => format!("{stderr}\n{}", stdout[start..].trim_end()),
-        None => stderr.to_string(),
-    }
-}
-
-/// [`pip_failure_report`] over a captured pip [`std::process::Output`].
-fn pip_output_report(output: &std::process::Output) -> String {
-    pip_failure_report(
-        &String::from_utf8_lossy(&output.stdout),
-        &String::from_utf8_lossy(&output.stderr),
-    )
-}
-
 /// Run a pip install, repairing the tree if pip cannot uninstall the old copy
 /// (#155/#183/#330).
 ///
@@ -1318,7 +1282,8 @@ fn pip_output_report(output: &std::process::Output) -> String {
 /// `dist-info/RECORD` (`is_missing_record_error`), the tree is corrupt rather
 /// than the install being wrong, so `repair` restores it and `run` is tried once
 /// more against the clean tree. Any other failure bails immediately, reported
-/// through [`pip_failure_report`] so a resolution failure carries its cause.
+/// through [`platform::pip_output_report`] so a resolution failure carries its
+/// cause from both of pip's streams.
 ///
 /// The repair puts back the version the user had and `run` then installs the
 /// target over it, so this path can pip-install twice. That is deliberate, not
@@ -1360,7 +1325,7 @@ where
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     if !is_missing_record_error(&stderr) {
-        anyhow::bail!("{fail_prefix}: {}", pip_output_report(&output));
+        anyhow::bail!("{fail_prefix}: {}", platform::pip_output_report(&output));
     }
 
     info!("{fail_prefix}: missing RECORD file; repairing the Python tree");
@@ -1371,7 +1336,7 @@ where
         info!("{success_msg} (after repairing the Python tree)");
         Ok(())
     } else {
-        anyhow::bail!("{fail_prefix}: {}", pip_output_report(&retry));
+        anyhow::bail!("{fail_prefix}: {}", platform::pip_output_report(&retry));
     }
 }
 
@@ -1788,48 +1753,6 @@ mod tests {
             "Cannot uninstall esphome-device-builder ...: no RECORD file was found"
         ));
         assert!(!is_missing_record_error("some other pip failure"));
-    }
-
-    /// pip stdout for the #327 failure: progress noise, then the diagnostic.
-    const CONFLICT_STDOUT: &str = "Collecting esphome==2026.7.0\n  Using cached esphome-2026.7.0-py3-none-any.whl\nINFO: pip is looking at multiple versions of esphome\n\nThe conflict is caused by:\n    The user requested esphome==2026.7.0\n    esphome 2026.7.0 depends on some-dep>=2\n\nAdditionally, some packages in these conflicts have no matching distributions available for your environment:\n    some-dep\n\nTo fix this you could try to:\n1. loosen the range of package versions you've specified\n";
-
-    /// pip stderr for the same failure: the headline, and nothing else.
-    const CONFLICT_STDERR: &str = "ERROR: Cannot install esphome and esphome==2026.7.0 because these package versions have conflicting dependencies.\nERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/\n";
-
-    #[test]
-    fn pip_failure_report_keeps_the_conflict_diagnostic() {
-        // #327: stderr alone says two requirements conflict but never which,
-        // so the report must carry stdout's block — including the line naming
-        // the dependency with no distribution for this environment, which is
-        // the whole reason the pinned install cannot resolve.
-        let report = pip_failure_report(CONFLICT_STDOUT, CONFLICT_STDERR);
-        assert!(report.contains("ERROR: Cannot install esphome and esphome==2026.7.0"));
-        assert!(report.contains("The conflict is caused by:"));
-        assert!(report.contains("esphome 2026.7.0 depends on some-dep>=2"));
-        assert!(report.contains("no matching distributions available for your environment"));
-    }
-
-    #[test]
-    fn pip_failure_report_drops_progress_noise_before_the_marker() {
-        // Only the diagnostic tail is wanted; the Collecting/Downloading
-        // chatter ahead of it would bury the cause in the dialog and the log.
-        let report = pip_failure_report(CONFLICT_STDOUT, CONFLICT_STDERR);
-        assert!(!report.contains("Collecting esphome==2026.7.0"));
-        assert!(!report.contains("Using cached"));
-    }
-
-    #[test]
-    fn pip_failure_report_without_a_marker_is_stderr_alone() {
-        // A failure pip words differently (a build error, no network) has no
-        // marker, and must report exactly what it did before.
-        let report = pip_failure_report(
-            "Collecting esphome==2026.7.0\n",
-            "ERROR: Could not find a version that satisfies the requirement esphome==2026.7.0\n",
-        );
-        assert_eq!(
-            report,
-            "ERROR: Could not find a version that satisfies the requirement esphome==2026.7.0"
-        );
     }
 
     #[test]


### PR DESCRIPTION
# What does this implement/fix?

pip splits a resolution failure across its streams: the `ERROR: Cannot install ...` headline is logged at CRITICAL (stderr), but the block naming which requirements conflict, including "some packages in these conflicts have no matching distributions available for your environment", is logged at INFO (stdout). Both of our install paths reported stderr alone, so a failure like #327 arrived as the symptom with none of the cause; on the startup restore path stdout was not even piped, and in a GUI process it went nowhere.

`pip_failure_report(stdout, stderr)` appends the tail of stdout from the "The conflict is caused by:" marker onward; earlier stdout is Collecting/Downloading noise and is dropped, and a failure without the marker (build error, no network) reports byte for byte as before. The tray-update path uses it at both bail sites of `install_with_record_recovery`; `pip_install_blocking` (the startup pinned-version restore, where the log is the only evidence a user has) now pipes stdout too, which `run_bounded` already drains, and reports through the same extraction.

This carries #338 forward: that branch is based on a pre repair-rework main, lives on a fork, and its author could not run the Rust checks; the helper, call sites and its three fixture tests are reproduced here adapted to the current code, plus a stub-interpreter test that proves the pipe, drain and report path end to end on the startup side. #327 becomes diagnosable from an attached log, not fixed. #338 should be closed as superseded when this merges.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes https://github.com/esphome/esphome-desktop/issues/339

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tested on the relevant platform(s) (macOS, Windows, Linux).
