### PR TITLE
Remove misleading Ctrl+O shortcut from tray menu

### DIFF
--- a/src-tauri/src/tray/mod.rs
+++ b/src-tauri/src/tray/mod.rs
@@ -176,7 +176,6 @@ pub fn build_tray_menu(app_handle: &AppHandle, state: &Arc<AppState>) -> Result<
     let menu = MenuBuilder::new(app_handle)
         .item(
             &MenuItemBuilder::with_id(ids::OPEN_DASHBOARD, t("tray.open_dashboard"))
-                .accelerator("CmdOrCtrl+O")
                 .build(app_handle)?,
         )
         .separator()


### PR DESCRIPTION
# What does this implement/fix?

The tray menu showed a Ctrl+O accelerator next to Open Device Builder. The shortcut only fires while the menu is open, but it is displayed like a system wide shortcut, which suggests the app overrides the standard Open shortcut used by other applications. Pressing Ctrl+O outside the menu does nothing. This removes the accelerator so the menu no longer advertises a shortcut it does not really provide.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes https://github.com/esphome/esphome-desktop/issues/397

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).