### PR TITLE
Bump major version to 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 A cross-platform desktop application that bundles ESPHome with Python and runs the ESPHome Device Builder as a background daemon with system tray integration.
 
+> **Status:** stable and ready for production use. With the 1.0.0 release, the
+> recovery system works the same on every platform (Windows was the last to
+> gain it). Issues and feedback welcome; please check
+> [existing issues](https://github.com/esphome/esphome-desktop/issues) first,
+> and join the [Discord channel](https://discord.gg/Rf2jWGVjaK) for live
+> discussion.
+
 ## Features
 
 - **System Tray Integration**: Runs in the background with a system tray icon
@@ -24,6 +31,17 @@ Download the latest release for your platform from [desktop.esphome.io](https://
 | Windows               | `ESPHome.Device.Builder_x.x.x_x64-setup.exe`                    |
 | Linux (x86_64)        | `ESPHome.Device.Builder_x.x.x_amd64.AppImage` or `.deb`         |
 | Linux (aarch64)       | `ESPHome.Device.Builder_x.x.x_aarch64.AppImage` or `_arm64.deb` |
+
+### Upgrading from a 0.x pre-release
+
+If you were running a pre-release 0.x version on Windows, do a one-time clean
+upgrade: uninstall the app, reboot, then install the latest release. The reboot
+ensures no backend process from the old install is left running
+([#322](https://github.com/esphome/esphome-desktop/issues/322)). This only
+affects Windows; macOS and Linux installs update in place as usual. Your
+ESPHome configurations in `~/esphome` are not touched by the uninstaller, and the
+`C:\esphb` build data folder is also kept (see
+[Data Locations](#data-locations)), so builds stay warm.
 
 ### First Run
 


### PR DESCRIPTION
# What does this implement/fix?

Now that we have the same recovery system for all platforms (Windows was the hold out), release 1.0.0. Adds a status note at the top of the README marking the app stable and ready for production use, plus a note recommending anyone on the pre-release 0.x series uninstall and reinstall once on Windows to clean up legacy cruft from the pre-release development. No version files change here; release-drafter bumps them on merge via the major label.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue (if applicable):**

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).
