### PR TITLE
Run the release upload job even though determine-jobs is skipped

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -725,7 +725,13 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_run'
+    # `always()` + an explicit result check, NOT the bare event guard: without
+    # a status function GitHub prepends `success()`, which is false whenever
+    # any job in the transitive needs chain was skipped — and `determine-jobs`
+    # (pull_request only) is always skipped on workflow_run events. That
+    # combination silently skipped this job on every release build after
+    # #357, stranding the draft release with stale assets.
+    if: always() && github.event_name == 'workflow_run' && needs.build.result == 'success'
     permissions:
       contents: write
 


### PR DESCRIPTION
# What does this implement/fix?

The draft release has been stuck with stale assets and the do not publish notice since July 17; the release upload job was silently skipped on every release build. Its bare event guard gets GitHub's implicit success() prepended, and success() is false when any job in the transitive needs chain was skipped, which determine-jobs from #357 always is on workflow_run events since it only runs on pull_request.

Spell the condition out with always() and an explicit needs.build.result check, the same pattern the build job already uses. Merging this triggers a fresh release build whose upload job will now run, refilling the draft and clearing the notice.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes <link to issue>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).
