### PR TITLE
Warn Intel Mac users on the download page that support ends soon

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -415,7 +415,7 @@
             <button type="button" data-arch="x64" aria-pressed="false">Intel</button>
           </div>
         </div>
-        <div class="note warning" id="mac-intel-warning" hidden>Support for Intel Macs will be removed soon. The Python ecosystem is dropping Intel macOS; the cryptography package no longer publishes Intel builds as of version 49.</div>
+        <div class="note warning" id="mac-intel-warning" role="status" hidden>Support for Intel Macs will be removed soon. The Python ecosystem is dropping Intel macOS; the cryptography package no longer publishes Intel builds as of version 49.</div>
         <div class="steps">
           <h3>Install</h3>
           <ol>

--- a/web/index.html
+++ b/web/index.html
@@ -28,12 +28,15 @@
       --border: #e4e5e9;
       --border-strong: #c7c9d0;
       --code-bg: #f1f2f3;
+      --warn: #d97706;
+      --warn-soft: #fef3c7;
       --shadow-sm: 0 1px 2px rgba(16, 18, 25, 0.06);
       --shadow-md: 0 4px 16px rgba(16, 18, 25, 0.08);
     }
     @media (prefers-color-scheme: dark) {
       :root {
         --brand-soft: rgba(0, 159, 238, 0.16);
+        --warn-soft: rgba(217, 119, 6, 0.16);
         --bg: #101219;
         --surface: #1b1d26;
         --surface-soft: #2f323f;
@@ -255,6 +258,10 @@
       color: var(--fg);
       border-left: 3px solid var(--brand);
     }
+    .note.warning {
+      background: var(--warn-soft);
+      border-left-color: var(--warn);
+    }
 
     code, pre {
       font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
@@ -408,6 +415,7 @@
             <button type="button" data-arch="x64" aria-pressed="false">Intel</button>
           </div>
         </div>
+        <div class="note warning" id="mac-intel-warning" hidden>Support for Intel Macs will be removed soon. The Python ecosystem is dropping Intel macOS; the cryptography package no longer publishes Intel builds as of version 49.</div>
         <div class="steps">
           <h3>Install</h3>
           <ol>
@@ -636,6 +644,7 @@
         function refresh(a) {
           // A stale persisted arch value must not break the page.
           btn.href = (files[a] || files.arm64)();
+          document.getElementById('mac-intel-warning').hidden = a !== 'x64';
         }
 
         const arch = segmented('#panel-macos .segmented button', 'arch', 'arm64', refresh);


### PR DESCRIPTION
# What does this implement/fix?

TLDR: this is out of our control; the Python ecosystem we rely on is dropping support for Intel Macs, specifically [cryptography as of 49.0.0](https://cryptography.io/en/stable/changelog/#v49-0-0). We can work around it for now by holding Intel Macs on cryptography 48.0.1, but as soon as something breaking lands or a critical security issue hits cryptography we will be forced to drop macOS Intel support.

Adds a deprecation notice to the download page's macOS panel, shown while the Intel build is selected: support for Intel Macs will be removed soon because the Python ecosystem is dropping the architecture; cryptography stopped publishing Intel macOS builds in version 49, which is what broke updates in #327 (pin fixes upstream in esphome/esphome#17658 and esphome/aioesphomeapi#1829).

The note reuses the existing `.note` styling with a warning variant and new `--warn`/`--warn-soft` tokens that follow the page's dark mode pattern; it is toggled from `setupMacOS`'s existing refresh callback, so it tracks the Apple Silicon/Intel segmented control including the auto detected arch.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue (if applicable):**

- related to https://github.com/esphome/esphome-desktop/issues/327

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).
