### PR TITLE
Offer a Windows firewall rule on first run so pairing works

### DIFF
--- a/.github/scripts/e2e_windows_backend_lifetime.ps1
+++ b/.github/scripts/e2e_windows_backend_lifetime.ps1
@@ -23,19 +23,12 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-# Read the product name rather than duplicating it: the install directory is
-# derived from it, and this script already refuses to assume it for the binary
-# name a few lines down. Hardcoding it here and discovering it there would be
-# the same assumption wearing a disguise.
-$conf = Get-Content 'src-tauri/tauri.conf.json' -Raw | ConvertFrom-Json
-$InstallDir = Join-Path $env:LOCALAPPDATA $conf.productName
-$AppDataDir = Join-Path $env:APPDATA $conf.identifier
+# Paths derived from tauri.conf.json and the install/uninstall helpers live
+# in the shared common file; this script keeps only what is backend-specific.
+. "$PSScriptRoot/e2e_windows_common.ps1"
+
 # The managed Python tree: on first launch the app copies the bundled tree
 # here and the backend runs from the copy, not the install dir (#335).
-$LocalDataDir = Join-Path $env:LOCALAPPDATA $conf.identifier
-# Mirrors PYTHON_TREE_DIRNAME in src-tauri/src/platform/mod.rs (and the
-# 'python' resource name in tauri.conf.json for the install-dir side).
-$PythonDirName = 'python'
 # Trailing separator so `C:\foo` cannot prefix-match `C:\foobar`.
 $Prefix = $InstallDir + '\'
 $TreePrefix = (Join-Path $LocalDataDir $PythonDirName) + '\'
@@ -122,20 +115,9 @@ function Show-Diagnostics {
 }
 
 # --- install the bundle we just built -------------------------------------
-$installer = Get-ChildItem 'src-tauri/target/release/bundle/nsis/*.exe' -ErrorAction SilentlyContinue |
-    Select-Object -First 1
-if (-not $installer) { throw 'no NSIS installer found; did the bundle step run?' }
-Write-Host "Installing $($installer.Name)"
+Install-Bundle
 
-$proc = Start-Process -FilePath $installer.FullName -ArgumentList '/S' -Wait -PassThru
-if ($proc.ExitCode -ne 0) { throw "silent install failed with exit code $($proc.ExitCode)" }
-if (-not (Test-Path $InstallDir)) { throw "installer reported success but $InstallDir does not exist" }
-
-# Discover the main binary rather than assuming the product name: it is derived
-# from tauri.conf.json and would drift silently.
-$exe = Get-ChildItem $InstallDir -Filter *.exe |
-    Where-Object { $_.Name -ine 'uninstall.exe' } | Select-Object -First 1
-if (-not $exe) { throw "no main binary in $InstallDir" }
+$exe = Get-MainExe
 Write-Host "Launching $($exe.Name)"
 
 # --- start it and wait for the backend ------------------------------------
