### PR TITLE
Remove trailing ellipsis from tray menu items

### DIFF
--- a/src-tauri/src/update/notify.rs
+++ b/src-tauri/src/update/notify.rs
@@ -185,12 +185,12 @@ mod tests {
         assert_eq!(
             update_notification_body(&esphome_wording().subject("2025.1.0"), "2024.12.2", true),
             "ESPHome 2025.1.0 (stable) is available (you have 2024.12.2). \
-             Open the tray menu and choose \"Check for Updates...\" to update."
+             Open the tray menu and choose \"Check for Updates\" to update."
         );
         assert_eq!(
             update_notification_body(&DEVICE_BUILDER_WORDING.subject("1.2.3"), "1.2.2", true),
             "ESPHome Device Builder 1.2.3 is available (you have 1.2.2). \
-             Open the tray menu and choose \"Check for Updates...\" to update."
+             Open the tray menu and choose \"Check for Updates\" to update."
         );
         // Without a tray, the hint falls back to the CLI.
         assert_eq!(

--- a/src-tauri/translations/en.json
+++ b/src-tauri/translations/en.json
@@ -13,9 +13,9 @@
     "startup": "Startup",
     "launch_at_login": "Launch at Login",
     "dont_launch_at_login": "Don't Launch at Login",
-    "check_updates": "Check for Updates...",
-    "view_logs": "View Logs...",
-    "open_config": "Open Config Folder...",
+    "check_updates": "Check for Updates",
+    "view_logs": "View Logs",
+    "open_config": "Open Config Folder",
     "restart_dashboard": "Restart Dashboard",
     "quit": "Quit ESPHome"
   },
@@ -99,7 +99,7 @@
   },
   "daemon": {
     "stopped_title": "{backend} stopped",
-    "stopped_body": "{backend} exited unexpectedly ({status}). Open the tray menu and choose \"View Logs...\" for details."
+    "stopped_body": "{backend} exited unexpectedly ({status}). Open the tray menu and choose \"View Logs\" for details."
   },
   "git_check": {
     "missing_title": "Git is not installed",
@@ -119,7 +119,7 @@
     "firewall_decline": "No thanks"
   },
   "hint": {
-    "updates_menu": "Open the tray menu and choose \"Check for Updates...\" to update.",
+    "updates_menu": "Open the tray menu and choose \"Check for Updates\" to update.",
     "updates_cli": "No system tray was detected. Run `esphome-desktop update` from a terminal to update."
   }
 }


### PR DESCRIPTION
# What does this implement/fix?

Removes the trailing "..." from the tray menu items Check for Updates, View Logs, and Open Config Folder; an ellipsis conventionally means the command opens a dialog asking for further input, but these all act immediately. Also updates the two notification hints that quote the menu labels so they stay in sync.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes https://github.com/esphome/esphome-desktop/issues/398

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).
