### PR TITLE
ci: move the superseded-Build canceller out of the gated workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,49 +20,12 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  # Belt-and-braces over GitHub's built-in `cancel-in-progress` (above), which
-  # under runner contention does not reliably cancel a Build for a superseded
-  # commit once that Build has already claimed runners: the stale run keeps its
-  # scarce macOS/Windows/ARM runners while this run queues behind it, and the
-  # required `CI Status` check stalls (observed 15+ minutes). Explicitly cancel
-  # any strictly-older still-active Build run for the same PR branch so its
-  # runners free up for this one. Best-effort and never fails the run; it is not
-  # a `CI Status` dependency, so a hiccup here cannot block a merge.
-  cancel-superseded:
-    name: Cancel superseded runs
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    permissions:
-      actions: write
-    steps:
-      - name: Cancel older in-progress Build runs for this PR branch
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          HEAD_REF: ${{ github.head_ref }}
-          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
-          THIS_NUM: ${{ github.run_number }}
-        run: |
-          set -euo pipefail
-          # Older still-active Build runs for THIS PR. head_branch alone is not
-          # unique across forks (two forks can share a branch name), so match the
-          # head repository too, or we could cancel a different PR's run. The
-          # run_number bound keeps it to strictly-older runs, never this one or a
-          # newer one (so a rapid second push can't have the older cancel the
-          # newer). `gh -f` url-encodes the branch filter for exotic names.
-          gh api -X GET "repos/$REPO/actions/workflows/build.yml/runs" \
-            -f event=pull_request -f branch="$HEAD_REF" -f per_page=100 \
-            --jq '.workflow_runs[]
-                  | select(.head_repository.full_name == env.HEAD_REPO
-                           and .head_branch == env.HEAD_REF
-                           and .status != "completed"
-                           and .run_number < (env.THIS_NUM | tonumber))
-                  | .id' \
-          | while read -r id; do
-              echo "Cancelling superseded Build run $id"
-              gh run cancel "$id" --repo "$REPO" || true
-            done
+  # NOTE: the "cancel superseded Build runs" fallback lives in its own
+  # workflow (cancel-superseded-builds.yml), NOT here. A job inside this
+  # workflow can never do that cancelling: when `cancel-in-progress` (above)
+  # misses, the superseding run waits at this workflow's concurrency gate with
+  # no jobs started, so an in-run canceller only executes in the cases where
+  # the gate already cleared and there is nothing left to cancel.
 
   # On pull requests, decide whether the build matrix needs to run at all. A PR
   # that only touches documentation or repo meta files skips it (the logic and

--- a/.github/workflows/cancel-superseded-builds.yml
+++ b/.github/workflows/cancel-superseded-builds.yml
@@ -31,6 +31,10 @@ jobs:
     continue-on-error: true
     permissions:
       actions: write
+      # For the head-sha read below; without it the PR lookup is denied (the
+      # determine-jobs job in build.yml documents the same requirement) and
+      # continue-on-error would hide the resulting silent no-op.
+      pull-requests: read
     steps:
       - name: Cancel Build runs for commits this PR has moved past
         env:
@@ -49,6 +53,9 @@ jobs:
           # this job sees the newest head and can only cancel runs the newest
           # push has itself superseded, never the newest run.
           current=$(gh api "repos/$REPO/pulls/$PR_NUM" --jq .head.sha)
+          # An empty anchor must abort: the filter below would otherwise
+          # match every active run, including the current head's.
+          [ -n "$current" ] || exit 0
           export CURRENT="$current"
           # head_branch alone is not unique across forks (two forks can share
           # a branch name), so match the head repository too, or we could

--- a/.github/workflows/cancel-superseded-builds.yml
+++ b/.github/workflows/cancel-superseded-builds.yml
@@ -53,9 +53,16 @@ jobs:
           # this job sees the newest head and can only cancel runs the newest
           # push has itself superseded, never the newest run.
           current=$(gh api "repos/$REPO/pulls/$PR_NUM" --jq .head.sha)
-          # An empty anchor must abort: the filter below would otherwise
-          # match every active run, including the current head's.
-          [ -n "$current" ] || exit 0
+          # Anything but a full commit sha aborts, loudly: jq renders a
+          # missing field as the non-empty string "null", and any such
+          # degenerate anchor would make the filter below match every active
+          # run, including the current head's. Failing the step (rather than
+          # a silent exit 0) leaves an annotation to find when the canceller
+          # stops cancelling; continue-on-error keeps it from blocking anyone.
+          if ! printf '%s' "$current" | grep -qE '^[0-9a-f]{40}$'; then
+            echo "::error::unexpected PR head sha '$current'; refusing to cancel anything"
+            exit 1
+          fi
           export CURRENT="$current"
           # head_branch alone is not unique across forks (two forks can share
           # a branch name), so match the head repository too, or we could

