### PR TITLE
Rebuild bundles to pick up ESPHome 2026.7.2

### DIFF
--- a/build-scripts/prepare_bundle.sh
+++ b/build-scripts/prepare_bundle.sh
@@ -493,6 +493,9 @@ install_python_packages() {
 
     echo ""
     echo "=== Installing ESPHome (${platform}) ==="
+    # Deliberately unpinned: every bundle build ships whatever ESPHome is
+    # current on PyPI, so picking up a new ESPHome release just needs any
+    # merge to main after it publishes.
     "$python_dir/$python_bin" -m pip install esphome
 
     echo ""


### PR DESCRIPTION
# What does this implement/fix?

Rebuild trigger for ESPHome 2026.7.2. The bundle installs ESPHome unpinned from PyPI at build time, so the release just needs a merge to main after 2026.7.2 is published; the one line diff documents that behavior at the install site.

Do not merge until esphome/esphome#17794 is published to PyPI.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue (if applicable):**

- fixes <link to issue>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).
