### PR TITLE
ci: pin tauri-cli to the tauri minor line, not the exact patch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -212,10 +212,16 @@ jobs:
           targets: ${{ matrix.rust_target }}
           cache-key: ${{ matrix.target }}
 
-      # Resolve a tauri-cli version from the locked `tauri` crate version so it
-      # tracks Dependabot's cargo bumps automatically (no hardcoded version to go
-      # stale). Used for the prebuilt install on the stock jobs below. The
-      # AppImage jobs build a pinned fork instead, so they skip this.
+      # Resolve a tauri-cli requirement from the locked `tauri` crate's
+      # major.minor so it tracks Dependabot's cargo bumps automatically (no
+      # hardcoded version to go stale). We pin the minor line, not the exact
+      # patch: `tauri` (the library) and `tauri-cli` publish on independent
+      # cadences, so an exact-patch pin breaks whenever they diverge by a patch
+      # (e.g. library 2.11.5 with no matching CLI 2.11.5). A `~major.minor`
+      # requirement installs the newest CLI patch in the same minor, which Tauri
+      # keeps compatible with the library. Used for the prebuilt install on the
+      # stock jobs below; the AppImage jobs build a pinned fork instead, so they
+      # skip this.
       - name: Resolve Tauri CLI version
         if: ${{ !matrix.tauri_rev }}
         shell: bash
@@ -231,8 +237,11 @@ jobs:
             echo "::error::unexpected tauri version from src-tauri/Cargo.lock: '$ver'"
             exit 1
           fi
-          echo "TAURI_CLI_VERSION=$ver" >> "$GITHUB_ENV"
-          echo "Resolved tauri-cli version: $ver"
+          # Derive the minor line (2.11.5 -> 2.11) from the already-validated
+          # string, then hand cargo-binstall a `~2.11` requirement.
+          minor=$(echo "$ver" | cut -d. -f1,2)
+          echo "TAURI_CLI_VERSION=~$minor" >> "$GITHUB_ENV"
+          echo "Resolved tauri-cli requirement: ~$minor (from tauri $ver)"
 
       # Stock jobs install a prebuilt cargo-tauri via cargo-binstall (seconds)
       # rather than compiling tauri-cli from source, which dominated the per-job


### PR DESCRIPTION
# What does this implement/fix?

The `Build` matrix installs `tauri-cli` at a version derived from the locked `tauri` library crate, pinned to the exact patch (`--version "=<tauri-lib-version>"`). The library `tauri` and the `tauri-cli` binary publish on independent cadences, so an exact patch pin breaks the moment they diverge.

That is what broke #315 (the tauri group Dependabot bump): it moved the library to `2.11.5`, which compiles fine (so `Rust lint & test` passed on all three OSes), but `tauri-cli` has no `2.11.5` (latest is `2.11.4`), so every `Build` leg failed at `cargo binstall tauri-cli --version "=2.11.5"` with "no version matching requirement".

This derives the library's `major.minor` and hands cargo-binstall a `~major.minor` requirement instead, so it installs the newest CLI patch within the same minor line (Tauri keeps those compatible) while still tracking Dependabot bumps with no hardcoded version to go stale. Unblocks #315.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- unblocks #315

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).