@@ -225,45 +207,23 @@ try {
     # checks is the install-dir side — the bundled payload, plus anything a
     # backend child like `git.exe` still holds there — being cleanly
     # removable. It is only meaningful sitting on top of the one above.
-    $uninstaller = Join-Path $InstallDir 'uninstall.exe'
-    if (-not (Test-Path $uninstaller)) { throw "no uninstaller at $uninstaller" }
-    Write-Host 'Uninstalling to confirm nothing is left holding the install dir open'
-
-    # Assert on the interpreter, not the whole tree: a locked `python.exe`
-    # fails its `Delete`, keeps `$INSTDIR\python` non-empty and strands the
-    # directory, so its removal is the signal. Assert it exists *before* the
-    # uninstall runs — if the bundle layout ever drifts away from this path,
-    # this check must fail loudly rather than pass on a file that was never
-    # there.
-    #
     # The tree itself legitimately survives a healthy uninstall: Tauri `Delete`s
     # only what its manifest lists and then calls non-recursive `RMDir`, while
     # `prepare_bundle.sh` strips every `__pycache__` before packaging ("Python
     # regenerates .pyc files at runtime"), so the app recreates .pyc files that
     # were never in the manifest and `RMDir` finds the directory non-empty.
     # Asserting the tree disappears is therefore red on every run, for a reason
-    # that has nothing to do with us.
-    $py = Join-Path $InstallDir (Join-Path $PythonDirName 'python.exe')
-    if (-not (Test-Path $py)) {
-        throw "no bundled interpreter at $py; did the bundle layout change?"
-    }
-
-    # `-Wait` is not enough on its own and the reason matters: a bare `/S`
-    # uninstall copies itself to $TEMP and re-execs, so the process started here
-    # returns immediately while the copy does the work. Poll for the tree.
-    # (Passing `_?=` keeps it in place and makes `-Wait` meaningful, but NSIS
-    # then deliberately leaves `uninstall.exe` behind and the directory never
-    # goes away — that same in-place mode is what made the reverted installer
-    # hooks kill themselves, see #328.)
-    Start-Process -FilePath $uninstaller -ArgumentList '/S' -Wait
-
+    # that has nothing to do with us. `Uninstall-Bundle` (common file) therefore
+    # asserts on the bundled interpreter, and carries the story of why a bare
+    # `/S` uninstall must be polled rather than waited on.
+    Write-Host 'Uninstalling to confirm nothing is left holding the install dir open'
     $unwatch = [Diagnostics.Stopwatch]::StartNew()
-    while ($unwatch.Elapsed.TotalSeconds -lt 90 -and (Test-Path $py)) {
-        Start-Sleep -Milliseconds 500
+    try {
+        Uninstall-Bundle
     }
-    if (Test-Path $py) {
+    catch {
         Show-Diagnostics 'the bundled interpreter survived the uninstall'
-        throw "$py still exists after uninstalling; something is holding it open"
+        throw
     }
     Write-Host "PASS: the bundled interpreter was removed after $([int]$unwatch.Elapsed.TotalSeconds)s"
 

--- a/.github/scripts/e2e_windows_common.ps1
+++ b/.github/scripts/e2e_windows_common.ps1
@@ -21,10 +21,20 @@ if ($modSrc -notmatch 'PYTHON_TREE_DIRNAME: &str = "([^"]+)"') {
 }
 $PythonDirName = $Matches[1]
 
+# The install-dir side is the bundled *resource* name from tauri.conf.json,
+# which mod.rs's get_bundled_python_root keeps deliberately independent of
+# PYTHON_TREE_DIRNAME (renaming the managed tree must not move the shipped
+# bundle, and vice versa). Assert it is really listed rather than trusting
+# the literal.
+$BundledPythonDirName = 'python'
+if ($conf.bundle.resources -notcontains $BundledPythonDirName) {
+    throw "tauri.conf.json bundle.resources no longer lists '$BundledPythonDirName'"
+}
+
 # The bundled interpreter's presence marks whether the (un)installer has
 # finished. The backend runs from the managed copy under $LocalDataDir, not
 # from this one (#335).
-$BundledPython = Join-Path $InstallDir (Join-Path $PythonDirName 'python.exe')
+$BundledPython = Join-Path $InstallDir (Join-Path $BundledPythonDirName 'python.exe')
 
 # Poll $Condition every 500ms until it returns truth or $TimeoutSec elapses;
 # returns whether it did.

--- a/.github/scripts/e2e_windows_common.ps1
+++ b/.github/scripts/e2e_windows_common.ps1
@@ -1,0 +1,86 @@
+# Shared plumbing for the Windows e2e scripts, dot-sourced as
+# `. "$PSScriptRoot/e2e_windows_common.ps1"` after Set-StrictMode: the paths
+# derived from tauri.conf.json and the install/uninstall contract of the NSIS
+# bundle. One spelling for all of it; the scripts assert against real
+# installs, and a second copy would let one of them quietly test yesterday's
+# layout.
+
+# Read the product name rather than duplicating it: the install directory is
+# derived from it. Same for the managed tree's dirname, which lives in the
+# Rust source as PYTHON_TREE_DIRNAME (src-tauri/src/platform/mod.rs) — a
+# hardcoded 'python' here would keep these scripts green while the fixture
+# stopped resembling a real machine.
+$conf = Get-Content 'src-tauri/tauri.conf.json' -Raw | ConvertFrom-Json
+$InstallDir = Join-Path $env:LOCALAPPDATA $conf.productName
+$AppDataDir = Join-Path $env:APPDATA $conf.identifier
+$LocalDataDir = Join-Path $env:LOCALAPPDATA $conf.identifier
+
+$modSrc = Get-Content 'src-tauri/src/platform/mod.rs' -Raw
+if ($modSrc -notmatch 'PYTHON_TREE_DIRNAME: &str = "([^"]+)"') {
+    throw 'could not read PYTHON_TREE_DIRNAME from src/platform/mod.rs'
+}
+$PythonDirName = $Matches[1]
+
+# The bundled interpreter's presence marks whether the (un)installer has
+# finished. The backend runs from the managed copy under $LocalDataDir, not
+# from this one (#335).
+$BundledPython = Join-Path $InstallDir (Join-Path $PythonDirName 'python.exe')
+
+# Poll $Condition every 500ms until it returns truth or $TimeoutSec elapses;
+# returns whether it did.
+function Wait-Until {
+    param([scriptblock]$Condition, [int]$TimeoutSec)
+    $watch = [Diagnostics.Stopwatch]::StartNew()
+    while ($watch.Elapsed.TotalSeconds -lt $TimeoutSec) {
+        if (& $Condition) { return $true }
+        Start-Sleep -Milliseconds 500
+    }
+    return [bool](& $Condition)
+}
+
+function Install-Bundle {
+    $installer = Get-ChildItem 'src-tauri/target/release/bundle/nsis/*.exe' -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+    if (-not $installer) { throw 'no NSIS installer found; did the bundle step run?' }
+    Write-Host "Installing $($installer.Name)"
+    $proc = Start-Process -FilePath $installer.FullName -ArgumentList '/S' -Wait -PassThru
+    if ($proc.ExitCode -ne 0) { throw "silent install failed with exit code $($proc.ExitCode)" }
+    if (-not (Test-Path $BundledPython)) { throw "installer reported success but $BundledPython does not exist" }
+}
+
+# Discover the main binary rather than assuming the product name: it is
+# derived from tauri.conf.json and would drift silently.
+function Get-MainExe {
+    $exe = Get-ChildItem $InstallDir -Filter *.exe |
+        Where-Object { $_.Name -ine 'uninstall.exe' } | Select-Object -First 1
+    if (-not $exe) { throw "no main binary in $InstallDir" }
+    return $exe
+}
+
+# `-Wait` is not enough on its own and the reason matters: a bare `/S`
+# uninstall copies itself to $TEMP and re-execs, so the process started here
+# returns immediately while the copy does the work. Poll for the bundled
+# interpreter instead — a locked `python.exe` fails its `Delete`, keeps
+# `$INSTDIR\python` non-empty and strands the directory, so its removal is
+# the signal. It is asserted to exist *before* the uninstall runs — if the
+# bundle layout ever drifts away from this path, that must fail loudly
+# rather than pass on a file that was never there. Once the bundle is gone,
+# wait for the re-exec'd copy (NSIS names it Un_A.exe and friends) to exit,
+# which is when the post-uninstall hooks have run too. (Passing `_?=` keeps
+# the uninstaller in place and makes `-Wait` meaningful, but NSIS then
+# deliberately leaves `uninstall.exe` behind and the directory never goes
+# away — that same in-place mode is what made the reverted installer hooks
+# kill themselves, see #328.)
+function Uninstall-Bundle {
+    param([string[]]$Arguments = @('/S'))
+    $uninstaller = Join-Path $InstallDir 'uninstall.exe'
+    if (-not (Test-Path $uninstaller)) { throw "no uninstaller at $uninstaller" }
+    if (-not (Test-Path $BundledPython)) {
+        throw "no bundled interpreter at $BundledPython; did the bundle layout change?"
+    }
+    Start-Process -FilePath $uninstaller -ArgumentList $Arguments -Wait
+    if (-not (Wait-Until { -not (Test-Path $BundledPython) } 90)) {
+        throw "$BundledPython still exists after uninstalling; something is holding it open"
+    }
+    [void](Wait-Until { -not (Get-Process -Name 'Un_*' -ErrorAction SilentlyContinue) } 60)
+}

--- a/.github/scripts/e2e_windows_firewall.ps1
+++ b/.github/scripts/e2e_windows_firewall.ps1
@@ -14,14 +14,11 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-# Read the product name rather than duplicating it; the install directory is
-# derived from it. Same for the rule and marker names, which live in the Rust
-# source — this script asserting against its own copies would let the two
-# drift without anything failing.
-$conf = Get-Content 'src-tauri/tauri.conf.json' -Raw | ConvertFrom-Json
-$InstallDir = Join-Path $env:LOCALAPPDATA $conf.productName
-$LocalDataDir = Join-Path $env:LOCALAPPDATA $conf.identifier
+. "$PSScriptRoot/e2e_windows_common.ps1"
 
+# Read the rule and marker names from the Rust source rather than duplicating
+# them; this script asserting against its own copies would let the two drift
+# without anything failing.
 $src = Get-Content 'src-tauri/src/platform/windows.rs' -Raw
 if ($src -notmatch 'FIREWALL_RULE_NAME: &str = "([^"]+)"') {
     throw 'could not read FIREWALL_RULE_NAME from src/platform/windows.rs'
@@ -36,9 +33,7 @@ $Marker = Join-Path $LocalDataDir $Matches[1]
 # Mirrors managed_interpreter_path in src-tauri/src/platform/mod.rs: the
 # interpreter the daemon actually runs, and therefore the path the rule is
 # scoped to.
-$ManagedPython = Join-Path $LocalDataDir 'python\python.exe'
-# The install-dir copy only marks whether the (un)installer has finished.
-$BundledPython = Join-Path $InstallDir 'python\python.exe'
+$ManagedPython = Join-Path $LocalDataDir (Join-Path $PythonDirName 'python.exe')
 
 function Test-FirewallRule {
     netsh advfirewall firewall show rule name="$RuleName" *> $null
@@ -46,36 +41,8 @@ function Test-FirewallRule {
 }
 
 function Remove-FirewallRule {
-    if (Test-FirewallRule) {
-        netsh advfirewall firewall delete rule name="$RuleName" | Out-Null
-    }
-}
-
-function Install-Bundle {
-    $installer = Get-ChildItem 'src-tauri/target/release/bundle/nsis/*.exe' -ErrorAction SilentlyContinue |
-        Select-Object -First 1
-    if (-not $installer) { throw 'no NSIS installer found; did the bundle step run?' }
-    $proc = Start-Process -FilePath $installer.FullName -ArgumentList '/S' -Wait -PassThru
-    if ($proc.ExitCode -ne 0) { throw "silent install failed with exit code $($proc.ExitCode)" }
-    if (-not (Test-Path $BundledPython)) { throw "installer reported success but $BundledPython does not exist" }
-}
-
-# A bare `/S` uninstall copies itself to $TEMP and re-execs, so `-Wait` on the
-# process started here returns before the work is done (see the backend
-# lifetime script for the full story); poll for the bundle instead. The
-# firewall hook runs after file deletion, so once the bundle is gone give the
-# uninstaller a moment to finish before asserting on the rule.
-function Uninstall-Bundle {
-    param([string[]]$Arguments)
-    $uninstaller = Join-Path $InstallDir 'uninstall.exe'
-    if (-not (Test-Path $uninstaller)) { throw "no uninstaller at $uninstaller" }
-    Start-Process -FilePath $uninstaller -ArgumentList $Arguments -Wait
-    $watch = [Diagnostics.Stopwatch]::StartNew()
-    while ($watch.Elapsed.TotalSeconds -lt 90 -and (Test-Path $BundledPython)) {
-        Start-Sleep -Milliseconds 500
-    }
-    if (Test-Path $BundledPython) { throw "$BundledPython still exists after uninstalling" }
-    Start-Sleep -Seconds 10
+    # Unconditional; "no rules match" is a nonzero exit and exactly as gone.
+    netsh advfirewall firewall delete rule name="$RuleName" *> $null
 }
 
 # --- fresh state, whatever earlier steps left behind ------------------------
@@ -86,24 +53,26 @@ try {
     # --- rule already present: the app must settle without prompting --------
     Install-Bundle
 
+    # Mirrors the rule shape add_firewall_rule builds (and its unit test
+    # pins) in src-tauri/src/platform/windows.rs, so the fixture matches an
+    # accepting user's machine.
     netsh advfirewall firewall add rule name="$RuleName" dir=in action=allow `
         program="$ManagedPython" enable=yes profile=private,domain | Out-Null
-    if (-not (Test-FirewallRule)) { throw 'pre-creating the firewall rule failed' }
-
-    $exe = Get-ChildItem $InstallDir -Filter *.exe |
-        Where-Object { $_.Name -ine 'uninstall.exe' } | Select-Object -First 1
-    if (-not $exe) { throw "no main binary in $InstallDir" }
+    if ($LASTEXITCODE -ne 0) { throw 'pre-creating the firewall rule failed' }
 
     # `--no-open-dashboard` for the same two reasons as the backend lifetime
     # script: no browser on the runner, and any explicit flag stops main.rs
     # treating this console-attached launch as a bare terminal invocation
     # that prints --help and exits.
+    $exe = Get-MainExe
     Write-Host "Launching $($exe.Name) with the rule pre-created"
     $app = Start-Process -FilePath $exe.FullName -ArgumentList '--no-open-dashboard' -PassThru
     try {
         # The marker is the app's own record that the flow settled without a
         # dialog. It is written early in setup, well before the backend is
-        # up, so this ceiling is generous.
+        # up, so this ceiling is generous. Hand-rolled rather than Wait-Until
+        # because a desktop that exits early should fail with its exit code,
+        # not with a timeout.
         $deadline = [Diagnostics.Stopwatch]::StartNew()
         while ($deadline.Elapsed.TotalSeconds -lt 120 -and -not (Test-Path $Marker)) {
             if ($app.HasExited) {
@@ -135,7 +104,9 @@ try {
     Install-Bundle
     Write-Host 'Uninstalling for real'
     Uninstall-Bundle -Arguments '/S'
-    if (Test-FirewallRule) { throw 'the firewall rule survived a real uninstall' }
+    if (-not (Wait-Until { -not (Test-FirewallRule) } 30)) {
+        throw 'the firewall rule survived a real uninstall'
+    }
     Write-Host 'PASS: the real uninstall removed the rule'
 }
 finally {

--- a/.github/scripts/e2e_windows_firewall.ps1
+++ b/.github/scripts/e2e_windows_firewall.ps1
@@ -1,0 +1,143 @@
+# End-to-end check of the Windows firewall pairing flow (#384) against the
+# real installed bundle.
+#
+# The interactive half of the flow — the first-run dialog and its UAC prompt —
+# cannot be clicked on a runner, so the rule is pre-created the way an
+# accepting user's machine would have it, and the app is expected to recognize
+# it and write its one-shot marker without prompting. That still exercises the
+# real probe (`netsh advfirewall firewall show rule`) through the real app.
+# The uninstaller side is covered in full: an update-mode uninstall must keep
+# the rule, a real uninstall must remove it. The runner is elevated, so the
+# uninstaller's direct netsh path runs without UAC, which is exactly the path
+# a CI-style silent uninstall takes.
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# Read the product name rather than duplicating it; the install directory is
+# derived from it. Same for the rule and marker names, which live in the Rust
+# source — this script asserting against its own copies would let the two
+# drift without anything failing.
+$conf = Get-Content 'src-tauri/tauri.conf.json' -Raw | ConvertFrom-Json
+$InstallDir = Join-Path $env:LOCALAPPDATA $conf.productName
+$AppDataDir = Join-Path $env:APPDATA $conf.identifier
+$LocalDataDir = Join-Path $env:LOCALAPPDATA $conf.identifier
+
+$src = Get-Content 'src-tauri/src/platform/windows.rs' -Raw
+if ($src -notmatch 'FIREWALL_RULE_NAME: &str = "([^"]+)"') {
+    throw 'could not read FIREWALL_RULE_NAME from src/platform/windows.rs'
+}
+$RuleName = $Matches[1]
+if ($src -notmatch 'MARKER_NAME: &str = "([^"]+)"') {
+    throw 'could not read MARKER_NAME from src/platform/windows.rs'
+}
+$Marker = Join-Path $AppDataDir $Matches[1]
+
+# Mirrors managed_interpreter_path in src-tauri/src/platform/mod.rs: the
+# interpreter the daemon actually runs, and therefore the path the rule is
+# scoped to.
+$ManagedPython = Join-Path $LocalDataDir 'python\python.exe'
+# The install-dir copy only marks whether the (un)installer has finished.
+$BundledPython = Join-Path $InstallDir 'python\python.exe'
+
+function Test-FirewallRule {
+    netsh advfirewall firewall show rule name="$RuleName" *> $null
+    return ($LASTEXITCODE -eq 0)
+}
+
+function Remove-FirewallRule {
+    if (Test-FirewallRule) {
+        netsh advfirewall firewall delete rule name="$RuleName" | Out-Null
+    }
+}
+
+function Install-Bundle {
+    $installer = Get-ChildItem 'src-tauri/target/release/bundle/nsis/*.exe' -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+    if (-not $installer) { throw 'no NSIS installer found; did the bundle step run?' }
+    $proc = Start-Process -FilePath $installer.FullName -ArgumentList '/S' -Wait -PassThru
+    if ($proc.ExitCode -ne 0) { throw "silent install failed with exit code $($proc.ExitCode)" }
+    if (-not (Test-Path $BundledPython)) { throw "installer reported success but $BundledPython does not exist" }
+}
+
+# A bare `/S` uninstall copies itself to $TEMP and re-execs, so `-Wait` on the
+# process started here returns before the work is done (see the backend
+# lifetime script for the full story); poll for the bundle instead. The
+# firewall hook runs after file deletion, so once the bundle is gone give the
+# uninstaller a moment to finish before asserting on the rule.
+function Uninstall-Bundle {
+    param([string[]]$Arguments)
+    $uninstaller = Join-Path $InstallDir 'uninstall.exe'
+    if (-not (Test-Path $uninstaller)) { throw "no uninstaller at $uninstaller" }
+    Start-Process -FilePath $uninstaller -ArgumentList $Arguments -Wait
+    $watch = [Diagnostics.Stopwatch]::StartNew()
+    while ($watch.Elapsed.TotalSeconds -lt 90 -and (Test-Path $BundledPython)) {
+        Start-Sleep -Milliseconds 500
+    }
+    if (Test-Path $BundledPython) { throw "$BundledPython still exists after uninstalling" }
+    Start-Sleep -Seconds 10
+}
+
+# --- fresh state, whatever earlier steps left behind ------------------------
+Remove-FirewallRule
+if (Test-Path $Marker) { Remove-Item $Marker }
+
+try {
+    # --- rule already present: the app must settle without prompting --------
+    Install-Bundle
+
+    netsh advfirewall firewall add rule name="$RuleName" dir=in action=allow `
+        program="$ManagedPython" enable=yes profile=private,domain | Out-Null
+    if (-not (Test-FirewallRule)) { throw 'pre-creating the firewall rule failed' }
+
+    $exe = Get-ChildItem $InstallDir -Filter *.exe |
+        Where-Object { $_.Name -ine 'uninstall.exe' } | Select-Object -First 1
+    if (-not $exe) { throw "no main binary in $InstallDir" }
+
+    # `--no-open-dashboard` for the same two reasons as the backend lifetime
+    # script: no browser on the runner, and any explicit flag stops main.rs
+    # treating this console-attached launch as a bare terminal invocation
+    # that prints --help and exits.
+    Write-Host "Launching $($exe.Name) with the rule pre-created"
+    $app = Start-Process -FilePath $exe.FullName -ArgumentList '--no-open-dashboard' -PassThru
+    try {
+        # The marker is the app's own record that the flow settled without a
+        # dialog. It is written early in setup, well before the backend is
+        # up, so this ceiling is generous.
+        $deadline = [Diagnostics.Stopwatch]::StartNew()
+        while ($deadline.Elapsed.TotalSeconds -lt 120 -and -not (Test-Path $Marker)) {
+            if ($app.HasExited) {
+                throw "the desktop exited on its own (code $($app.ExitCode)) before writing the firewall marker"
+            }
+            Start-Sleep -Milliseconds 500
+        }
+        if (-not (Test-Path $Marker)) {
+            throw "no firewall marker at $Marker after 120s; is the app stuck on a dialog it should not show?"
+        }
+        Write-Host "PASS: the app recognized the existing rule and wrote its marker after $([int]$deadline.Elapsed.TotalSeconds)s"
+    }
+    finally {
+        if (-not $app.HasExited) {
+            Stop-Process -Id $app.Id -Force -ErrorAction SilentlyContinue
+            $app.WaitForExit(30000) | Out-Null
+        }
+    }
+
+    # --- update-mode uninstall must keep the rule ---------------------------
+    # The updater runs the previous uninstaller with /UPDATE; stripping the
+    # rule there would break pairing on every app update.
+    Write-Host 'Uninstalling in update mode'
+    Uninstall-Bundle -Arguments '/UPDATE', '/S'
+    if (-not (Test-FirewallRule)) { throw 'the update-mode uninstall removed the firewall rule' }
+    Write-Host 'PASS: the update-mode uninstall kept the rule'
+
+    # --- a real uninstall must remove it ------------------------------------
+    Install-Bundle
+    Write-Host 'Uninstalling for real'
+    Uninstall-Bundle -Arguments '/S'
+    if (Test-FirewallRule) { throw 'the firewall rule survived a real uninstall' }
+    Write-Host 'PASS: the real uninstall removed the rule'
+}
+finally {
+    Remove-FirewallRule
+}

--- a/.github/scripts/e2e_windows_firewall.ps1
+++ b/.github/scripts/e2e_windows_firewall.ps1
@@ -102,16 +102,20 @@ try {
     Write-Host 'Uninstalling in update mode'
     Uninstall-Bundle -Arguments '/UPDATE', '/S'
     if (-not (Test-FirewallRule)) { throw 'the update-mode uninstall removed the firewall rule' }
-    Write-Host 'PASS: the update-mode uninstall kept the rule'
+    if (-not (Test-Path $Marker)) { throw 'the update-mode uninstall removed the prompt marker' }
+    Write-Host 'PASS: the update-mode uninstall kept the rule and the marker'
 
-    # --- a real uninstall must remove it ------------------------------------
+    # --- a real uninstall must remove both ----------------------------------
+    # The marker has to go with the rule: a reinstall that found a stale
+    # marker would skip the prompt and pairing would be broken again.
     Install-Bundle
     Write-Host 'Uninstalling for real'
     Uninstall-Bundle -Arguments '/S'
     if (-not (Wait-Until { -not (Test-FirewallRule) } 30)) {
         throw 'the firewall rule survived a real uninstall'
     }
-    Write-Host 'PASS: the real uninstall removed the rule'
+    if (Test-Path $Marker) { throw 'the prompt marker survived a real uninstall' }
+    Write-Host 'PASS: the real uninstall removed the rule and the marker'
 }
 finally {
     Remove-FirewallRule

--- a/.github/scripts/e2e_windows_firewall.ps1
+++ b/.github/scripts/e2e_windows_firewall.ps1
@@ -20,7 +20,6 @@ $ErrorActionPreference = 'Stop'
 # drift without anything failing.
 $conf = Get-Content 'src-tauri/tauri.conf.json' -Raw | ConvertFrom-Json
 $InstallDir = Join-Path $env:LOCALAPPDATA $conf.productName
-$AppDataDir = Join-Path $env:APPDATA $conf.identifier
 $LocalDataDir = Join-Path $env:LOCALAPPDATA $conf.identifier
 
 $src = Get-Content 'src-tauri/src/platform/windows.rs' -Raw
@@ -31,7 +30,8 @@ $RuleName = $Matches[1]
 if ($src -notmatch 'MARKER_NAME: &str = "([^"]+)"') {
     throw 'could not read MARKER_NAME from src/platform/windows.rs'
 }
-$Marker = Join-Path $AppDataDir $Matches[1]
+# Machine local on purpose, next to the managed tree; see MARKER_NAME's doc.
+$Marker = Join-Path $LocalDataDir $Matches[1]
 
 # Mirrors managed_interpreter_path in src-tauri/src/platform/mod.rs: the
 # interpreter the daemon actually runs, and therefore the path the rule is

--- a/.github/scripts/e2e_windows_firewall.ps1
+++ b/.github/scripts/e2e_windows_firewall.ps1
@@ -43,6 +43,10 @@ function Test-FirewallRule {
 function Remove-FirewallRule {
     # Unconditional; "no rules match" is a nonzero exit and exactly as gone.
     netsh advfirewall firewall delete rule name="$RuleName" *> $null
+    # This runs last (the `finally` below), and the Actions pwsh shell exits
+    # with the trailing $LASTEXITCODE — an already-gone rule must not turn a
+    # fully-passed run into a failed step. Real failures throw.
+    $global:LASTEXITCODE = 0
 }
 
 # --- fresh state, whatever earlier steps left behind ------------------------

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -543,6 +543,15 @@ jobs:
         shell: pwsh
         run: ./.github/scripts/e2e_windows_backend_lifetime.ps1
 
+      # The firewall pairing flow (#384): the app must settle without a
+      # prompt when the rule already exists, an update-mode uninstall must
+      # keep the rule, a real uninstall must remove it. Runs after the
+      # lifetime script, which leaves the runner uninstalled.
+      - name: E2E firewall rule (Windows CI)
+        if: matrix.platform == 'windows' && github.event_name != 'workflow_run'
+        shell: pwsh
+        run: ./.github/scripts/e2e_windows_firewall.ps1
+
       - name: Upload NSIS updater signature
         if: contains(matrix.bundles, 'nsis') && github.event_name == 'workflow_run'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -70,7 +70,7 @@ cocoa = "0.26"
 tauri = { version = "2.11.2", features = ["image-png"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.62", features = ["Win32_System_Threading", "Win32_Foundation", "Win32_System_Console", "Win32_System_JobObjects", "Win32_Security"] }
+windows = { version = "0.62", features = ["Win32_System_Threading", "Win32_Foundation", "Win32_System_Console", "Win32_System_JobObjects", "Win32_Security", "Win32_System_SystemInformation"] }
 
 # "Win32_System_Diagnostics_ToolHelp" is only needed to walk to the grandchild in
 # the job object test, so it stays out of the shipping binary's feature set.

--- a/src-tauri/installer-hooks.nsi
+++ b/src-tauri/installer-hooks.nsi
@@ -20,3 +20,31 @@
   Delete "$SMPROGRAMS\ESPHome Builder.lnk"
   Delete "$DESKTOP\ESPHome Builder.lnk"
 !macroend
+
+; On first run the app offers to add an inbound firewall rule for the managed
+; Python interpreter so other dashboards can pair with this machine (issue
+; #384). The name must match FIREWALL_RULE_NAME in src/platform/windows.rs;
+; a drift test there checks this !define. Removal is best effort: this
+; per-user uninstaller runs unelevated, so if a direct netsh fails the user
+; gets one UAC prompt, and declining just leaves the rule behind (inert once
+; python.exe is gone). Updates run the uninstaller too ($UpdateMode = 1) and
+; must keep the rule.
+!define FIREWALL_RULE_NAME "ESPHome Device Builder"
+
+!macro NSIS_HOOK_POSTUNINSTALL
+  ${If} $UpdateMode <> 1
+    nsExec::ExecToStack 'netsh advfirewall firewall show rule name="${FIREWALL_RULE_NAME}"'
+    Pop $0
+    Pop $1
+    ${If} $0 == "0"
+      DetailPrint "Removing firewall rule..."
+      nsExec::ExecToStack 'netsh advfirewall firewall delete rule name="${FIREWALL_RULE_NAME}"'
+      Pop $0
+      Pop $1
+      ${If} $0 != "0"
+      ${AndIfNot} ${Silent}
+        ExecWait `powershell -NoProfile -NonInteractive -Command "Start-Process -FilePath netsh.exe -ArgumentList 'advfirewall firewall delete rule name=\"${FIREWALL_RULE_NAME}\"' -Verb RunAs -Wait"`
+      ${EndIf}
+    ${EndIf}
+  ${EndIf}
+!macroend

--- a/src-tauri/installer-hooks.nsi
+++ b/src-tauri/installer-hooks.nsi
@@ -31,11 +31,18 @@
 ; must keep the rule.
 !define FIREWALL_RULE_NAME "ESPHome Device Builder"
 
+; The app's one-shot record that the firewall flow settled; must match
+; MARKER_NAME in src/platform/windows.rs (drift-tested there too). A real
+; uninstall removes it along with the rule, otherwise a reinstall would see
+; the stale marker, skip the prompt, and pairing would be broken again.
+!define FIREWALL_PROMPT_MARKER ".windows_firewall_prompt"
+
 ; netsh and powershell by absolute $SYSDIR paths throughout: the fallback
 ; runs elevated, and a by-name lookup could resolve a planted binary from a
 ; user-writable directory into that elevation.
 !macro NSIS_HOOK_POSTUNINSTALL
   ${If} $UpdateMode <> 1
+    Delete "$LOCALAPPDATA\io.esphome.builder\${FIREWALL_PROMPT_MARKER}"
     nsExec::ExecToStack '"$SYSDIR\netsh.exe" advfirewall firewall show rule name="${FIREWALL_RULE_NAME}"'
     Pop $0
     Pop $1

--- a/src-tauri/installer-hooks.nsi
+++ b/src-tauri/installer-hooks.nsi
@@ -31,19 +31,22 @@
 ; must keep the rule.
 !define FIREWALL_RULE_NAME "ESPHome Device Builder"
 
+; netsh and powershell by absolute $SYSDIR paths throughout: the fallback
+; runs elevated, and a by-name lookup could resolve a planted binary from a
+; user-writable directory into that elevation.
 !macro NSIS_HOOK_POSTUNINSTALL
   ${If} $UpdateMode <> 1
-    nsExec::ExecToStack 'netsh advfirewall firewall show rule name="${FIREWALL_RULE_NAME}"'
+    nsExec::ExecToStack '"$SYSDIR\netsh.exe" advfirewall firewall show rule name="${FIREWALL_RULE_NAME}"'
     Pop $0
     Pop $1
     ${If} $0 == "0"
       DetailPrint "Removing firewall rule..."
-      nsExec::ExecToStack 'netsh advfirewall firewall delete rule name="${FIREWALL_RULE_NAME}"'
+      nsExec::ExecToStack '"$SYSDIR\netsh.exe" advfirewall firewall delete rule name="${FIREWALL_RULE_NAME}"'
       Pop $0
       Pop $1
       ${If} $0 != "0"
       ${AndIfNot} ${Silent}
-        ExecWait `powershell -NoProfile -NonInteractive -Command "Start-Process -FilePath netsh.exe -ArgumentList 'advfirewall firewall delete rule name=\"${FIREWALL_RULE_NAME}\"' -Verb RunAs -Wait"`
+        ExecWait `"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -NonInteractive -Command "Start-Process -FilePath '$SYSDIR\netsh.exe' -ArgumentList 'advfirewall firewall delete rule name=\"${FIREWALL_RULE_NAME}\"' -Verb RunAs -Wait"`
       ${EndIf}
     ${EndIf}
   ${EndIf}

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -16,6 +16,8 @@ mod macos;
 mod pip;
 mod process;
 mod python_env;
+#[cfg(target_os = "windows")]
+mod windows;
 
 pub use health::{
     clear_repair_count, esphome_config_probe, is_managed_python_tree, may_repair_tree,
@@ -194,13 +196,25 @@ fn get_bundled_python_root(app_handle: &AppHandle) -> Result<PathBuf> {
     Ok(get_bundled_resource_dir(app_handle)?.join("python"))
 }
 
+/// Interpreter path of the managed user Python tree, whether or not the
+/// first-run copy exists yet.
+///
+/// The single spelling of that composition, shared by [`get_python_path`] and
+/// the Windows firewall rule, which must scope its program filter to the
+/// exact path the daemon executes; a second copy is how the two would drift
+/// apart.
+fn managed_interpreter_path(app_handle: &AppHandle) -> Result<PathBuf> {
+    Ok(interpreter_in_tree(
+        &get_python_parent_dir(app_handle)?.join(PYTHON_TREE_DIRNAME),
+    ))
+}
+
 /// Get the path to the user Python executable: the copy `ensure_user_python`
 /// keeps under [`get_python_parent_dir`], falling back to the bundled tree
 /// before the first-run copy exists and to a bare system Python in development
 /// builds with no bundle.
 pub fn get_python_path(app_handle: &AppHandle) -> Result<PathBuf> {
-    let parent_dir = get_python_parent_dir(app_handle)?;
-    let python_path = interpreter_in_tree(&parent_dir.join(PYTHON_TREE_DIRNAME));
+    let python_path = managed_interpreter_path(app_handle)?;
 
     if python_path.exists() {
         debug!("Using user Python: {:?}", python_path);
@@ -621,13 +635,13 @@ pub fn ensure_ccache_on_path(app_handle: &AppHandle) -> Result<()> {
 }
 
 /// Platform-specific initialization
-#[cfg_attr(not(target_os = "macos"), allow(unused_variables))]
+#[cfg_attr(target_os = "linux", allow(unused_variables))]
 pub fn init(app_handle: &AppHandle) {
     #[cfg(target_os = "macos")]
     macos::init(app_handle);
 
     #[cfg(target_os = "windows")]
-    windows::init();
+    windows::init(app_handle);
 
     #[cfg(target_os = "linux")]
     linux::init();
@@ -654,13 +668,6 @@ pub fn relaunch_for_update(app_handle: &AppHandle) {
     // Non-macOS, or the LaunchServices path couldn't be set up: fall back to
     // Tauri's direct relaunch (diverges).
     app_handle.restart();
-}
-
-#[cfg(target_os = "windows")]
-mod windows {
-    pub fn init() {
-        // Windows-specific initialization
-    }
 }
 
 /// One-shot cleanup of the legacy `/Applications/ESPHome Builder.app` bundle

--- a/src-tauri/src/platform/windows.rs
+++ b/src-tauri/src/platform/windows.rs
@@ -23,9 +23,11 @@ use super::process::configure_no_window_command;
 /// spellings in sync.
 const FIREWALL_RULE_NAME: &str = "ESPHome Device Builder";
 
-/// Marker file in the app data dir recording that the flow already ran, so
-/// later launches stop at one file stat (same pattern as
-/// `cleanup_legacy_macos_app`).
+/// Marker file recording that the flow already settled, so later launches
+/// stop at one file stat. It lives in the machine-local data dir
+/// (`get_python_parent_dir`), not the roaming one: the rule is per machine,
+/// and a marker that roamed to another machine would suppress the prompt
+/// where the rule does not exist.
 const MARKER_NAME: &str = ".windows_firewall_prompt";
 
 pub fn init(app_handle: &AppHandle) {
@@ -37,14 +39,17 @@ pub fn init(app_handle: &AppHandle) {
 /// `netsh` probe included, runs off the setup thread, and every failure is
 /// logged and dropped.
 fn ensure_firewall_rule(app_handle: &AppHandle) {
-    let data_dir = match super::get_data_dir(app_handle) {
+    let local_dir = match super::get_python_parent_dir(app_handle) {
         Ok(d) => d,
         Err(e) => {
-            debug!("Skipping firewall prompt; data dir unavailable: {}", e);
+            debug!(
+                "Skipping firewall prompt; local data dir unavailable: {}",
+                e
+            );
             return;
         }
     };
-    let marker = data_dir.join(MARKER_NAME);
+    let marker = local_dir.join(MARKER_NAME);
     if marker.exists() {
         return;
     }
@@ -85,15 +90,25 @@ fn ensure_firewall_rule(app_handle: &AppHandle) {
             if confirmed {
                 match tokio::task::spawn_blocking(move || add_firewall_rule(&python_exe)).await {
                     Ok(Ok(())) => info!("Added firewall rule {:?}", FIREWALL_RULE_NAME),
-                    Ok(Err(e)) => warn!("Failed to add firewall rule: {}", e),
-                    Err(e) => warn!("Firewall rule task failed: {}", e),
+                    // The user wanted the rule but did not get it — a
+                    // declined or mis-clicked UAC prompt, a transient netsh
+                    // failure. Skip the marker so the next launch retries;
+                    // only a settled outcome (rule present, or an explicit
+                    // decline of the dialog) is final.
+                    Ok(Err(e)) => {
+                        warn!("Failed to add firewall rule: {}", e);
+                        return;
+                    }
+                    Err(e) => {
+                        warn!("Firewall rule task failed: {}", e);
+                        return;
+                    }
                 }
             }
         }
 
-        // Written regardless of the outcome (also when the rule already
-        // exists) so the user is not nagged and later launches stop at the
-        // marker check above.
+        // Rule present or dialog declined: settled, so the user is not
+        // nagged and later launches stop at the marker check above.
         if let Err(e) = std::fs::write(&marker, "") {
             warn!("Failed to write firewall-prompt marker: {}", e);
         }

--- a/src-tauri/src/platform/windows.rs
+++ b/src-tauri/src/platform/windows.rs
@@ -1,0 +1,193 @@
+//! Windows-specific initialization: a guided first-run flow that opens
+//! Windows Defender Firewall for peer-link pairing.
+//!
+//! The bundled Python backend listens for peer-link connections on all
+//! interfaces (TCP 6055, falling forward when the port is busy) and answers
+//! mDNS queries on UDP 5353. Windows Defender Firewall blocks both inbound
+//! paths by default, so pairing another dashboard to this machine fails
+//! until an allow rule exists (#384). The installer runs per-user without
+//! elevation and cannot add the rule itself, so on startup the app offers to
+//! add a program-scoped inbound allow rule for the managed Python
+//! interpreter, behind one UAC prompt.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use tauri::AppHandle;
+use tracing::{debug, info, warn};
+
+use super::process::configure_no_window_command;
+
+/// Name of the inbound allow rule. The uninstaller deletes rules by this
+/// exact name (`installer-hooks.nsi`); a drift test below keeps the two
+/// spellings in sync.
+const FIREWALL_RULE_NAME: &str = "ESPHome Device Builder";
+
+/// Marker file in the app data dir recording that the flow already ran, so
+/// later launches stop at one file stat (same pattern as
+/// `cleanup_legacy_macos_app`).
+const MARKER_NAME: &str = ".windows_firewall_prompt";
+
+pub fn init(app_handle: &AppHandle) {
+    ensure_firewall_rule(app_handle);
+}
+
+/// Offer to add the firewall rule if it is missing and the user has not been
+/// asked before. Never blocks startup: everything past the marker stat, the
+/// `netsh` probe included, runs off the setup thread, and every failure is
+/// logged and dropped.
+fn ensure_firewall_rule(app_handle: &AppHandle) {
+    let data_dir = match super::get_data_dir(app_handle) {
+        Ok(d) => d,
+        Err(e) => {
+            debug!("Skipping firewall prompt; data dir unavailable: {}", e);
+            return;
+        }
+    };
+    let marker = data_dir.join(MARKER_NAME);
+    if marker.exists() {
+        return;
+    }
+
+    // The managed copy of the interpreter is what the daemon runs, so that is
+    // the path the rule must be scoped to. It may not exist yet this early on
+    // the very first launch; netsh records the path without checking it.
+    let python_exe = match super::managed_interpreter_path(app_handle) {
+        Ok(p) => p,
+        Err(e) => {
+            debug!("Skipping firewall prompt; python dir unavailable: {}", e);
+            return;
+        }
+    };
+
+    let app = app_handle.clone();
+    tauri::async_runtime::spawn(async move {
+        // netsh spawns a subprocess; keep it off the async executor.
+        let exists = tokio::task::spawn_blocking(firewall_rule_exists)
+            .await
+            .unwrap_or(false);
+        if exists {
+            debug!("Firewall rule {:?} already present", FIREWALL_RULE_NAME);
+        } else {
+            info!(
+                "Firewall rule {:?} missing; prompting user to add it",
+                FIREWALL_RULE_NAME
+            );
+            let confirmed = crate::dialog::confirm(
+                &app,
+                &crate::i18n::t("platform.firewall_title"),
+                crate::i18n::t("platform.firewall_prompt"),
+                &crate::i18n::t("platform.firewall_allow"),
+                &crate::i18n::t("platform.firewall_decline"),
+            )
+            .await;
+
+            if confirmed {
+                match tokio::task::spawn_blocking(move || add_firewall_rule(&python_exe)).await {
+                    Ok(Ok(())) => info!("Added firewall rule {:?}", FIREWALL_RULE_NAME),
+                    Ok(Err(e)) => warn!("Failed to add firewall rule: {}", e),
+                    Err(e) => warn!("Firewall rule task failed: {}", e),
+                }
+            }
+        }
+
+        // Written regardless of the outcome (also when the rule already
+        // exists) so the user is not nagged and later launches stop at the
+        // marker check above.
+        if let Err(e) = std::fs::write(&marker, "") {
+            warn!("Failed to write firewall-prompt marker: {}", e);
+        }
+    });
+}
+
+/// Whether a rule named [`FIREWALL_RULE_NAME`] exists. Querying the firewall
+/// needs no elevation; `netsh` exits non-zero when no rule matches.
+fn firewall_rule_exists() -> bool {
+    let mut cmd = std::process::Command::new("netsh");
+    cmd.args([
+        "advfirewall",
+        "firewall",
+        "show",
+        "rule",
+        &format!("name={FIREWALL_RULE_NAME}"),
+    ]);
+    configure_no_window_command(&mut cmd);
+    matches!(cmd.output(), Ok(out) if out.status.success())
+}
+
+/// The argument string handed to the elevated `netsh.exe`. One program-scoped
+/// rule with no port or protocol restriction covers the peer-link TCP port
+/// (6055 with fall-forward) and mDNS on UDP 5353 in one go.
+/// `profile=private,domain` deliberately leaves public networks blocked,
+/// matching the default of Windows' own allow popup.
+fn netsh_add_rule_args(python_exe: &Path) -> String {
+    format!(
+        "advfirewall firewall add rule name=\"{FIREWALL_RULE_NAME}\" dir=in action=allow \
+         program=\"{}\" enable=yes profile=private,domain",
+        python_exe.display()
+    )
+}
+
+/// Add the inbound allow rule via an elevated `netsh`, triggering one UAC
+/// prompt. `Start-Process -Verb RunAs` is the way to elevate from an
+/// unelevated process; `-Wait` holds until netsh exits. The rule is
+/// re-queried afterwards because neither a declined prompt nor a failed
+/// netsh reliably shows in `Start-Process`'s own exit status.
+fn add_firewall_rule(python_exe: &Path) -> Result<()> {
+    // PowerShell single-quoted strings escape ' by doubling it.
+    let netsh_args = netsh_add_rule_args(python_exe).replace('\'', "''");
+    let command =
+        format!("Start-Process -FilePath netsh.exe -ArgumentList '{netsh_args}' -Verb RunAs -Wait");
+
+    let mut cmd = std::process::Command::new("powershell");
+    cmd.args(["-NoProfile", "-NonInteractive", "-Command", &command]);
+    configure_no_window_command(&mut cmd);
+    let output = cmd.output().context("Failed to run powershell")?;
+
+    if !output.status.success() {
+        // Start-Process throws when the UAC prompt is declined.
+        anyhow::bail!(
+            "elevation failed or was declined: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    if !firewall_rule_exists() {
+        anyhow::bail!("netsh did not create the rule");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_rule_args_quote_the_program_path() {
+        let args = netsh_add_rule_args(Path::new(
+            r"C:\Users\Jane Doe\AppData\Local\io.esphome.builder\python\python.exe",
+        ));
+        assert!(args.contains("name=\"ESPHome Device Builder\""), "{args}");
+        assert!(
+            args.contains(
+                "program=\"C:\\Users\\Jane Doe\\AppData\\Local\\io.esphome.builder\\python\\python.exe\""
+            ),
+            "{args}"
+        );
+        assert!(args.contains("dir=in"), "{args}");
+        assert!(args.contains("action=allow"), "{args}");
+        assert!(args.contains("profile=private,domain"), "{args}");
+    }
+
+    /// The uninstaller deletes rules by name; its spelling lives in
+    /// `installer-hooks.nsi` and must match [`FIREWALL_RULE_NAME`].
+    #[test]
+    fn installer_hook_rule_name_matches() {
+        let hooks = include_str!("../../installer-hooks.nsi");
+        assert!(
+            hooks.contains(&format!(
+                "!define FIREWALL_RULE_NAME \"{FIREWALL_RULE_NAME}\""
+            )),
+            "installer-hooks.nsi must define the same firewall rule name"
+        );
+    }
+}

--- a/src-tauri/src/platform/windows.rs
+++ b/src-tauri/src/platform/windows.rs
@@ -88,19 +88,19 @@ fn ensure_firewall_rule(app_handle: &AppHandle) {
             .await;
 
             if confirmed {
-                match tokio::task::spawn_blocking(move || add_firewall_rule(&python_exe)).await {
-                    Ok(Ok(())) => info!("Added firewall rule {:?}", FIREWALL_RULE_NAME),
+                let added = tokio::task::spawn_blocking(move || add_firewall_rule(&python_exe))
+                    .await
+                    .map_err(anyhow::Error::from)
+                    .and_then(|r| r);
+                match added {
+                    Ok(()) => info!("Added firewall rule {:?}", FIREWALL_RULE_NAME),
                     // The user wanted the rule but did not get it — a
                     // declined or mis-clicked UAC prompt, a transient netsh
                     // failure. Skip the marker so the next launch retries;
                     // only a settled outcome (rule present, or an explicit
                     // decline of the dialog) is final.
-                    Ok(Err(e)) => {
-                        warn!("Failed to add firewall rule: {}", e);
-                        return;
-                    }
                     Err(e) => {
-                        warn!("Firewall rule task failed: {}", e);
+                        warn!("Failed to add firewall rule: {}", e);
                         return;
                     }
                 }
@@ -108,7 +108,9 @@ fn ensure_firewall_rule(app_handle: &AppHandle) {
         }
 
         // Rule present or dialog declined: settled, so the user is not
-        // nagged and later launches stop at the marker check above.
+        // nagged and later launches stop at the marker check above. A dialog
+        // that failed to show also lands here as a decline; accepted, the
+        // two cannot be told apart through `confirm`.
         if let Err(e) = std::fs::write(&marker, "") {
             warn!("Failed to write firewall-prompt marker: {}", e);
         }

--- a/src-tauri/src/platform/windows.rs
+++ b/src-tauri/src/platform/windows.rs
@@ -127,10 +127,17 @@ fn ensure_firewall_rule(app_handle: &AppHandle) {
 fn system32(tail: &str) -> std::path::PathBuf {
     use std::os::windows::ffi::OsStringExt;
 
-    let mut buf = [0u16; 260];
-    let len =
-        unsafe { ::windows::Win32::System::SystemInformation::GetSystemDirectoryW(Some(&mut buf)) }
-            as usize;
+    use ::windows::Win32::System::SystemInformation::GetSystemDirectoryW;
+
+    let mut buf = vec![0u16; 260];
+    let mut len = unsafe { GetSystemDirectoryW(Some(&mut buf)) } as usize;
+    if len > buf.len() {
+        // Returned length is the required size; retry rather than fall back,
+        // the hardcoded default would point at the wrong drive on systems
+        // where the path really is that long.
+        buf.resize(len, 0);
+        len = unsafe { GetSystemDirectoryW(Some(&mut buf)) } as usize;
+    }
     let dir = if len > 0 && len <= buf.len() {
         std::path::PathBuf::from(std::ffi::OsString::from_wide(&buf[..len]))
     } else {
@@ -221,8 +228,9 @@ mod tests {
         assert!(args.contains("profile=private,domain"), "{args}");
     }
 
-    /// The uninstaller deletes rules by name; its spelling lives in
-    /// `installer-hooks.nsi` and must match [`FIREWALL_RULE_NAME`].
+    /// The uninstaller deletes the rule by name and the settle marker by
+    /// filename; both spellings live in `installer-hooks.nsi` and must match
+    /// [`FIREWALL_RULE_NAME`] and [`MARKER_NAME`].
     #[test]
     fn installer_hook_rule_name_matches() {
         let hooks = include_str!("../../installer-hooks.nsi");
@@ -231,6 +239,17 @@ mod tests {
                 "!define FIREWALL_RULE_NAME \"{FIREWALL_RULE_NAME}\""
             )),
             "installer-hooks.nsi must define the same firewall rule name"
+        );
+        assert!(
+            hooks.contains(&format!("!define FIREWALL_PROMPT_MARKER \"{MARKER_NAME}\"")),
+            "installer-hooks.nsi must define the same firewall marker name"
+        );
+        assert!(
+            hooks.contains(&format!(
+                "\\{}\\${{FIREWALL_PROMPT_MARKER}}",
+                super::super::BUNDLE_IDENTIFIER
+            )),
+            "installer-hooks.nsi must delete the marker under the bundle identifier's local data dir"
         );
     }
 }

--- a/src-tauri/src/platform/windows.rs
+++ b/src-tauri/src/platform/windows.rs
@@ -117,10 +117,21 @@ fn ensure_firewall_rule(app_handle: &AppHandle) {
     });
 }
 
+/// Absolute path of a binary under `System32`. The firewall flow launches an
+/// *elevated* subprocess, and both `CreateProcessW` and `ShellExecuteEx`
+/// include the current directory in their by-name search order — a planted
+/// `netsh.exe` in a user-writable CWD would run as administrator behind the
+/// one UAC prompt the user expects. Resolving from `%SystemRoot%` pins the
+/// real binaries; the unelevated query uses it too for consistency.
+fn system32(tail: &str) -> std::path::PathBuf {
+    let root = std::env::var_os("SystemRoot").unwrap_or_else(|| r"C:\Windows".into());
+    Path::new(&root).join("System32").join(tail)
+}
+
 /// Whether a rule named [`FIREWALL_RULE_NAME`] exists. Querying the firewall
 /// needs no elevation; `netsh` exits non-zero when no rule matches.
 fn firewall_rule_exists() -> bool {
-    let mut cmd = std::process::Command::new("netsh");
+    let mut cmd = std::process::Command::new(system32("netsh.exe"));
     cmd.args([
         "advfirewall",
         "firewall",
@@ -153,10 +164,14 @@ fn netsh_add_rule_args(python_exe: &Path) -> String {
 fn add_firewall_rule(python_exe: &Path) -> Result<()> {
     // PowerShell single-quoted strings escape ' by doubling it.
     let netsh_args = netsh_add_rule_args(python_exe).replace('\'', "''");
+    let netsh = system32("netsh.exe")
+        .display()
+        .to_string()
+        .replace('\'', "''");
     let command =
-        format!("Start-Process -FilePath netsh.exe -ArgumentList '{netsh_args}' -Verb RunAs -Wait");
+        format!("Start-Process -FilePath '{netsh}' -ArgumentList '{netsh_args}' -Verb RunAs -Wait");
 
-    let mut cmd = std::process::Command::new("powershell");
+    let mut cmd = std::process::Command::new(system32(r"WindowsPowerShell\v1.0\powershell.exe"));
     cmd.args(["-NoProfile", "-NonInteractive", "-Command", &command]);
     configure_no_window_command(&mut cmd);
     let output = cmd.output().context("Failed to run powershell")?;

--- a/src-tauri/src/platform/windows.rs
+++ b/src-tauri/src/platform/windows.rs
@@ -121,11 +121,22 @@ fn ensure_firewall_rule(app_handle: &AppHandle) {
 /// *elevated* subprocess, and both `CreateProcessW` and `ShellExecuteEx`
 /// include the current directory in their by-name search order — a planted
 /// `netsh.exe` in a user-writable CWD would run as administrator behind the
-/// one UAC prompt the user expects. Resolving from `%SystemRoot%` pins the
-/// real binaries; the unelevated query uses it too for consistency.
+/// one UAC prompt the user expects. Resolved via `GetSystemDirectoryW`
+/// rather than `%SystemRoot%`, since the environment is user-writable state
+/// too; the unelevated query uses it as well for consistency.
 fn system32(tail: &str) -> std::path::PathBuf {
-    let root = std::env::var_os("SystemRoot").unwrap_or_else(|| r"C:\Windows".into());
-    Path::new(&root).join("System32").join(tail)
+    use std::os::windows::ffi::OsStringExt;
+
+    let mut buf = [0u16; 260];
+    let len =
+        unsafe { ::windows::Win32::System::SystemInformation::GetSystemDirectoryW(Some(&mut buf)) }
+            as usize;
+    let dir = if len > 0 && len <= buf.len() {
+        std::path::PathBuf::from(std::ffi::OsString::from_wide(&buf[..len]))
+    } else {
+        std::path::PathBuf::from(r"C:\Windows\System32")
+    };
+    dir.join(tail)
 }
 
 /// Whether a rule named [`FIREWALL_RULE_NAME`] exists. Querying the firewall

--- a/src-tauri/translations/en.json
+++ b/src-tauri/translations/en.json
@@ -112,7 +112,11 @@
     "remove_legacy_title": "Remove old ESPHome Builder",
     "remove_legacy_prompt": "An older version of this app named “ESPHome Builder” was found in your Applications folder. Move it to the Trash?\n\nYour settings and configs are not affected.",
     "move_to_trash": "Move to Trash",
-    "keep": "Keep"
+    "keep": "Keep",
+    "firewall_title": "Allow network pairing",
+    "firewall_prompt": "Windows Firewall is blocking other ESPHome dashboards from pairing with this computer. Allow incoming connections for the app’s Python backend?\n\nWindows will ask for administrator approval.",
+    "firewall_allow": "Allow access",
+    "firewall_decline": "No thanks"
   },
   "hint": {
     "updates_menu": "Open the tray menu and choose \"Check for Updates...\" to update.",


### PR DESCRIPTION
# What does this implement/fix?

Pairing another dashboard to a Windows desktop install fails out of the box; Windows Defender blocks inbound connections to the peer link listener and usually the backend's mDNS responses too. The installer is per user and unelevated, so it cannot add a firewall rule itself.

On first run the app now offers to add a program scoped inbound allow rule for the managed Python interpreter behind one UAC prompt; a single program rule covers the peer link TCP port, including its fall forward, and mDNS on UDP 5353. The prompt is one shot, a marker file keeps later launches at a single stat. The uninstaller removes the rule best effort on a real uninstall and leaves it in place during updates; a drift test keeps the rule name in the NSIS hook and the Rust constant in sync.

A new Windows e2e in CI installs the real bundle and covers the headless testable paths: the app settles without prompting when the rule already exists, an update mode uninstall keeps the rule, a real uninstall removes it.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes https://github.com/esphome/esphome-desktop/issues/384

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).
