### PR TITLE
Rebuild bundles to pick up the next device builder release

### DIFF
--- a/build-scripts/prepare_bundle.sh
+++ b/build-scripts/prepare_bundle.sh
@@ -506,6 +506,9 @@ install_python_packages() {
     # release so the bundle matches Backend::default() == BuilderStable in
     # src-tauri/src/settings/mod.rs; a beta binary here would put fresh installs
     # on the beta channel while the UI reports Stable (see #241/#245).
+    # Deliberately unpinned within that channel: every bundle build ships the
+    # latest stable on PyPI, so picking up a new device builder release just
+    # needs any merge to main after it publishes.
     echo ""
     echo "=== Installing ESPHome Device Builder (${platform}) ==="
     "$python_dir/$python_bin" -m pip install esphome-device-builder


### PR DESCRIPTION
# What does this implement/fix?

Rebuild trigger for the next esphome-device-builder release. The bundle installs esphome-device-builder unpinned from PyPI at build time, so the release just needs a merge to main after the new version is published; the one line diff documents that behavior at the install site.

Do not merge until the device builder release following esphome/device-builder#2281 is published to PyPI.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue (if applicable):**

- fixes <link to issue>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).
