### PR TITLE
Bump bundled Python to 3.14 (3.14.6)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Download from Lokalise
         # Non-English locales are gitignored, so pull them before building to

--- a/.github/workflows/scripts-test.yml
+++ b/.github/workflows/scripts-test.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       # Pin ruff exactly: its lint rules and formatter output can change between
       # releases, so an unpinned upgrade could fail this gate on an unrelated PR
@@ -64,7 +64,7 @@ jobs:
         # The device-builder maintenance helper depends on importlib.metadata
         # behavior and filesystem semantics that differ by OS (the #190 loop
         # manifested on Windows), so exercise every platform we ship. We bundle
-        # CPython 3.13, so that is the only version worth testing.
+        # CPython 3.14, so that is the only version worth testing.
         os: [ubuntu-22.04, macos-15, windows-latest]
     steps:
       - name: Checkout
@@ -73,7 +73,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       # Pin to a major so a breaking/yanked pytest release can't fail this gate
       # on unrelated PRs (same reasoning the repo pins the Rust toolchain).

--- a/.github/workflows/translations-upload.yml
+++ b/.github/workflows/translations-upload.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Upload to Lokalise
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ locally, match that pinned version (see `toolchain:` in `lint-test.yml`).
 The first-party Python (the release tooling under `.github/scripts/` and the
 runtime helpers under `src-tauri/scripts/` that the Rust binary embeds) is gated
 by the `Scripts Test` workflow, which lints with `ruff` and runs the `pytest`
-suite across macOS, Windows, and Linux on the CPython 3.13 line we bundle:
+suite across macOS, Windows, and Linux on the CPython 3.14 line we bundle:
 
 ```bash
 python3 -m pip install pytest ruff   # one-time

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A cross-platform desktop application that bundles ESPHome with Python and runs t
 - **Auto-Updates**: Checks for ESPHome (Python) updates and notifies you
 - **Self-Updating App**: macOS DMG, Windows NSIS, and Linux AppImage installs can update themselves in-place from GitHub Releases
 - **Cross-Platform**: Native installers for macOS (DMG), Windows (NSIS), and Linux (AppImage/deb)
-- **Bundled Python**: Includes a full Python 3.13 runtime - no system Python required
+- **Bundled Python**: Includes a full Python 3.14 runtime - no system Python required
 
 ## Installation
 

--- a/build-scripts/prepare_bundle.sh
+++ b/build-scripts/prepare_bundle.sh
@@ -16,7 +16,7 @@
 
 set -e
 
-PYTHON_VERSION="3.13.14"
+PYTHON_VERSION="3.14.6"
 PBS_VERSION="20260718"
 BASE_URL="https://github.com/astral-sh/python-build-standalone/releases/download/${PBS_VERSION}"
 
@@ -419,7 +419,7 @@ EOF
 # machine the kernel can't find the interpreter and every `esphome`,
 # `platformio`, `pip`, … invocation fails silently (see issue #34).
 # Replace each shebang with the same sh/Python polyglot that
-# python-build-standalone uses for its own scripts (idle3, pydoc3.13, …),
+# python-build-standalone uses for its own scripts (idle3, pydoc3.14, …),
 # so the whole bin/ directory is consistent and relocatable.
 # Windows uses .exe launchers (not text scripts) so it's not called there.
 make_scripts_relocatable() {

--- a/build-scripts/sign_python_bundle.sh
+++ b/build-scripts/sign_python_bundle.sh
@@ -34,7 +34,7 @@ echo ""
 
 SIGNED=0
 
-# Use find -L to follow symlinks (python, python3 are often symlinks to python3.13)
+# Use find -L to follow symlinks (python, python3 are often symlinks to python3.14)
 # Sign dylibs and .so files first (inside-out signing)
 echo "--- Signing shared libraries (.dylib and .so) ---"
 while IFS= read -r -d '' file; do


### PR DESCRIPTION
# What does this implement/fix?

> [!WARNING]
> This must not merge until https://github.com/esphome/esphome/pull/17671 is published in an esphome release. The PlatformIO cache in `~/.platformio` persists across the bundled Python refresh; without that fix, a cache provisioned under 3.13 keeps rejecting 3.14 until the user runs Reset Build Environment.

The esphome containers moved to Python 3.14 (esphome/docker-base#74), so this bumps the bundled interpreter to 3.14.6 from the same PBS release (20260718) we already pin; all five platform artifacts were verified to exist. The CI runner Python pins and comments that mirror the bundled minor are updated to match.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue (if applicable):**

- fixes <link to issue>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).

