### PR TITLE
Add Development category to the Linux desktop entry

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -15,6 +15,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "category": "DeveloperTool",
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
# What does this implement/fix?

Sets the bundle category to DeveloperTool so the generated Linux .desktop file gets `Categories=Development;`, without it KDE Plasma hides the app from the launch menu.

The setting is cross platform; macOS bundles also gain `LSApplicationCategoryType=public.app-category.developer-tools`, which is benign and does not conflict with the hand maintained Info.plist.

Verified against this branch's CI built amd64 deb; its .desktop file now contains `Categories=Development;`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes https://github.com/esphome/esphome-desktop/issues/414

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).
