### PR TITLE
fix: dedupe duplicate dist-info metadata after each bundled-tree copy

### DIFF
--- a/src-tauri/scripts/device_builder_maintenance.py
+++ b/src-tauri/scripts/device_builder_maintenance.py
@@ -143,6 +143,14 @@ def dedupe_dist_info(
                 file=sys.stderr,
             )
             continue
+        if not name:
+            # A dist-info with no Name header cannot be attributed to a
+            # package. Grouping the nameless together (their names all
+            # normalize to "") would treat unrelated broken dist-infos as
+            # duplicates of one another — never prune on missing identity.
+            path = getattr(dist, "_path", "?")
+            print(f"dedupe: skipping nameless distribution {path}", file=sys.stderr)
+            continue
         if targets is not None and name not in targets:
             continue
         # ``_path`` is private; guard it so a future importlib change degrades to

--- a/src-tauri/scripts/device_builder_maintenance.py
+++ b/src-tauri/scripts/device_builder_maintenance.py
@@ -83,6 +83,11 @@ def _norm(name: str | None) -> str:
     return (name or "").lower().replace("_", "-")
 
 
+def _dist_path(dist: Distribution) -> object:
+    """``dist``'s private ``_path`` for log messages, or ``"?"`` if absent."""
+    return getattr(dist, "_path", "?")
+
+
 def detect_version(dists: Iterable[Distribution]) -> str | None:
     """Return the highest version among all esphome-device-builder dists.
 
@@ -105,9 +110,8 @@ def detect_version(dists: Iterable[Distribution]) -> str | None:
             # Don't let one unreadable distribution abort detection, but log it:
             # silently dropping the real target would reintroduce the #190 loop
             # with no trace.
-            path = getattr(dist, "_path", "?")
             print(
-                f"detect: skipping unreadable distribution {path}: {err}",
+                f"detect: skipping unreadable distribution {_dist_path(dist)}: {err}",
                 file=sys.stderr,
             )
     return max(versions, key=vkey) if versions else None
@@ -137,9 +141,8 @@ def dedupe_dist_info(
         except Exception as err:
             # Log rather than silently skip: an unreadable target dist-info that
             # is never considered for dedup leaves the pileup in place (#190).
-            path = getattr(dist, "_path", "?")
             print(
-                f"dedupe: skipping unreadable distribution {path}: {err}",
+                f"dedupe: skipping unreadable distribution {_dist_path(dist)}: {err}",
                 file=sys.stderr,
             )
             continue
@@ -148,8 +151,10 @@ def dedupe_dist_info(
             # package. Grouping the nameless together (their names all
             # normalize to "") would treat unrelated broken dist-infos as
             # duplicates of one another — never prune on missing identity.
-            path = getattr(dist, "_path", "?")
-            print(f"dedupe: skipping nameless distribution {path}", file=sys.stderr)
+            print(
+                f"dedupe: skipping nameless distribution {_dist_path(dist)}",
+                file=sys.stderr,
+            )
             continue
         if targets is not None and name not in targets:
             continue

--- a/src-tauri/scripts/device_builder_maintenance.py
+++ b/src-tauri/scripts/device_builder_maintenance.py
@@ -1,9 +1,15 @@
 #!/usr/bin/env python3
 """Maintenance for the bundled esphome-device-builder install (#190).
 
-Two modes, selected by argv:
-  detect  -> print the highest installed version (empty if undeterminable)
-  dedupe  -> remove orphaned duplicate *.dist-info dirs; print the count removed
+Three modes, selected by argv:
+  detect     -> print the highest installed version (empty if undeterminable)
+  dedupe     -> remove orphaned duplicate *.dist-info dirs for the device-builder
+                packages; print the count removed
+  dedupe-all -> the same prune over every installed distribution; print the
+                count removed. Run after each bundled-tree copy so a dirty
+                source (the installer overlays the bundle without deleting the
+                previous release's dist-info dirs, #389) still yields a copy
+                with unambiguous importlib.metadata answers.
 
 The bundled Python accumulates duplicate dist-info dirs (orphaned by the
 ``--ignore-installed`` missing-RECORD recovery), which makes importlib.metadata
@@ -107,8 +113,13 @@ def detect_version(dists: Iterable[Distribution]) -> str | None:
     return max(versions, key=vkey) if versions else None
 
 
-def dedupe_dist_info(dists: Iterable[Distribution]) -> int:
-    """Keep the highest-version dist-info per target package; remove the rest.
+def dedupe_dist_info(
+    dists: Iterable[Distribution], targets: set[str] | None = TARGETS
+) -> int:
+    """Keep the highest-version dist-info per package; remove the rest.
+
+    ``targets`` limits the prune to the given normalized package names;
+    ``None`` considers every distribution (the ``dedupe-all`` mode).
 
     The newest version is the code installed last by ``pip install --upgrade``,
     so its metadata is the one to keep. Returns the number of stale dist-info
@@ -132,7 +143,7 @@ def dedupe_dist_info(dists: Iterable[Distribution]) -> int:
                 file=sys.stderr,
             )
             continue
-        if name not in TARGETS:
+        if targets is not None and name not in targets:
             continue
         # ``_path`` is private; guard it so a future importlib change degrades to
         # a no-op rather than deleting the wrong directory.
@@ -184,6 +195,9 @@ def main(argv: list[str]) -> int:
         return 0
     if mode == "dedupe":
         print(dedupe_dist_info(distributions()))
+        return 0
+    if mode == "dedupe-all":
+        print(dedupe_dist_info(distributions(), targets=None))
         return 0
     print(f"unknown mode: {mode!r}", file=sys.stderr)
     return 2

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -30,6 +30,7 @@ pub use process::{
     configure_daemon_tokio_command, isolate_python_tokio_command, run_python_capture,
     run_python_capture_stdout,
 };
+pub(crate) use python_env::{dedupe_dist_info, DistInfoDedupeScope, DEVICE_BUILDER_MAINT_PY};
 pub use python_env::{ensure_user_python, interpreter_is_usable, RefreshReason};
 
 /// Application bundle identifier. Must match the `identifier` field in
@@ -1163,6 +1164,17 @@ mod tests {
             crate::update::is_newer_version(&current, &downgraded),
             "the downgrade produced {downgraded}, which is not older than {current}"
         );
+        // Dirty the second source the way the installer overlay does (#389):
+        // a stale dist-info stranded beside the real one, so importlib gets
+        // two answers for esphome's version. The refresh below must not
+        // reproduce this into the user tree.
+        let stale_dist_info = e2e_purelib(&old_python).join("esphome-0.0.1.dist-info");
+        std::fs::create_dir_all(&stale_dist_info).unwrap();
+        std::fs::write(
+            stale_dist_info.join("METADATA"),
+            "Metadata-Version: 2.1\nName: esphome\nVersion: 0.0.1\n",
+        )
+        .unwrap();
 
         // 9. Refresh from the older source. The snapshot reads the newer
         //    version from the user tree, the copy lands the older one, and the
@@ -1199,6 +1211,26 @@ mod tests {
         assert!(
             out.contains(&current),
             "esphome reports a version other than {current} after the restore: {out}"
+        );
+
+        // 11. The stale dist-info planted in the source must not have survived
+        //     the copy: the post-copy dedupe prunes to one dist-info per
+        //     package, so importlib has exactly one answer for esphome — the
+        //     direct negation of the #389 symptom. Counted in the refreshed
+        //     tree's own purelib (re-resolved: the refresh wiped and recreated
+        //     the directory the step-2 value pointed into).
+        let refreshed_purelib = e2e_purelib(&python);
+        let esphome_dist_infos: Vec<_> = std::fs::read_dir(&refreshed_purelib)
+            .expect("could not list the refreshed purelib")
+            .filter_map(|entry| {
+                let name = entry.unwrap().file_name().into_string().unwrap();
+                (name.starts_with("esphome-") && name.ends_with(".dist-info")).then_some(name)
+            })
+            .collect();
+        assert_eq!(
+            esphome_dist_infos,
+            [format!("esphome-{current}.dist-info")],
+            "the refreshed tree must hold exactly one esphome dist-info"
         );
 
         let _ = std::fs::remove_dir_all(&base);

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -27,10 +27,9 @@ pub use pip::{pip_command, pip_output_report, run_pip};
 #[cfg(target_os = "windows")]
 pub use process::{assign_to_kill_on_close_job, send_ctrl_break};
 pub use process::{
-    configure_daemon_tokio_command, isolate_python_tokio_command, run_python_capture,
-    run_python_capture_stdout,
+    configure_daemon_tokio_command, isolate_python_tokio_command, run_python_capture_stdout,
 };
-pub(crate) use python_env::{dedupe_dist_info, DistInfoDedupeScope, DEVICE_BUILDER_MAINT_PY};
+pub(crate) use python_env::{dedupe_dist_info, detect_device_builder_version, DistInfoDedupeScope};
 pub use python_env::{ensure_user_python, interpreter_is_usable, RefreshReason};
 
 /// Application bundle identifier. Must match the `identifier` field in
@@ -965,13 +964,13 @@ mod tests {
 
     /// Run the tree's interpreter and return (success, stdout+stderr).
     ///
-    /// Goes through [`run_python_capture`] so the harness is isolated exactly as
-    /// the code under test is. Spawning the interpreter directly would let the
-    /// runner's user site-packages or an ambient `PYTHONPATH` satisfy an import
-    /// (#318), and every assertion in the e2e must report on the tree under
-    /// test alone.
+    /// Goes through [`process::run_python_capture`] so the harness is isolated
+    /// exactly as the code under test is. Spawning the interpreter directly
+    /// would let the runner's user site-packages or an ambient `PYTHONPATH`
+    /// satisfy an import (#318), and every assertion in the e2e must report on
+    /// the tree under test alone.
     fn e2e_run(python: &Path, args: &[&str]) -> (bool, String) {
-        let output = run_python_capture(python, args)
+        let output = process::run_python_capture(python, args)
             .unwrap_or_else(|e| panic!("failed to run {python:?} {args:?}: {e}"));
         e2e_verdict(output)
     }
@@ -1216,11 +1215,10 @@ mod tests {
         // 11. The stale dist-info planted in the source must not have survived
         //     the copy: the post-copy dedupe prunes to one dist-info per
         //     package, so importlib has exactly one answer for esphome — the
-        //     direct negation of the #389 symptom. Counted in the refreshed
-        //     tree's own purelib (re-resolved: the refresh wiped and recreated
-        //     the directory the step-2 value pointed into).
-        let refreshed_purelib = e2e_purelib(&python);
-        let esphome_dist_infos: Vec<_> = std::fs::read_dir(&refreshed_purelib)
+        //     direct negation of the #389 symptom. The step-2 `purelib` path
+        //     is still the right place to look: the refresh recreated the
+        //     directory, but at the same location.
+        let esphome_dist_infos: Vec<_> = std::fs::read_dir(&purelib)
             .expect("could not list the refreshed purelib")
             .filter_map(|entry| {
                 let name = entry.unwrap().file_name().into_string().unwrap();

--- a/src-tauri/src/platform/python_env.rs
+++ b/src-tauri/src/platform/python_env.rs
@@ -239,7 +239,7 @@ pub(super) fn refresh_python_tree(
     // carry both releases' `.dist-info` dirs and the copy above reproduces
     // them (#389). Prune to one dist-info per package before anything reads
     // the fresh tree — the version restore below and every later pip
-    // uninstall reason from `importlib.metadata`, which duplicates make
+    // uninstall rely on `importlib.metadata`, which duplicates make
     // ambiguous. Best-effort: duplicate metadata does not fail the health
     // probe, so failing the refresh over it would turn an ambiguity into a
     // broken tree. Runs before the marker write so a crash mid-prune leaves

--- a/src-tauri/src/platform/python_env.rs
+++ b/src-tauri/src/platform/python_env.rs
@@ -395,15 +395,19 @@ fn restore_preserved_versions(python_bin: &Path, preserved: &PreservedVersions) 
 /// if undeterminable); `dedupe` / `dedupe-all` remove orphaned duplicate
 /// `.dist-info` dirs and print how many they removed. Embedded so it ships with
 /// the binary and stays in sync with its pytest suite
-/// (`tests/test_device_builder_maintenance.py`).
-pub(crate) const DEVICE_BUILDER_MAINT_PY: &str =
-    include_str!("../../scripts/device_builder_maintenance.py");
+/// (`tests/test_device_builder_maintenance.py`). Private: the argv-mode
+/// contract is owned entirely by the two runners below.
+const DEVICE_BUILDER_MAINT_PY: &str = include_str!("../../scripts/device_builder_maintenance.py");
 
 /// Which distributions [`dedupe_dist_info`] may prune.
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum DistInfoDedupeScope {
     /// Only `esphome-device-builder` and its frontend — the lazy #190 heal the
     /// device-builder update check runs when it cannot determine a version.
+    /// Deliberately narrow even though the guards are scope-independent: this
+    /// heal runs on a live user tree mid-session, so it prunes no more than
+    /// the packages whose metadata it needs; the post-copy self-clean owns
+    /// the whole-tree scope.
     DeviceBuilder,
     /// Every installed distribution — the self-clean each bundle copy runs so a
     /// dirty source tree still yields unambiguous metadata (#389).
@@ -442,17 +446,60 @@ pub(crate) fn dedupe_dist_info(python_bin: &Path, scope: DistInfoDedupeScope) ->
         );
     }
     // The helper logs dist-info it couldn't read or remove to stderr; surface it
-    // so a partial prune isn't silently lost.
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    let stderr = stderr.trim();
+    // (bounded) so a partial prune isn't silently lost.
+    let stderr = tail_for_log(&String::from_utf8_lossy(&output.stderr));
     if !stderr.is_empty() {
         warn!("dist-info dedup ({mode}): {stderr}");
     }
-    let removed = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let removed = stdout.trim();
     if !removed.is_empty() && removed != "0" {
         info!("Removed {removed} stale dist-info dir(s) ({mode})");
     }
     Ok(())
+}
+
+/// Get the installed `esphome-device-builder` package version using the
+/// maintenance helper's `detect` mode, which enumerates every matching
+/// distribution and takes the highest version — robust to the duplicate
+/// dist-info pileup that makes a plain `importlib.metadata.version(...)`
+/// return None or an older version (#190).
+///
+/// - `Ok(Some(v))` — package is installed, returns the version string.
+/// - `Ok(None)` — `detect` ran successfully (exit 0) but printed no version:
+///   the package is not installed, or duplicate dist-info dirs left it
+///   undeterminable (#190).
+/// - `Err(_)` — detection itself failed: the spawn failed or the helper exited
+///   non-zero (a broken interpreter / import error). Callers should surface
+///   this rather than treat it as "not installed".
+pub(crate) fn detect_device_builder_version(python_bin: &Path) -> Result<Option<String>> {
+    // `-I` (isolated) keeps user site-packages, PYTHONPATH and sitecustomize off
+    // sys.path so detection only ever sees the managed bundled install.
+    let output = run_python_capture(python_bin, ["-I", "-c", DEVICE_BUILDER_MAINT_PY, "detect"])
+        .context("Failed to run python")?;
+    if !output.status.success() {
+        // `detect` exits 0 even when the package is absent (it prints nothing),
+        // so a non-zero exit is a real execution failure.
+        anyhow::bail!(
+            "device-builder version detection failed: {}",
+            tail_for_log(&String::from_utf8_lossy(&output.stderr))
+        );
+    }
+    // `detect` logs skipped/unreadable distributions to stderr; surface it so
+    // the reason a version came back undeterminable isn't lost.
+    let stderr = tail_for_log(&String::from_utf8_lossy(&output.stderr));
+    if !stderr.is_empty() {
+        warn!("device-builder version detection: {stderr}");
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let version = stdout.trim();
+    // Empty means "not determinable" (no install or an unresolvable pileup);
+    // the "None" guard is belt-and-suspenders. Either way the caller must not
+    // be offered an endless update (#190).
+    if version.is_empty() || version == "None" {
+        return Ok(None);
+    }
+    Ok(Some(version.to_string()))
 }
 
 /// Read the installed version of a Python package via `importlib.metadata`.
@@ -766,6 +813,19 @@ mod tests {
         assert_marker_current(&user);
 
         let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn maint_script_pins_the_argv_mode_contract() {
+        // Behavior is covered in depth by tests/test_device_builder_maintenance.py;
+        // here we only pin the argv modes the two runners above invoke, so a
+        // rename of the modes (not the internal functions) can't pass silently.
+        // The bare `dedupe` mode is matched by its dispatch line because any
+        // string containing "dedupe-all" trivially contains "dedupe".
+        assert!(DEVICE_BUILDER_MAINT_PY.contains("detect"));
+        assert!(DEVICE_BUILDER_MAINT_PY.contains("if mode == \"dedupe\":"));
+        assert!(DEVICE_BUILDER_MAINT_PY.contains("dedupe-all"));
+        assert!(DEVICE_BUILDER_MAINT_PY.contains("esphome-device-builder-frontend"));
     }
 
     #[cfg(unix)]

--- a/src-tauri/src/platform/python_env.rs
+++ b/src-tauri/src/platform/python_env.rs
@@ -234,6 +234,22 @@ pub(super) fn refresh_python_tree(
     copy_dir_recursive(&bundled_python, user_python)?;
     let copy_elapsed = copy_started.elapsed();
 
+    // The bundle is not guaranteed clean: the installer overlays the install
+    // dir without deleting the previous release's files, so the source can
+    // carry both releases' `.dist-info` dirs and the copy above reproduces
+    // them (#389). Prune to one dist-info per package before anything reads
+    // the fresh tree — the version restore below and every later pip
+    // uninstall reason from `importlib.metadata`, which duplicates make
+    // ambiguous. Best-effort: duplicate metadata does not fail the health
+    // probe, so failing the refresh over it would turn an ambiguity into a
+    // broken tree. Runs before the marker write so a crash mid-prune leaves
+    // no marker and the next launch re-copies and re-prunes.
+    if let Err(e) = dedupe_dist_info(&python_check, DistInfoDedupeScope::All) {
+        warn!(
+            "dist-info dedup after the bundle copy failed ({e:#}); continuing with the copied tree"
+        );
+    }
+
     // Atomic write: a torn marker could read back as a partial version
     // string, mismatching on next launch and re-copying the whole tree.
     crate::util::atomic_write(&marker_path, current_version)
@@ -372,6 +388,71 @@ fn restore_preserved_versions(python_bin: &Path, preserved: &PreservedVersions) 
             );
         }
     }
+}
+
+/// Maintenance helper run with the bundled interpreter as `python -I -c <src>
+/// <mode>`. `detect` prints the highest installed device-builder version (empty
+/// if undeterminable); `dedupe` / `dedupe-all` remove orphaned duplicate
+/// `.dist-info` dirs and print how many they removed. Embedded so it ships with
+/// the binary and stays in sync with its pytest suite
+/// (`tests/test_device_builder_maintenance.py`).
+pub(crate) const DEVICE_BUILDER_MAINT_PY: &str =
+    include_str!("../../scripts/device_builder_maintenance.py");
+
+/// Which distributions [`dedupe_dist_info`] may prune.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum DistInfoDedupeScope {
+    /// Only `esphome-device-builder` and its frontend — the lazy #190 heal the
+    /// device-builder update check runs when it cannot determine a version.
+    DeviceBuilder,
+    /// Every installed distribution — the self-clean each bundle copy runs so a
+    /// dirty source tree still yields unambiguous metadata (#389).
+    All,
+}
+
+/// Remove orphaned duplicate `.dist-info` directories, keeping the highest
+/// version's metadata per package (the code on disk is whatever pip installed
+/// last, i.e. the newest).
+///
+/// Duplicates make `importlib.metadata` answer with an arbitrary one of the
+/// piled-up versions, which poisons everything that trusts it: the
+/// device-builder update check loops on "version None" (#190), and the
+/// pinned-version snapshot/restore around a tree refresh compares against a
+/// stale version (#389). The prune itself lives in
+/// [`DEVICE_BUILDER_MAINT_PY`], which never deletes an entry it cannot rank —
+/// see its pytest suite for the guard behavior.
+///
+/// `Err` covers both a failed spawn and a non-zero exit; callers on paths that
+/// must not fail (the copy in [`refresh_python_tree`], the best-effort heal in
+/// the update check) log and continue.
+pub(crate) fn dedupe_dist_info(python_bin: &Path, scope: DistInfoDedupeScope) -> Result<()> {
+    let mode = match scope {
+        DistInfoDedupeScope::DeviceBuilder => "dedupe",
+        DistInfoDedupeScope::All => "dedupe-all",
+    };
+    // `-I` (isolated) keeps user site-packages, PYTHONPATH and sitecustomize off
+    // sys.path so this destructive prune can only ever touch the managed bundled
+    // install, never a user-site or externally-injected tree.
+    let output = run_python_capture(python_bin, ["-I", "-c", DEVICE_BUILDER_MAINT_PY, mode])
+        .context("Failed to run dist-info dedup")?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "dist-info dedup ({mode}) exited non-zero: {}",
+            tail_for_log(&String::from_utf8_lossy(&output.stderr))
+        );
+    }
+    // The helper logs dist-info it couldn't read or remove to stderr; surface it
+    // so a partial prune isn't silently lost.
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stderr = stderr.trim();
+    if !stderr.is_empty() {
+        warn!("dist-info dedup ({mode}): {stderr}");
+    }
+    let removed = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if !removed.is_empty() && removed != "0" {
+        info!("Removed {removed} stale dist-info dir(s) ({mode})");
+    }
+    Ok(())
 }
 
 /// Read the installed version of a Python package via `importlib.metadata`.
@@ -630,6 +711,79 @@ mod tests {
         assert!(!orphan.exists(), "the repair must wipe before re-copying");
         assert!(interpreter_in_tree(&user).is_file());
         assert_marker_current(&user);
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    /// Stub interpreter body that appends the last argv entry — the maintenance
+    /// script's mode argument — to `log`, so a test can assert which mode a
+    /// spawn used without wading through the embedded script text.
+    #[cfg(unix)]
+    fn log_last_arg_stub(log: &Path) -> String {
+        format!(
+            "for a; do last=$a; done; echo \"$last\" >> {}",
+            log.display()
+        )
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn refresh_copy_runs_the_all_packages_dedupe() {
+        // The copied bundle is not guaranteed clean (#389), so every copy must
+        // finish with a `dedupe-all` pass through the fresh tree's own
+        // interpreter — here a stub that records the mode it was invoked with.
+        let base = unique_temp_dir("refresh-dedupe");
+        let bundle = base.join("bundle");
+        let log = base.join("calls.log");
+        write_stub_interpreter(&bundle.join("bin"), &log_last_arg_stub(&log));
+        let user = base.join("python");
+
+        refresh_python_tree(&user, || Ok(bundle.clone()), RefreshReason::Startup).unwrap();
+
+        let calls = std::fs::read_to_string(&log).unwrap_or_default();
+        assert!(
+            calls.lines().any(|line| line == "dedupe-all"),
+            "the copy must run the all-packages dist-info dedupe, got: {calls:?}"
+        );
+        assert_marker_current(&user);
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn refresh_survives_a_failing_dedupe() {
+        // The dedupe is best-effort: duplicate metadata does not fail the
+        // health probe, so a dedupe failure must not fail the refresh either —
+        // the marker still lands and the tree stays usable.
+        let base = unique_temp_dir("refresh-dedupe-fail");
+        let bundle = base.join("bundle");
+        write_stub_interpreter(&bundle.join("bin"), "exit 1");
+        let user = base.join("python");
+
+        refresh_python_tree(&user, || Ok(bundle.clone()), RefreshReason::Startup)
+            .expect("a failed dedupe must not fail the refresh");
+        assert_marker_current(&user);
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn dedupe_scope_selects_the_script_mode() {
+        let base = unique_temp_dir("dedupe-scope");
+        let log = base.join("calls.log");
+        let bin = write_stub_interpreter(&base, &log_last_arg_stub(&log));
+
+        dedupe_dist_info(&bin, DistInfoDedupeScope::DeviceBuilder).unwrap();
+        dedupe_dist_info(&bin, DistInfoDedupeScope::All).unwrap();
+
+        let calls = std::fs::read_to_string(&log).unwrap();
+        assert_eq!(
+            calls.lines().collect::<Vec<_>>(),
+            ["dedupe", "dedupe-all"],
+            "each scope must map to its maintenance-script mode"
+        );
 
         let _ = std::fs::remove_dir_all(&base);
     }

--- a/src-tauri/src/update/mod.rs
+++ b/src-tauri/src/update/mod.rs
@@ -950,13 +950,6 @@ fn find_latest_any(releases: &HashMap<String, Vec<PyPIRelease>>) -> Option<Strin
     highest_version(releases, |_| true)
 }
 
-/// Maintenance helper run with the bundled interpreter as `python -c <src>
-/// <mode>`. `detect` prints the highest installed device-builder version (empty
-/// if undeterminable); `dedupe` removes orphaned duplicate `.dist-info` dirs and
-/// prints how many it removed. Embedded so it ships with the binary and stays in
-/// sync with its pytest suite (`tests/test_device_builder_maintenance.py`).
-const DEVICE_BUILDER_MAINT_PY: &str = include_str!("../../scripts/device_builder_maintenance.py");
-
 /// Get the installed `esphome-device-builder` package version.
 ///
 /// - `Ok(Some(v))` — package is installed, returns the version string.
@@ -977,7 +970,7 @@ pub fn get_installed_device_builder_version(app_handle: &AppHandle) -> Result<Op
     // sys.path so detection only ever sees the managed bundled install.
     let output = platform::run_python_capture(
         &python_path,
-        ["-I", "-c", DEVICE_BUILDER_MAINT_PY, "detect"],
+        ["-I", "-c", platform::DEVICE_BUILDER_MAINT_PY, "detect"],
     )
     .context("Failed to run python")?;
 
@@ -1016,49 +1009,22 @@ pub fn get_installed_device_builder_version(app_handle: &AppHandle) -> Result<Op
 /// The `--ignore-installed` install fallback skipped the uninstall and left the
 /// previous version's `.dist-info` behind; once several pile up,
 /// `importlib.metadata` can no longer resolve a single version and the updater
-/// loops forever offering "version None" (#190). This heals that state. It is
-/// best-effort: a failure is logged and swallowed so it can never block an
-/// install or an update check.
+/// loops forever offering "version None" (#190). This heals that state. An
+/// `Err` covers both a failed spawn and a non-zero helper exit; the one caller
+/// treats it as best-effort, logging rather than blocking the update check.
 ///
-/// Nothing produces this damage any more — the fallback that caused it is gone
-/// (see [`install_with_record_recovery`]) and the repair re-copies a pristine
-/// tree, leaving no orphans.
-/// It stays because trees damaged *before* that change still exist in the wild,
-/// and nothing else recovers them: duplicate metadata does not fail an install
-/// or the `esphome config` health probe, so neither repair path would ever fire.
-/// Delete it once the installed base has cycled past the releases that shipped
-/// the fallback.
+/// The `--ignore-installed` fallback that caused most of this damage is gone
+/// (see [`install_with_record_recovery`]), but the damage still arises: the
+/// installer overlays the install dir without deleting the previous release's
+/// files, so the bundled tree itself can carry duplicate dist-info dirs (#389).
+/// Each bundle copy now prunes itself
+/// ([`platform::dedupe_dist_info`] runs in `dedupe-all` scope after the copy),
+/// so this lazy device-builder-scoped heal mostly covers trees that predate
+/// that self-clean; duplicate metadata does not fail an install or the
+/// `esphome config` health probe, so nothing else would recover them.
 pub fn dedupe_device_builder_dist_info(app_handle: &AppHandle) -> Result<()> {
     let python_path = platform::get_python_path(app_handle)?;
-
-    // `-I` (isolated) keeps user site-packages, PYTHONPATH and sitecustomize off
-    // sys.path so this destructive prune can only ever touch the managed bundled
-    // install, never a user-site or externally-injected tree.
-    let output = platform::run_python_capture(
-        &python_path,
-        ["-I", "-c", DEVICE_BUILDER_MAINT_PY, "dedupe"],
-    )
-    .context("Failed to run dist-info dedup")?;
-
-    if output.status.success() {
-        // The helper logs dist-info it couldn't read or remove to stderr;
-        // surface it so a partial prune isn't silently lost.
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let stderr = stderr.trim();
-        if !stderr.is_empty() {
-            warn!("device-builder dist-info dedup: {stderr}");
-        }
-        let removed = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        if !removed.is_empty() && removed != "0" {
-            info!("Removed {removed} stale device-builder dist-info dir(s)");
-        }
-    } else {
-        warn!(
-            "device-builder dist-info dedup failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-    Ok(())
+    platform::dedupe_dist_info(&python_path, platform::DistInfoDedupeScope::DeviceBuilder)
 }
 
 /// Detect the installed device-builder version, healing a duplicate dist-info
@@ -1624,8 +1590,10 @@ mod tests {
         // here we only pin the argv-mode contract this module invokes it with, so
         // a rename of the modes (not the internal functions) can't pass silently.
         // Match the bare mode words so the check is tolerant of quote style.
+        use crate::platform::DEVICE_BUILDER_MAINT_PY;
         assert!(DEVICE_BUILDER_MAINT_PY.contains("detect"));
         assert!(DEVICE_BUILDER_MAINT_PY.contains("dedupe"));
+        assert!(DEVICE_BUILDER_MAINT_PY.contains("dedupe-all"));
         assert!(DEVICE_BUILDER_MAINT_PY.contains("esphome-device-builder-frontend"));
     }
 

--- a/src-tauri/src/update/mod.rs
+++ b/src-tauri/src/update/mod.rs
@@ -950,57 +950,12 @@ fn find_latest_any(releases: &HashMap<String, Vec<PyPIRelease>>) -> Option<Strin
     highest_version(releases, |_| true)
 }
 
-/// Get the installed `esphome-device-builder` package version.
-///
-/// - `Ok(Some(v))` — package is installed, returns the version string.
-/// - `Ok(None)` — `detect` ran successfully (exit 0) but printed no version: the
-///   package is not installed, or duplicate dist-info dirs left it
-///   undeterminable (#190).
-/// - `Err(e)` — detection itself failed: the bundled Python is missing, the
-///   spawn failed, or the helper exited non-zero (a broken interpreter / import
-///   error). The caller should surface this rather than treat it as "not
-///   installed".
+/// Get the installed `esphome-device-builder` package version. Result
+/// semantics (including why `Err` must not be read as "not installed") are
+/// [`platform::detect_device_builder_version`]'s.
 pub fn get_installed_device_builder_version(app_handle: &AppHandle) -> Result<Option<String>> {
     let python_path = platform::get_python_path(app_handle)?;
-
-    // Enumerate all device-builder distributions and take the highest version,
-    // which is robust to the duplicate dist-info pileup that makes a plain
-    // `importlib.metadata.version(...)` return None or an older version (#190).
-    // `-I` (isolated) keeps user site-packages, PYTHONPATH and sitecustomize off
-    // sys.path so detection only ever sees the managed bundled install.
-    let output = platform::run_python_capture(
-        &python_path,
-        ["-I", "-c", platform::DEVICE_BUILDER_MAINT_PY, "detect"],
-    )
-    .context("Failed to run python")?;
-
-    if output.status.success() {
-        // `detect` logs skipped/unreadable distributions to stderr; surface it so
-        // the reason a version came back undeterminable isn't lost.
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let stderr = stderr.trim();
-        if !stderr.is_empty() {
-            warn!("device-builder version detection: {stderr}");
-        }
-        let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        // `detect` prints nothing when it cannot determine a version (no install
-        // or an unresolvable pileup); the "None" guard is belt-and-suspenders.
-        // Treat either as "not determinable" so the updater does not offer an
-        // endless update (#190).
-        if version.is_empty() || version == "None" {
-            return Ok(None);
-        }
-        Ok(Some(version))
-    } else {
-        // `detect` exits 0 even when the package is absent (it prints nothing),
-        // so a non-zero exit is a real execution failure (broken bundled
-        // interpreter, import error, etc.). Surface it rather than silently
-        // misclassifying it as "not installed" and skipping the update check.
-        anyhow::bail!(
-            "device-builder version detection failed: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
-        )
-    }
+    platform::detect_device_builder_version(&python_path)
 }
 
 /// Remove orphaned duplicate `.dist-info` directories for the device-builder
@@ -1009,9 +964,9 @@ pub fn get_installed_device_builder_version(app_handle: &AppHandle) -> Result<Op
 /// The `--ignore-installed` install fallback skipped the uninstall and left the
 /// previous version's `.dist-info` behind; once several pile up,
 /// `importlib.metadata` can no longer resolve a single version and the updater
-/// loops forever offering "version None" (#190). This heals that state. An
-/// `Err` covers both a failed spawn and a non-zero helper exit; the one caller
-/// treats it as best-effort, logging rather than blocking the update check.
+/// loops forever offering "version None" (#190). This heals that state. Error
+/// semantics are [`platform::dedupe_dist_info`]'s; the one caller treats an
+/// `Err` as best-effort, logging rather than blocking the update check.
 ///
 /// The `--ignore-installed` fallback that caused most of this damage is gone
 /// (see [`install_with_record_recovery`]), but the damage still arises: the
@@ -1582,19 +1537,6 @@ mod tests {
         assert!(!is_newer_version("2026.5.0-dev", "2026.5.0"));
         // A newer base version dev is still newer than an older stable
         assert!(is_newer_version("2026.5.0-dev", "2026.4.0"));
-    }
-
-    #[test]
-    fn test_device_builder_maint_py_well_formed() {
-        // Behavior is covered in depth by tests/test_device_builder_maintenance.py;
-        // here we only pin the argv-mode contract this module invokes it with, so
-        // a rename of the modes (not the internal functions) can't pass silently.
-        // Match the bare mode words so the check is tolerant of quote style.
-        use crate::platform::DEVICE_BUILDER_MAINT_PY;
-        assert!(DEVICE_BUILDER_MAINT_PY.contains("detect"));
-        assert!(DEVICE_BUILDER_MAINT_PY.contains("dedupe"));
-        assert!(DEVICE_BUILDER_MAINT_PY.contains("dedupe-all"));
-        assert!(DEVICE_BUILDER_MAINT_PY.contains("esphome-device-builder-frontend"));
     }
 
     #[test]

--- a/tests/test_device_builder_maintenance.py
+++ b/tests/test_device_builder_maintenance.py
@@ -179,3 +179,49 @@ def test_dedupe_groups_frontend_independently(tmp_path: Path) -> None:
     assert maint.dedupe_dist_info(_dists(tmp_path)) == 2
     assert main_keep.is_dir()
     assert fe_keep.is_dir()
+
+
+# --------------------------------------------------------------------------- #
+# dedupe_dist_info(targets=None): the post-copy self-clean (#389).
+# --------------------------------------------------------------------------- #
+
+
+def test_dedupe_default_scope_ignores_non_target_duplicates(tmp_path: Path) -> None:
+    # The #190 heal must stay scoped to the device-builder packages: a plain
+    # esphome pileup is the copy path's job (dedupe-all), not the update
+    # check's.
+    old = _make_dist_info(tmp_path, "esphome", "2026.7.0")
+    new = _make_dist_info(tmp_path, "esphome", "2026.7.1")
+    assert maint.dedupe_dist_info(_dists(tmp_path)) == 0
+    assert old.is_dir()
+    assert new.is_dir()
+
+
+def test_dedupe_all_prunes_any_package(tmp_path: Path) -> None:
+    # The live #389 shape: the installer overlays the bundle without deleting
+    # the previous release's files, stranding its dist-info next to the new
+    # one for several packages at once.
+    esphome_old = _make_dist_info(tmp_path, "esphome", "2026.7.0")
+    esphome_new = _make_dist_info(tmp_path, "esphome", "2026.7.1")
+    aioesp_old = _make_dist_info(tmp_path, "aioesphomeapi", "45.6.0")
+    aioesp_new = _make_dist_info(tmp_path, "aioesphomeapi", "45.6.2")
+    single = _make_dist_info(tmp_path, "bleak", "2.1.1")
+    assert maint.dedupe_dist_info(_dists(tmp_path), targets=None) == 2
+    assert esphome_new.is_dir()
+    assert aioesp_new.is_dir()
+    assert single.is_dir()
+    assert not esphome_old.exists()
+    assert not aioesp_old.exists()
+
+
+def test_dedupe_all_keeps_safety_guards(tmp_path: Path) -> None:
+    # The guard behavior must survive the scope widening: an all-unparseable
+    # group is left whole, and an unparseable sibling is never deleted on the
+    # strength of the lowest-sort sentinel.
+    amb_a = _make_dist_info(tmp_path, "aioesphomeapi", "45.6.0", with_version=False)
+    amb_b = _make_dist_info(tmp_path, "aioesphomeapi", "45.6.2", with_version=False)
+    keep = _make_dist_info(tmp_path, "esphome", "2026.7.1")
+    broken = _make_dist_info(tmp_path, "esphome", "2026.7.0", with_version=False)
+    assert maint.dedupe_dist_info(_dists(tmp_path), targets=None) == 0
+    for path in (amb_a, amb_b, keep, broken):
+        assert path.is_dir()

--- a/tests/test_device_builder_maintenance.py
+++ b/tests/test_device_builder_maintenance.py
@@ -30,12 +30,19 @@ maint = load_script_module(SCRIPT_PATH)
 
 
 def _make_dist_info(
-    site: Path, package: str, version: str | None, *, with_version: bool = True
+    site: Path,
+    package: str,
+    version: str | None,
+    *,
+    with_version: bool = True,
+    with_name: bool = True,
 ) -> Path:
     """Create a *.dist-info dir for ``package`` and return its path."""
     dist_info = site / f"{package.replace('-', '_')}-{version}.dist-info"
     dist_info.mkdir(parents=True)
-    lines = ["Metadata-Version: 2.1", f"Name: {package}"]
+    lines = ["Metadata-Version: 2.1"]
+    if with_name:
+        lines.append(f"Name: {package}")
     if with_version and version is not None:
         lines.append(f"Version: {version}")
     (dist_info / "METADATA").write_text("\n".join(lines) + "\n")
@@ -212,6 +219,22 @@ def test_dedupe_all_prunes_any_package(tmp_path: Path) -> None:
     assert single.is_dir()
     assert not esphome_old.exists()
     assert not aioesp_old.exists()
+
+
+def test_dedupe_all_never_groups_nameless_dist_infos(tmp_path: Path) -> None:
+    # Two unrelated dist-infos whose METADATA lost its Name header normalize
+    # to ""; grouping them would prune one as a "duplicate" of the other even
+    # though they belong to different packages. Both must survive, and a
+    # healthy pair must still dedupe normally alongside them.
+    orphan_a = _make_dist_info(tmp_path, "pkg-a", "1.0.0", with_name=False)
+    orphan_b = _make_dist_info(tmp_path, "pkg-b", "2.0.0", with_name=False)
+    keep = _make_dist_info(tmp_path, "esphome", "2026.7.1")
+    stale = _make_dist_info(tmp_path, "esphome", "2026.7.0")
+    assert maint.dedupe_dist_info(_dists(tmp_path), targets=None) == 1
+    assert orphan_a.is_dir()
+    assert orphan_b.is_dir()
+    assert keep.is_dir()
+    assert not stale.exists()
 
 
 def test_dedupe_all_keeps_safety_guards(tmp_path: Path) -> None:


### PR DESCRIPTION
## Proposed change

Fixes #389.

Every bundled-tree copy now finishes with a dist-info dedupe pass, so a dirty
source still yields a copy with unambiguous `importlib.metadata` answers.

The refresh copy (`refresh_python_tree`) reproduces the bundle verbatim — and
the bundle is not guaranteed clean: the installer overlays the install dir
without deleting the previous release's files, so the shipped tree can carry
both releases' `.dist-info` dirs. Verified live on a 0.16.0 Windows install:
`esphome-2026.7.0.dist-info` + `esphome-2026.7.1.dist-info` (plus matching
pairs for `aioesphomeapi`, `esphome-device-builder`, and the frontend) side by
side, with `importlib.metadata.version("esphome")` answering 2026.7.0 while
the code on disk is 2026.7.1. A successful health-probe repair faithfully
restores that ambiguity, and it poisons real decisions: the pinned-version
snapshot around the refresh reads the stale version, and pip resolves against
metadata that names the wrong install.

- `device_builder_maintenance.py` grows a `dedupe-all` mode:
  `dedupe_dist_info` takes an optional `targets` scope, `None` meaning every
  distribution. The `detect`/`dedupe` modes and all safety guards (never
  delete an entry that cannot be ranked, leave a group with no parseable
  winner) are unchanged and now pinned by tests in the widened scope.
- The maintenance-script runner moves down into `platform::python_env`
  (`dedupe_dist_info(python_bin, DistInfoDedupeScope)`), and
  `refresh_python_tree` invokes it in `All` scope after the copy, before the
  version marker lands and before `restore_preserved_versions` reads the fresh
  tree. Best-effort: duplicate metadata does not fail the health probe, so a
  failed dedupe warns and keeps the tree rather than failing the refresh. A
  crash mid-dedupe leaves no marker, so the next launch re-copies and
  re-prunes.
- `update::dedupe_device_builder_dist_info` becomes a thin wrapper over the
  moved runner (`DeviceBuilder` scope), keeping the lazy #190 heal in the
  device-builder update check exactly as it was.

Deliberate non-goals: no dedupe on routine no-copy startups (existing dirty
app-data trees heal at the next app update or repair, and a per-launch
interpreter spawn is a real cost on Defender-scanned Windows), and no
installer change to stop the overlay from dirtying the bundle in the first
place — that root cause is worth its own issue, especially with the
#323→#329 history on installer hooks.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Test plan

- pytest: `dedupe-all` prunes the live #389 shape (esphome + aioesphomeapi
  pairs, singleton untouched, highest kept); the safety guards hold under
  `targets=None`; the default scope still ignores non-target duplicates.
- Rust unit tests: the refresh copy invokes the interpreter with `dedupe-all`;
  a failing dedupe does not fail the refresh; each scope maps to its script
  mode.
- e2e (`e2e_repair_cycle`): the downgraded second source is now also dirtied
  with a stale `esphome-0.0.1.dist-info` the way the installer overlay does;
  after the refresh + restore the tree must hold exactly one esphome
  dist-info, naming the restored version.
- Live on the affected Windows machine: ran the full `e2e_repair_cycle` with
  `ESPHOME_E2E_PYTHON_TREE` pointed at the real dirty 0.16.0 install-dir
  bundle (the one with the duplicate pairs above). The production copy path
  pruned the duplicates and every leg passed, including the new
  single-dist-info assertion.
- Gates run locally on the pinned toolchain: `cargo fmt --check`, `clippy
  --all-targets --all-features -D warnings`, `cargo test --all-features`
  (191 passed), `ruff check` / `ruff format --check`, `check_file_size.py`,
  and `pytest tests/ -v` (173 passed).

## Additional information

- This PR fixes or closes issue: fixes #389