--- a/.github/workflows/cancel-superseded-builds.yml
+++ b/.github/workflows/cancel-superseded-builds.yml
@@ -1,0 +1,68 @@
+name: Cancel Superseded Builds
+
+# Frees Build's concurrency group when GitHub's own `cancel-in-progress`
+# misses, which happens: a push while the previous head's Build is running has
+# twice left the new run "pending" at the gate with zero jobs started while
+# the stale run kept its runners, stalling the required `CI Status` check
+# until someone cancelled the old run by hand.
+#
+# This must be its own workflow. The first attempt (#360) was a job inside
+# build.yml, and a run waiting at a workflow-level concurrency gate starts no
+# jobs at all — so that canceller could only execute in the cases where the
+# gate had already cleared and there was nothing left to cancel. This
+# workflow declares NO concurrency group, so it always runs immediately on
+# push and can clear the gate from outside.
+#
+# Fork PRs get a read-only GITHUB_TOKEN, so the cancel calls fail there;
+# that is the pre-existing limitation of the in-run version too, and it is
+# why every step is best-effort. Not a `CI Status` dependency, so a hiccup
+# here can never block a merge.
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  cancel:
+    name: Cancel superseded Build runs
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      actions: write
+    steps:
+      - name: Cancel Build runs for commits this PR has moved past
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+          HEAD_REF: ${{ github.head_ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+        run: |
+          set -euo pipefail
+          # Separate workflows do not share a run_number sequence, so the
+          # "strictly older" guard the in-run version used cannot work here.
+          # Anchor on content instead: re-read the PR's head at execution
+          # time and cancel active Build runs for any OTHER commit. This is
+          # also what makes a rapid double push safe — a stale instance of
+          # this job sees the newest head and can only cancel runs the newest
+          # push has itself superseded, never the newest run.
+          current=$(gh api "repos/$REPO/pulls/$PR_NUM" --jq .head.sha)
+          export CURRENT="$current"
+          # head_branch alone is not unique across forks (two forks can share
+          # a branch name), so match the head repository too, or we could
+          # cancel a different PR's run. `gh -f` url-encodes the branch
+          # filter for exotic names.
+          gh api -X GET "repos/$REPO/actions/workflows/build.yml/runs" \
+            -f event=pull_request -f branch="$HEAD_REF" -f per_page=100 \
+            --jq '.workflow_runs[]
+                  | select(.head_repository.full_name == env.HEAD_REPO
+                           and .head_branch == env.HEAD_REF
+                           and .status != "completed"
+                           and .head_sha != env.CURRENT)
+                  | .id' \
+          | while read -r id; do
+              echo "Cancelling superseded Build run $id"
+              gh run cancel "$id" --repo "$REPO" || true
+            done


### PR DESCRIPTION
# What does this implement/fix?

The #360 canceller cannot fire in the case it exists for. It was a job inside build.yml, but the failure it guards against, GitHub's `cancel-in-progress` missing a superseded run, leaves the new run pending at that workflow's own concurrency gate with zero jobs started; a run that has not started jobs cannot run its canceller either. It could only execute once the gate had already cleared, when there is nothing left to cancel. Observed twice since #360 merged (on #358 and #361): the superseded head's Build kept running, the new head's run queued behind it, and the required `CI Status` check sat unreported until someone cancelled the stale run by hand.

The job moves to its own workflow with no concurrency group, so it always starts immediately on a PR push and clears Build's gate from the outside. One semantic change was forced by the move: separate workflows do not share a `run_number` sequence, so the strictly-older guard becomes a head anchor; the job re-reads the PR's current head at execution time and cancels active Build runs for any other commit. That is also what keeps a rapid double push safe, since a stale instance sees the newest head and can only cancel runs that head has itself superseded. Fork PRs keep the pre-existing limitation (read-only token, best-effort cancels), and the job is not a `CI Status` dependency so it can never block a merge.

actionlint reports nothing on the new workflow; this PR's own run of it is the first live execution (a single-head PR, so it should find nothing to cancel).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue (if applicable):**

- follow-up to #360; no tracking issue

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tested on the relevant platform(s) (macOS, Windows, Linux).
