### PR TITLE
Remove metadata-dead dist-info dirs so the missing-RECORD repair can succeed

### DIFF
--- a/.github/workflows/python-tree-repair.yml
+++ b/.github/workflows/python-tree-repair.yml
@@ -12,10 +12,13 @@ name: Python Tree Repair
 # self-contained and healthy; an orphaned component directory (exactly what the
 # removed `--ignore-installed` fallback left behind, and what broke every
 # compile on 2026.7) fails the health probe; the repair re-copy removes it with
-# no network; and a refresh from an older bundle does not silently downgrade a
-# newer esphome the tree already had — the restore reinstalls it through a real
-# `pip install` (#353). That last leg is why the job needs PyPI; the repair
-# itself stays offline.
+# no network; a tree carrying a metadata-dead frontend dist-info makes the real
+# updater pip command abort with uninstall-no-record-file and a repair from a
+# source carrying the same corruption recovers it (the "Cannot uninstall
+# esphome-device-builder-frontend None" report); and a refresh from an older
+# bundle does not silently downgrade a newer esphome the tree already had — the
+# restore reinstalls it through a real `pip install` (#353). Those pip legs are
+# why the job needs PyPI; the repair itself stays offline.
 #
 # A venv would be cheaper but would not do: on Windows a venv puts python.exe in
 # Scripts\ while the real bundle has it at the tree root, so the layout the copy

--- a/.github/workflows/python-tree-repair.yml
+++ b/.github/workflows/python-tree-repair.yml
@@ -12,7 +12,7 @@ name: Python Tree Repair
 # self-contained and healthy; an orphaned component directory (exactly what the
 # removed `--ignore-installed` fallback left behind, and what broke every
 # compile on 2026.7) fails the health probe; the repair re-copy removes it with
-# no network; a tree carrying a metadata-dead frontend dist-info makes the real
+# no network; a tree carrying a RECORD-less frontend dist-info makes the real
 # updater pip command abort with uninstall-no-record-file and a repair from a
 # source carrying the same corruption recovers it (the "Cannot uninstall
 # esphome-device-builder-frontend None" report); and a refresh from an older

--- a/.github/workflows/python-tree-repair.yml
+++ b/.github/workflows/python-tree-repair.yml
@@ -34,6 +34,7 @@ on:
     branches: [main]
     paths:
       - "build-scripts/**"
+      - "src-tauri/scripts/**"
       - "src-tauri/src/platform/**"
       - "src-tauri/src/update/**"
       - ".github/workflows/python-tree-repair.yml"

--- a/src-tauri/scripts/device_builder_maintenance.py
+++ b/src-tauri/scripts/device_builder_maintenance.py
@@ -101,27 +101,36 @@ def _dist_path(dist: Distribution) -> object:
     return getattr(dist, "_path", "?")
 
 
+def _clear_readonly_and_retry(
+    func: Callable[[str], object], failed: str, exc: BaseException
+) -> None:
+    """``shutil.rmtree`` error handler: clear a read-only flag, retry once.
+
+    A path that is writable yet still failed re-raises the original error:
+    the flag is not the problem there, and retrying would just fail again. A
+    retry that fails anew chains the original error so the log names both
+    causes. Module-level rather than nested in [`_rmtree`] so the early-out
+    and the chain are unit-testable on every platform; the flag-clearing leg
+    only ever fires on Windows.
+    """
+    if os.access(failed, os.W_OK):
+        raise exc
+    try:
+        Path(failed).chmod(stat.S_IWUSR | stat.S_IRUSR | stat.S_IXUSR)
+        func(failed)
+    except OSError as retry_err:
+        raise retry_err from exc
+
+
 def _rmtree(path: Path) -> None:
     """``shutil.rmtree`` that clears Windows' read-only flag and retries.
 
     Files inside a dist-info can carry the read-only attribute on Windows,
     which fails the plain delete (same handling as ``esphome.helpers.rmtree``,
     plus the execute bit so a chmod'd directory stays traversable for the
-    retry). A path that is writable yet still failed re-raises: the flag is
-    not the problem there, and retrying would just fail again. A retry that
-    fails anew chains the original error so the log names both causes.
+    retry).
     """
-
-    def _onexc(func: Callable[[str], object], failed: str, exc: BaseException) -> None:
-        if os.access(failed, os.W_OK):
-            raise exc
-        try:
-            Path(failed).chmod(stat.S_IWUSR | stat.S_IRUSR | stat.S_IXUSR)
-            func(failed)
-        except OSError as retry_err:
-            raise retry_err from exc
-
-    shutil.rmtree(path, onexc=_onexc)
+    shutil.rmtree(path, onexc=_clear_readonly_and_retry)
 
 
 def _infer_name(path: Path) -> str:
@@ -262,8 +271,13 @@ def dedupe_dist_info(
                 except OSError as err:
                     # Counted, not just logged: this entry still blocks every
                     # install, so the run must not report success around it.
+                    # Worded apart from the best-effort "skip" below so a
+                    # bounded stderr tail says which failure drove the exit 1.
                     failed += 1
-                    print(f"skip {path}: {err}", file=sys.stderr)
+                    print(
+                        f"dedupe: could not remove RECORD-less {path}: {err}",
+                        file=sys.stderr,
+                    )
                 continue
             if inferred:
                 # A directory name is identity enough to condemn a
@@ -317,8 +331,9 @@ def main(argv: list[str]) -> int:
         )
         print(removed)
         # A RECORD-less dir that survived the prune still aborts every
-        # install; exit 1 so the caller logs "still corrupt" instead of
-        # retrying into the same wall as if the tree were healed.
+        # install; exit 1 so a partial prune is never reported as a heal. The
+        # callers are best-effort and continue either way, so the exit code
+        # buys a distinguishable log line, not a control-flow guard.
         return 1 if failed else 0
     print(f"unknown mode: {mode!r}", file=sys.stderr)
     return 2

--- a/src-tauri/scripts/device_builder_maintenance.py
+++ b/src-tauri/scripts/device_builder_maintenance.py
@@ -24,9 +24,10 @@ version when METADATA survived), and because the installer overlay can plant
 one in the bundled tree itself (#389), the repair re-copy restores it and the
 failure becomes permanent. A completed pip install always writes RECORD, so
 this shape is torn metadata rather than a real install; deleting the dist-info
-dir loses nothing pip could use, and the next install writes a fresh one. A
-RECORD-less entry the prune could not remove fails the run (exit 1): leaving
-it in place means that abort loop, which must not read as success.
+dir loses nothing pip could use, and the next install writes a fresh one.
+In-scope damage the prune could not resolve — a removal that failed, a
+directory it could not list — fails the run (exit 1): a partial prune must
+never read as a heal.
 
 Embedded into the Rust binary via ``include_str!`` and run with the bundled
 interpreter as ``python -c <this file> <mode>``; also imported directly by the
@@ -214,9 +215,14 @@ def dedupe_dist_info(
     regardless of group size or version readability: pip can never uninstall
     one, so it aborts every upgrade with ``uninstall-no-record-file`` until it
     is gone. Returns ``(removed, failed)``: dist-info directories removed, and
-    RECORD-less ones that could not be removed — those leave the abort loop in
-    place, so the CLI turns them into a non-zero exit.
+    in-scope damage the prune could not resolve — a RECORD-less entry it could
+    not remove (still aborts every install), a stale duplicate it could not
+    remove (still breaks version detection, #190), or a directory it could not
+    even list (may be any of those). The CLI turns ``failed`` into a non-zero
+    exit so a partial prune is never reported as a heal.
     """
+    removed = 0
+    failed = 0
     groups: dict[str, list[tuple[str | None, Path, bool, bool]]] = {}
     for dist in dists:
         # ``_path`` is private; guard it so a future importlib change degrades to
@@ -227,14 +233,6 @@ def dedupe_dist_info(
             or path.suffix != ".dist-info"
             or not path.is_dir()
         ):
-            continue
-        try:
-            children = {child.name for child in path.iterdir()}
-        except OSError as err:
-            # A directory that cannot even be listed decides nothing, least of
-            # all its own removal: a transient read failure must not turn
-            # "RECORD not seen" into "RECORD absent" and delete a real install.
-            print(f"dedupe: skipping unlistable {path}: {err}", file=sys.stderr)
             continue
         name = ""
         version = None
@@ -267,12 +265,23 @@ def dedupe_dist_info(
             continue
         if targets is not None and name not in targets:
             continue
+        try:
+            children = {child.name for child in path.iterdir()}
+        except OSError as err:
+            # A directory that cannot even be listed decides nothing, least of
+            # all its own removal: a transient read failure must not turn
+            # "RECORD not seen" into "RECORD absent" and delete a real install.
+            # But it is counted: this entry may be the RECORD-less blocker,
+            # and "could not determine the tree is clean" must not read as
+            # clean. After the scope filter so an unlistable non-target dir
+            # cannot fail the scoped heal.
+            failed += 1
+            print(f"dedupe: could not list {path}: {err}", file=sys.stderr)
+            continue
         groups.setdefault(name, []).append(
             (version, path, "RECORD" in children, inferred)
         )
 
-    removed = 0
-    failed = 0
     for entries in groups.values():
         items: list[tuple[str | None, Path]] = []
         for version, path, has_record, inferred in entries:
@@ -335,7 +344,16 @@ def dedupe_dist_info(
                 _rmtree(path)
                 removed += 1
             except OSError as err:
-                print(f"skip {path}: {err}", file=sys.stderr)
+                # Also counted: a surviving duplicate keeps the #190 pileup in
+                # place, so importlib still cannot resolve a single version
+                # and the updater loops on "version None". Worded apart from
+                # the RECORD-less and unlistable lines so a bounded stderr
+                # tail says which failure drove the exit 1.
+                failed += 1
+                print(
+                    f"dedupe: could not remove stale duplicate {path}: {err}",
+                    file=sys.stderr,
+                )
     return removed, failed
 
 
@@ -351,10 +369,11 @@ def main(argv: list[str]) -> int:
             distributions(), targets=TARGETS if mode == "dedupe" else None
         )
         print(removed)
-        # A RECORD-less dir that survived the prune still aborts every
-        # install; exit 1 so a partial prune is never reported as a heal. The
-        # callers are best-effort and continue either way, so the exit code
-        # buys a distinguishable log line, not a control-flow guard.
+        # Damage the prune could not resolve still blocks the updater (a
+        # RECORD-less dir aborts every install, a surviving duplicate breaks
+        # version detection); exit 1 so a partial prune is never reported as
+        # a heal. The callers are best-effort and continue either way, so the
+        # exit code buys a distinguishable log line, not a control-flow guard.
         return 1 if failed else 0
     print(f"unknown mode: {mode!r}", file=sys.stderr)
     return 2

--- a/src-tauri/scripts/device_builder_maintenance.py
+++ b/src-tauri/scripts/device_builder_maintenance.py
@@ -130,25 +130,46 @@ def _rmtree(path: Path) -> None:
     plus the execute bit so a chmod'd directory stays traversable for the
     retry).
     """
-    shutil.rmtree(path, onexc=_clear_readonly_and_retry)
+    if sys.version_info >= (3, 12):
+        shutil.rmtree(path, onexc=_clear_readonly_and_retry)
+        return
+
+    # The bundled interpreter is far newer, but dev builds without a bundle
+    # fall back to the system Python, which can predate ``onexc`` (3.12); the
+    # resulting TypeError would escape the callers' ``except OSError`` and
+    # kill the whole prune. ``onerror`` passes an exc_info triple instead of
+    # the exception, so adapt.
+    def _onerror(
+        func: Callable[[str], object],
+        failed: str,
+        exc_info: tuple[type[BaseException], BaseException, object],
+    ) -> None:
+        _clear_readonly_and_retry(func, failed, exc_info[1])
+
+    shutil.rmtree(path, onerror=_onerror)
 
 
 def _infer_name(path: Path) -> str:
     """Normalized package name from a ``*.dist-info`` directory name.
 
-    ``pkg_name-1.2.3.dist-info`` -> ``pkg-name``; with no version separator the
-    whole stem is taken as the name. The wheel spec underscore-normalizes the
-    name part, so the last ``-`` always cuts at the version for anything pip
-    wrote, and pip resolves identity from the directory name the same way when
-    METADATA is gone ("Cannot uninstall esphome-device-builder-frontend None").
+    ``pkg_name-1.2.3.dist-info`` -> ``pkg-name``; when the tail after the last
+    ``-`` does not look like a version, the whole stem is taken as the name.
+    The wheel spec underscore-normalizes the name part, so the last ``-``
+    always cuts at the version for anything pip wrote, and pip resolves
+    identity from the directory name the same way when METADATA is gone
+    ("Cannot uninstall esphome-device-builder-frontend None"). The digit check
+    only matters for hand-damaged names like ``foo-bar.dist-info``, which must
+    not shed their last segment on the way into the scope filter.
 
     Only used when METADATA is missing or has no Name header, and only to
-    scope-filter the entry and attribute the metadata-dead removal; an
-    inferred name never ranks its entry against properly named siblings.
+    scope-filter the entry and attribute the RECORD-less removal; an inferred
+    name never ranks its entry against properly named siblings.
     """
     stem = path.name[: -len(".dist-info")]
-    name, sep, _version = stem.rpartition("-")
-    return _norm(name if sep else stem)
+    name, sep, version = stem.rpartition("-")
+    if sep and version[:1].isdigit():
+        return _norm(name)
+    return _norm(stem)
 
 
 def detect_version(dists: Iterable[Distribution]) -> str | None:

--- a/src-tauri/scripts/device_builder_maintenance.py
+++ b/src-tauri/scripts/device_builder_maintenance.py
@@ -45,6 +45,24 @@ import sys
 from collections.abc import Callable, Iterable
 from importlib.metadata import Distribution, distributions
 from pathlib import Path
+from typing import NamedTuple
+
+
+class _Entry(NamedTuple):
+    """One dist-info dir under consideration by the dedupe prune.
+
+    Named rather than a bare tuple because three of the fields are adjacent
+    same-typed booleans feeding the destructive branch: a silent positional
+    transposition would flip "deliberate keep" into "counted failure" (or
+    worse) without any test noticing the shape change.
+    """
+
+    version: str | None
+    path: Path
+    has_record: bool
+    inferred: bool
+    unreadable: bool
+
 
 # Only the builder packages: the device-builder updater resolves its version via
 # importlib.metadata, which the duplicate dist-info pileup breaks (#190). Plain
@@ -231,12 +249,13 @@ def dedupe_dist_info(
     (unrankable or dir-name-only entries that still have a RECORD, ambiguous
     groups) are not failures: pip can still manage those, and deleting on a
     guess is the one wrong this prune must never commit. The exception is a
-    group left with nothing rankable at all — its version still cannot be
-    resolved, so its keeps count as unresolved even though they stay.
+    group whose version still cannot be resolved afterwards — nothing rankable
+    at all, or no parseable version anywhere in it: its keeps count as
+    unresolved even though they stay.
     """
     removed = 0
     failed = 0
-    groups: dict[str, list[tuple[str | None, Path, bool, bool, bool]]] = {}
+    groups: dict[str, list[_Entry]] = {}
     for dist in dists:
         # ``_path`` is private; guard it so a future importlib change degrades
         # to a logged, counted no-op rather than deleting the wrong directory
@@ -336,14 +355,21 @@ def dedupe_dist_info(
                     file=sys.stderr,
                 )
         groups.setdefault(name, []).append(
-            (version, path, "RECORD" in children, inferred, unreadable)
+            _Entry(
+                version=version,
+                path=path,
+                has_record="RECORD" in children,
+                inferred=inferred,
+                unreadable=unreadable,
+            )
         )
 
     for entries in groups.values():
         items: list[tuple[str | None, Path]] = []
         kept_dir_name_only = 0
-        for version, path, has_record, inferred, unreadable in entries:
-            if not has_record:
+        for entry in entries:
+            version, path = entry.version, entry.path
+            if not entry.has_record:
                 # No RECORD: pip can never uninstall this entry, so any
                 # install that tries aborts with uninstall-no-record-file,
                 # whether or not the version is still readable ("Cannot
@@ -367,8 +393,8 @@ def dedupe_dist_info(
                         file=sys.stderr,
                     )
                 continue
-            if inferred:
-                if unreadable:
+            if entry.inferred:
+                if entry.unreadable:
                     # METADATA exists but could not be read. pip can still
                     # manage the entry (a RECORD got it past the branch
                     # above), but its version is unknowable right now, so any
@@ -405,8 +431,11 @@ def dedupe_dist_info(
         keep_version, keep_path = items[-1]
         if vkey(keep_version) == _UNRANKED:
             # No entry in the group has a parseable version, so we can't tell
-            # which is the real install. Leave the whole group rather than risk
-            # a wrong rmtree; detect_version still tolerates the duplicates.
+            # which is the real install. Leave the whole group rather than
+            # risk a wrong rmtree — but count it, like the nothing-rankable
+            # case above: a version that still cannot be resolved afterwards
+            # is not a heal, whichever shape left it unresolvable.
+            failed += len(items)
             print(
                 f"dedupe: keeping ambiguous group, no parseable version "
                 f"near {keep_path}",

--- a/src-tauri/scripts/device_builder_maintenance.py
+++ b/src-tauri/scripts/device_builder_maintenance.py
@@ -317,14 +317,23 @@ def dedupe_dist_info(
             failed += 1
             print(f"dedupe: could not list {path}: {err}", file=sys.stderr)
             continue
+        unreadable = metadata_unreadable and "METADATA" in children
+        if not unreadable and inferred and "METADATA" in children:
+            # importlib suppresses read failures (PermissionError and
+            # friends) into an empty answer, indistinguishable from a
+            # Name-less file, so no exception reached the handler above.
+            # Probe the file directly: present but unreadable is a transient
+            # failure hiding the pileup, not a torn shape.
+            try:
+                (path / "METADATA").read_bytes()
+            except OSError as err:
+                unreadable = True
+                print(
+                    f"dedupe: unreadable metadata in {path}: {err}",
+                    file=sys.stderr,
+                )
         groups.setdefault(name, []).append(
-            (
-                version,
-                path,
-                "RECORD" in children,
-                inferred,
-                metadata_unreadable and "METADATA" in children,
-            )
+            (version, path, "RECORD" in children, inferred, unreadable)
         )
 
     for entries in groups.values():

--- a/src-tauri/scripts/device_builder_maintenance.py
+++ b/src-tauri/scripts/device_builder_maintenance.py
@@ -249,9 +249,10 @@ def dedupe_dist_info(
     (unrankable or dir-name-only entries that still have a RECORD, ambiguous
     groups) are not failures: pip can still manage those, and deleting on a
     guess is the one wrong this prune must never commit. The exception is a
-    group whose version still cannot be resolved afterwards — nothing rankable
-    at all, or no parseable version anywhere in it: its keeps count as
-    unresolved even though they stay.
+    group whose best surviving entry still has no rankable version — nothing
+    rankable at all, a lone entry with an unparseable Version, or an
+    all-unparseable pileup: its keeps count as unresolved even though they
+    stay, since detect_version resolves them all to nothing alike.
     """
     groups, failed = _collect_entries(dists, targets)
     removed = 0
@@ -449,31 +450,26 @@ def _prune_group(entries: list[_Entry]) -> tuple[int, int]:
             print(f"dedupe: keeping dir-name-only {path}", file=sys.stderr)
             continue
         items.append(entry)
-    if not items and kept_dir_name_only:
-        # The group ended up with nothing rankable: detect_version filters
-        # on the METADATA Name, so this package still resolves to no
-        # version — the same #190 consequence as a duplicate the prune
-        # could not remove, and on the builder path no install is ever
-        # offered that would let pip heal these keeps. They stand (deleting
-        # on a guess is still the one forbidden wrong), but the run must
-        # not call this resolved.
-        failed += kept_dir_name_only
+    items.sort(key=lambda entry: vkey(entry.version))
+    if not items or vkey(items[-1].version) == _UNRANKED:
+        # Resolvability is judged once, for every group size: if even the
+        # best surviving entry has no rankable version, detect_version still
+        # resolves this package to nothing — the same #190 consequence
+        # whichever shape produced it (nothing rankable at all, a lone entry
+        # with an unparseable Version, or an all-unparseable pileup) — and on
+        # the builder path no install is ever offered that would let pip heal
+        # the keeps. They stand (deleting on a guess is still the one
+        # forbidden wrong), but the run must not call any of these resolved.
+        failed += kept_dir_name_only + len(items)
+        if items:
+            print(
+                f"dedupe: keeping ambiguous group, no parseable version "
+                f"near {items[-1].path}",
+                file=sys.stderr,
+            )
+        return removed, failed
     if len(items) < 2:
         return removed, failed  # a single healthy install is left untouched
-    items.sort(key=lambda entry: vkey(entry.version))
-    keep = items[-1]
-    if vkey(keep.version) == _UNRANKED:
-        # No entry in the group has a parseable version, so we can't tell
-        # which is the real install. Leave the whole group rather than
-        # risk a wrong rmtree — but count it, like the nothing-rankable
-        # case above: a version that still cannot be resolved afterwards
-        # is not a heal, whichever shape left it unresolvable.
-        failed += len(items)
-        print(
-            f"dedupe: keeping ambiguous group, no parseable version near {keep.path}",
-            file=sys.stderr,
-        )
-        return removed, failed
     for entry in items[:-1]:
         if vkey(entry.version) == _UNRANKED:
             # An unparseable version with a RECORD (RECORD-less entries

--- a/src-tauri/scripts/device_builder_maintenance.py
+++ b/src-tauri/scripts/device_builder_maintenance.py
@@ -34,10 +34,12 @@ iterable instead of always reading the live environment.
 
 from __future__ import annotations
 
+import os
 import re
 import shutil
+import stat
 import sys
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from importlib.metadata import Distribution, distributions
 from pathlib import Path
 
@@ -95,6 +97,24 @@ def _norm(name: str | None) -> str:
 def _dist_path(dist: Distribution) -> object:
     """``dist``'s private ``_path`` for log messages, or ``"?"`` if absent."""
     return getattr(dist, "_path", "?")
+
+
+def _rmtree(path: Path) -> None:
+    """``shutil.rmtree`` that clears Windows' read-only flag and retries.
+
+    Files inside a dist-info can carry the read-only attribute on Windows,
+    which fails the plain delete (same handling as ``esphome.helpers.rmtree``).
+    A path that is writable yet still failed re-raises: the flag is not the
+    problem there, and retrying would just fail again.
+    """
+
+    def _onexc(func: Callable[[str], object], failed: str, exc: BaseException) -> None:
+        if os.access(failed, os.W_OK):
+            raise exc
+        Path(failed).chmod(stat.S_IWUSR | stat.S_IRUSR)
+        func(failed)
+
+    shutil.rmtree(path, onexc=_onexc)
 
 
 def _infer_name(path: Path) -> str:
@@ -210,7 +230,7 @@ def dedupe_dist_info(
                 # of the abort loop.
                 print(f"dedupe: removing metadata-dead {path}", file=sys.stderr)
                 try:
-                    shutil.rmtree(path)
+                    _rmtree(path)
                     removed += 1
                 except OSError as err:
                     print(f"skip {path}: {err}", file=sys.stderr)
@@ -238,7 +258,7 @@ def dedupe_dist_info(
                 print(f"dedupe: keeping unrankable {path}", file=sys.stderr)
                 continue
             try:
-                shutil.rmtree(path)
+                _rmtree(path)
                 removed += 1
             except OSError as err:
                 print(f"skip {path}: {err}", file=sys.stderr)

--- a/src-tauri/scripts/device_builder_maintenance.py
+++ b/src-tauri/scripts/device_builder_maintenance.py
@@ -224,29 +224,45 @@ def dedupe_dist_info(
     in-scope damage the prune could not resolve — a RECORD-less entry it could
     not remove (still aborts every install), a stale duplicate it could not
     remove (still breaks version detection, #190), a directory it could not
-    even list (may be any of those), or, in all-scope mode, an entry with no
-    attributable name. The CLI turns ``failed`` into a non-zero exit so a
-    partial prune is never reported as a heal. Deliberate conservative keeps
+    even list, a METADATA it could not read (either may be any of those), or,
+    in all-scope mode, an entry with no attributable name or usable path. The
+    CLI turns ``failed`` into a non-zero exit so a partial prune is never
+    reported as a heal. Deliberate conservative keeps
     (unrankable or dir-name-only entries that still have a RECORD, ambiguous
     groups) are not failures: pip can still manage those, and deleting on a
     guess is the one wrong this prune must never commit.
     """
     removed = 0
     failed = 0
-    groups: dict[str, list[tuple[str | None, Path, bool, bool]]] = {}
+    groups: dict[str, list[tuple[str | None, Path, bool, bool, bool]]] = {}
     for dist in dists:
         # ``_path`` is private; guard it so a future importlib change degrades
-        # to a no-op rather than deleting the wrong directory. Non-dist-info
-        # entries (egg-info) are out of this prune's contract and skip
-        # silently by design. Deliberately no ``is_dir()`` here: it folds a
-        # stat error into False, which would vanish a possibly-blocking entry
-        # uncounted — a non-directory or unstatable path flows through to the
-        # scope-aware, counted listing probe below instead.
+        # to a logged, counted no-op rather than deleting the wrong directory
+        # or silently reading as a clean tree. Deliberately no ``is_dir()``
+        # here: it folds a stat error into False, which would vanish a
+        # possibly-blocking entry uncounted — a non-directory or unstatable
+        # path flows through to the scope-aware, counted listing probe below
+        # instead.
         path = getattr(dist, "_path", None)
-        if not isinstance(path, Path) or path.suffix != ".dist-info":
+        if not isinstance(path, Path):
+            # If importlib ever changes the private attribute, every entry
+            # lands here and the prune can do nothing at all; a total no-op
+            # must not read as a heal. Counted in all-scope mode only:
+            # without a path there is no name to scope-filter on.
+            if targets is None:
+                failed += 1
+            print(
+                f"dedupe: no usable path for distribution {_dist_path(dist)}",
+                file=sys.stderr,
+            )
+            continue
+        if path.suffix != ".dist-info":
+            # egg-info and friends are out of this prune's contract: a quiet
+            # skip by design.
             continue
         name = ""
         version = None
+        metadata_unreadable = False
         try:
             # .get() avoids the implicit-None DeprecationWarning (future
             # KeyError) on missing headers, and reading Version here keeps a
@@ -257,6 +273,11 @@ def dedupe_dist_info(
         except Exception as err:
             # Log rather than silently skip: an unreadable target dist-info that
             # is never considered for dedup leaves the pileup in place (#190).
+            # Whether it also counts as unresolved is decided below, once the
+            # listing says if METADATA is even there: an absent file is the
+            # torn shape (a deliberate keep), a present-but-unreadable one is
+            # a transient failure hiding the pileup.
+            metadata_unreadable = True
             print(
                 f"dedupe: unreadable metadata in {path}: {err}",
                 file=sys.stderr,
@@ -297,12 +318,18 @@ def dedupe_dist_info(
             print(f"dedupe: could not list {path}: {err}", file=sys.stderr)
             continue
         groups.setdefault(name, []).append(
-            (version, path, "RECORD" in children, inferred)
+            (
+                version,
+                path,
+                "RECORD" in children,
+                inferred,
+                metadata_unreadable and "METADATA" in children,
+            )
         )
 
     for entries in groups.values():
         items: list[tuple[str | None, Path]] = []
-        for version, path, has_record, inferred in entries:
+        for version, path, has_record, inferred, unreadable in entries:
             if not has_record:
                 # No RECORD: pip can never uninstall this entry, so any
                 # install that tries aborts with uninstall-no-record-file,
@@ -328,8 +355,20 @@ def dedupe_dist_info(
                     )
                 continue
             if inferred:
+                if unreadable:
+                    # METADATA exists but could not be read. pip can still
+                    # manage the entry (a RECORD got it past the branch
+                    # above), but its version is unknowable right now, so any
+                    # pileup it belongs to is unresolved: counted, not folded
+                    # into the deliberate keeps below.
+                    failed += 1
+                    print(
+                        f"dedupe: could not read METADATA in {path}",
+                        file=sys.stderr,
+                    )
+                    continue
                 # A directory name is identity enough to condemn a
-                # metadata-dead entry above (pip trusts it the same way when
+                # RECORD-less entry above (pip trusts it the same way when
                 # it aborts), but not to rank the entry against properly named
                 # siblings: a corrupted name landing in another package's
                 # group could evict that package's real dist-info. Keep it

--- a/src-tauri/scripts/device_builder_maintenance.py
+++ b/src-tauri/scripts/device_builder_maintenance.py
@@ -123,6 +123,12 @@ def _clear_readonly_and_retry(
         raise retry_err from exc
 
 
+# Whether shutil.rmtree accepts ``onexc`` (3.12+). Evaluated at import so the
+# test suite can force the fallback branch without patching the process-wide
+# ``sys.version_info``.
+_RMTREE_HAS_ONEXC = sys.version_info >= (3, 12)
+
+
 def _rmtree(path: Path) -> None:
     """``shutil.rmtree`` that clears Windows' read-only flag and retries.
 
@@ -131,7 +137,7 @@ def _rmtree(path: Path) -> None:
     plus the execute bit so a chmod'd directory stays traversable for the
     retry).
     """
-    if sys.version_info >= (3, 12):
+    if _RMTREE_HAS_ONEXC:
         shutil.rmtree(path, onexc=_clear_readonly_and_retry)
         return
 
@@ -229,14 +235,15 @@ def dedupe_dist_info(
     failed = 0
     groups: dict[str, list[tuple[str | None, Path, bool, bool]]] = {}
     for dist in dists:
-        # ``_path`` is private; guard it so a future importlib change degrades to
-        # a no-op rather than deleting the wrong directory.
+        # ``_path`` is private; guard it so a future importlib change degrades
+        # to a no-op rather than deleting the wrong directory. Non-dist-info
+        # entries (egg-info) are out of this prune's contract and skip
+        # silently by design. Deliberately no ``is_dir()`` here: it folds a
+        # stat error into False, which would vanish a possibly-blocking entry
+        # uncounted — a non-directory or unstatable path flows through to the
+        # scope-aware, counted listing probe below instead.
         path = getattr(dist, "_path", None)
-        if (
-            not isinstance(path, Path)
-            or path.suffix != ".dist-info"
-            or not path.is_dir()
-        ):
+        if not isinstance(path, Path) or path.suffix != ".dist-info":
             continue
         name = ""
         version = None

--- a/src-tauri/scripts/device_builder_maintenance.py
+++ b/src-tauri/scripts/device_builder_maintenance.py
@@ -17,6 +17,15 @@ return None or the wrong version and loops the updater forever. The version
 ranking is self-contained so this does not depend on the third-party
 ``packaging`` library being importable in the bundled interpreter.
 
+Both dedupe modes also remove metadata-dead dist-info dirs: no readable
+version and no RECORD file. pip cannot uninstall such an entry, so every
+upgrade that touches the package aborts with ``uninstall-no-record-file``
+("Cannot uninstall <pkg> None"), and because the installer overlay can plant
+one in the bundled tree itself (#389), the repair re-copy restores it and the
+failure becomes permanent. A completed pip install always writes RECORD, so
+this shape is torn metadata rather than a real install; deleting the dist-info
+dir loses nothing pip could use, and the next install writes a fresh one.
+
 Embedded into the Rust binary via ``include_str!`` and run with the bundled
 interpreter as ``python -c <this file> <mode>``; also imported directly by the
 pytest suite, which is why the functions take an injectable distributions
@@ -88,6 +97,19 @@ def _dist_path(dist: Distribution) -> object:
     return getattr(dist, "_path", "?")
 
 
+def _infer_name(path: Path) -> str:
+    """Normalized package name from a ``*.dist-info`` directory name.
+
+    ``pkg_name-1.2.3.dist-info`` -> ``pkg-name``; with no version separator the
+    whole stem is taken as the name. Only used when METADATA is missing or has
+    no Name header, and only for scope filtering and grouping; version ranking
+    never trusts the directory name.
+    """
+    stem = path.name[: -len(".dist-info")]
+    name, sep, _version = stem.rpartition("-")
+    return _norm(name if sep else stem)
+
+
 def detect_version(dists: Iterable[Distribution]) -> str | None:
     """Return the highest version among all esphome-device-builder dists.
 
@@ -126,11 +148,24 @@ def dedupe_dist_info(
     ``None`` considers every distribution (the ``dedupe-all`` mode).
 
     The newest version is the code installed last by ``pip install --upgrade``,
-    so its metadata is the one to keep. Returns the number of stale dist-info
-    directories removed.
+    so its metadata is the one to keep. Metadata-dead entries (no readable
+    version and no RECORD) are removed regardless of group size: pip can never
+    uninstall one, so it aborts every upgrade with ``uninstall-no-record-file``
+    until it is gone. Returns the number of dist-info directories removed.
     """
-    groups: dict[str, list[tuple[str | None, Path]]] = {}
+    groups: dict[str, list[tuple[str | None, Path, bool]]] = {}
     for dist in dists:
+        # ``_path`` is private; guard it so a future importlib change degrades to
+        # a no-op rather than deleting the wrong directory.
+        path = getattr(dist, "_path", None)
+        if (
+            not isinstance(path, Path)
+            or path.suffix != ".dist-info"
+            or not path.is_dir()
+        ):
+            continue
+        name = ""
+        version = None
         try:
             # .get() avoids the implicit-None DeprecationWarning (future
             # KeyError) on missing headers, and reading Version here keeps a
@@ -142,35 +177,45 @@ def dedupe_dist_info(
             # Log rather than silently skip: an unreadable target dist-info that
             # is never considered for dedup leaves the pileup in place (#190).
             print(
-                f"dedupe: skipping unreadable distribution {_dist_path(dist)}: {err}",
+                f"dedupe: unreadable metadata in {path}: {err}",
                 file=sys.stderr,
             )
-            continue
         if not name:
-            # A dist-info with no Name header cannot be attributed to a
-            # package. Grouping the nameless together (their names all
-            # normalize to "") would treat unrelated broken dist-infos as
-            # duplicates of one another — never prune on missing identity.
+            # No METADATA, or one with no Name header. The directory name still
+            # identifies the package well enough to scope-filter and group the
+            # entry; without it the torn dist-info behind the permanent
+            # uninstall-no-record-file abort could never be considered at all.
+            name = _infer_name(path)
+        if not name:
             print(
-                f"dedupe: skipping nameless distribution {_dist_path(dist)}",
+                f"dedupe: skipping nameless distribution {path}",
                 file=sys.stderr,
             )
             continue
         if targets is not None and name not in targets:
             continue
-        # ``_path`` is private; guard it so a future importlib change degrades to
-        # a no-op rather than deleting the wrong directory.
-        path = getattr(dist, "_path", None)
-        if (
-            not isinstance(path, Path)
-            or path.suffix != ".dist-info"
-            or not path.is_dir()
-        ):
-            continue
-        groups.setdefault(name, []).append((version, path))
+        groups.setdefault(name, []).append((version, path, (path / "RECORD").is_file()))
 
     removed = 0
-    for items in groups.values():
+    for entries in groups.values():
+        items: list[tuple[str | None, Path]] = []
+        for version, path, has_record in entries:
+            if vkey(version) == _UNRANKED and not has_record:
+                # Metadata-dead: no readable version and no RECORD. pip cannot
+                # uninstall this entry, so any install that tries aborts with
+                # uninstall-no-record-file ("Cannot uninstall <pkg> None"). A
+                # completed pip install always writes RECORD, so unlike the
+                # unrankable-but-managed case below this cannot be the real
+                # install, and removing the dist-info dir is the only way out
+                # of the abort loop.
+                print(f"dedupe: removing metadata-dead {path}", file=sys.stderr)
+                try:
+                    shutil.rmtree(path)
+                    removed += 1
+                except OSError as err:
+                    print(f"skip {path}: {err}", file=sys.stderr)
+                continue
+            items.append((version, path))
         if len(items) < 2:
             continue  # a single healthy install is left untouched
         items.sort(key=lambda item: vkey(item[0]))
@@ -187,7 +232,8 @@ def dedupe_dist_info(
             continue
         for version, path in items[:-1]:
             if vkey(version) == _UNRANKED:
-                # An unparseable version might itself be the real install, so
+                # An unparseable version with a RECORD (metadata-dead entries
+                # never reach this loop) might itself be the real install, so
                 # never delete it on the strength of the lowest-sort sentinel.
                 print(f"dedupe: keeping unrankable {path}", file=sys.stderr)
                 continue

--- a/src-tauri/scripts/device_builder_maintenance.py
+++ b/src-tauri/scripts/device_builder_maintenance.py
@@ -217,9 +217,10 @@ def dedupe_dist_info(
     is gone. Returns ``(removed, failed)``: dist-info directories removed, and
     in-scope damage the prune could not resolve — a RECORD-less entry it could
     not remove (still aborts every install), a stale duplicate it could not
-    remove (still breaks version detection, #190), or a directory it could not
-    even list (may be any of those). The CLI turns ``failed`` into a non-zero
-    exit so a partial prune is never reported as a heal.
+    remove (still breaks version detection, #190), a directory it could not
+    even list (may be any of those), or, in all-scope mode, an entry with no
+    attributable name. The CLI turns ``failed`` into a non-zero exit so a
+    partial prune is never reported as a heal.
     """
     removed = 0
     failed = 0
@@ -258,8 +259,15 @@ def dedupe_dist_info(
             # uninstall-no-record-file abort could never be considered at all.
             name = _infer_name(path)
         if not name:
+            # No name from metadata or the directory: the entry cannot be
+            # attributed, ranked, or condemned. In all-scope mode that is
+            # unresolved (it may be install-blocking damage), so it counts; in
+            # target scope it cannot be tied to the packages this heal owns,
+            # so it is left for dedupe-all, uncounted.
+            if targets is None:
+                failed += 1
             print(
-                f"dedupe: skipping nameless distribution {path}",
+                f"dedupe: cannot attribute nameless {path}",
                 file=sys.stderr,
             )
             continue

--- a/src-tauri/scripts/device_builder_maintenance.py
+++ b/src-tauri/scripts/device_builder_maintenance.py
@@ -220,7 +220,10 @@ def dedupe_dist_info(
     remove (still breaks version detection, #190), a directory it could not
     even list (may be any of those), or, in all-scope mode, an entry with no
     attributable name. The CLI turns ``failed`` into a non-zero exit so a
-    partial prune is never reported as a heal.
+    partial prune is never reported as a heal. Deliberate conservative keeps
+    (unrankable or dir-name-only entries that still have a RECORD, ambiguous
+    groups) are not failures: pip can still manage those, and deleting on a
+    guess is the one wrong this prune must never commit.
     """
     removed = 0
     failed = 0

--- a/src-tauri/scripts/device_builder_maintenance.py
+++ b/src-tauri/scripts/device_builder_maintenance.py
@@ -247,10 +247,11 @@ def dedupe_dist_info(
         if not isinstance(path, Path):
             # If importlib ever changes the private attribute, every entry
             # lands here and the prune can do nothing at all; a total no-op
-            # must not read as a heal. Counted in all-scope mode only:
-            # without a path there is no name to scope-filter on.
-            if targets is None:
-                failed += 1
+            # must not read as a heal. Counted in both modes: unlike a single
+            # nameless directory (which may genuinely be foreign to the
+            # scoped heal), a pathless entry is a systemic contract break
+            # that hits the target packages by definition.
+            failed += 1
             print(
                 f"dedupe: no usable path for distribution {_dist_path(dist)}",
                 file=sys.stderr,

--- a/src-tauri/scripts/device_builder_maintenance.py
+++ b/src-tauri/scripts/device_builder_maintenance.py
@@ -17,14 +17,16 @@ return None or the wrong version and loops the updater forever. The version
 ranking is self-contained so this does not depend on the third-party
 ``packaging`` library being importable in the bundled interpreter.
 
-Both dedupe modes also remove metadata-dead dist-info dirs: no readable
-version and no RECORD file. pip cannot uninstall such an entry, so every
-upgrade that touches the package aborts with ``uninstall-no-record-file``
-("Cannot uninstall <pkg> None"), and because the installer overlay can plant
+Both dedupe modes also remove RECORD-less dist-info dirs. pip cannot uninstall
+an entry with no RECORD file, so every upgrade that touches the package aborts
+with ``uninstall-no-record-file`` ("Cannot uninstall <pkg> None", or with the
+version when METADATA survived), and because the installer overlay can plant
 one in the bundled tree itself (#389), the repair re-copy restores it and the
 failure becomes permanent. A completed pip install always writes RECORD, so
 this shape is torn metadata rather than a real install; deleting the dist-info
-dir loses nothing pip could use, and the next install writes a fresh one.
+dir loses nothing pip could use, and the next install writes a fresh one. A
+RECORD-less entry the prune could not remove fails the run (exit 1): leaving
+it in place means that abort loop, which must not read as success.
 
 Embedded into the Rust binary via ``include_str!`` and run with the bundled
 interpreter as ``python -c <this file> <mode>``; also imported directly by the
@@ -103,16 +105,21 @@ def _rmtree(path: Path) -> None:
     """``shutil.rmtree`` that clears Windows' read-only flag and retries.
 
     Files inside a dist-info can carry the read-only attribute on Windows,
-    which fails the plain delete (same handling as ``esphome.helpers.rmtree``).
-    A path that is writable yet still failed re-raises: the flag is not the
-    problem there, and retrying would just fail again.
+    which fails the plain delete (same handling as ``esphome.helpers.rmtree``,
+    plus the execute bit so a chmod'd directory stays traversable for the
+    retry). A path that is writable yet still failed re-raises: the flag is
+    not the problem there, and retrying would just fail again. A retry that
+    fails anew chains the original error so the log names both causes.
     """
 
     def _onexc(func: Callable[[str], object], failed: str, exc: BaseException) -> None:
         if os.access(failed, os.W_OK):
             raise exc
-        Path(failed).chmod(stat.S_IWUSR | stat.S_IRUSR)
-        func(failed)
+        try:
+            Path(failed).chmod(stat.S_IWUSR | stat.S_IRUSR | stat.S_IXUSR)
+            func(failed)
+        except OSError as retry_err:
+            raise retry_err from exc
 
     shutil.rmtree(path, onexc=_onexc)
 
@@ -166,17 +173,19 @@ def detect_version(dists: Iterable[Distribution]) -> str | None:
 
 def dedupe_dist_info(
     dists: Iterable[Distribution], targets: set[str] | None = TARGETS
-) -> int:
+) -> tuple[int, int]:
     """Keep the highest-version dist-info per package; remove the rest.
 
     ``targets`` limits the prune to the given normalized package names;
     ``None`` considers every distribution (the ``dedupe-all`` mode).
 
     The newest version is the code installed last by ``pip install --upgrade``,
-    so its metadata is the one to keep. Metadata-dead entries (no readable
-    version and no RECORD) are removed regardless of group size: pip can never
-    uninstall one, so it aborts every upgrade with ``uninstall-no-record-file``
-    until it is gone. Returns the number of dist-info directories removed.
+    so its metadata is the one to keep. RECORD-less entries are removed
+    regardless of group size or version readability: pip can never uninstall
+    one, so it aborts every upgrade with ``uninstall-no-record-file`` until it
+    is gone. Returns ``(removed, failed)``: dist-info directories removed, and
+    RECORD-less ones that could not be removed — those leave the abort loop in
+    place, so the CLI turns them into a non-zero exit.
     """
     groups: dict[str, list[tuple[str | None, Path, bool, bool]]] = {}
     for dist in dists:
@@ -188,6 +197,14 @@ def dedupe_dist_info(
             or path.suffix != ".dist-info"
             or not path.is_dir()
         ):
+            continue
+        try:
+            children = {child.name for child in path.iterdir()}
+        except OSError as err:
+            # A directory that cannot even be listed decides nothing, least of
+            # all its own removal: a transient read failure must not turn
+            # "RECORD not seen" into "RECORD absent" and delete a real install.
+            print(f"dedupe: skipping unlistable {path}: {err}", file=sys.stderr)
             continue
         name = ""
         version = None
@@ -221,26 +238,31 @@ def dedupe_dist_info(
         if targets is not None and name not in targets:
             continue
         groups.setdefault(name, []).append(
-            (version, path, (path / "RECORD").is_file(), inferred)
+            (version, path, "RECORD" in children, inferred)
         )
 
     removed = 0
+    failed = 0
     for entries in groups.values():
         items: list[tuple[str | None, Path]] = []
         for version, path, has_record, inferred in entries:
-            if vkey(version) == _UNRANKED and not has_record:
-                # Metadata-dead: no readable version and no RECORD. pip cannot
-                # uninstall this entry, so any install that tries aborts with
-                # uninstall-no-record-file ("Cannot uninstall <pkg> None"). A
-                # completed pip install always writes RECORD, so unlike the
-                # unrankable-but-managed case below this cannot be the real
-                # install, and removing the dist-info dir is the only way out
-                # of the abort loop.
-                print(f"dedupe: removing metadata-dead {path}", file=sys.stderr)
+            if not has_record:
+                # No RECORD: pip can never uninstall this entry, so any
+                # install that tries aborts with uninstall-no-record-file,
+                # whether or not the version is still readable ("Cannot
+                # uninstall <pkg> None", or with the version when METADATA
+                # survived). A completed pip install always writes RECORD, so
+                # unlike the unrankable-but-managed case below this cannot be
+                # the real install, and removing the dist-info dir is the only
+                # way out of the abort loop.
+                print(f"dedupe: removing RECORD-less {path}", file=sys.stderr)
                 try:
                     _rmtree(path)
                     removed += 1
                 except OSError as err:
+                    # Counted, not just logged: this entry still blocks every
+                    # install, so the run must not report success around it.
+                    failed += 1
                     print(f"skip {path}: {err}", file=sys.stderr)
                 continue
             if inferred:
@@ -269,7 +291,7 @@ def dedupe_dist_info(
             continue
         for version, path in items[:-1]:
             if vkey(version) == _UNRANKED:
-                # An unparseable version with a RECORD (metadata-dead entries
+                # An unparseable version with a RECORD (RECORD-less entries
                 # never reach this loop) might itself be the real install, so
                 # never delete it on the strength of the lowest-sort sentinel.
                 print(f"dedupe: keeping unrankable {path}", file=sys.stderr)
@@ -279,7 +301,7 @@ def dedupe_dist_info(
                 removed += 1
             except OSError as err:
                 print(f"skip {path}: {err}", file=sys.stderr)
-    return removed
+    return removed, failed
 
 
 def main(argv: list[str]) -> int:
@@ -289,12 +311,15 @@ def main(argv: list[str]) -> int:
         if version:
             print(version)
         return 0
-    if mode == "dedupe":
-        print(dedupe_dist_info(distributions()))
-        return 0
-    if mode == "dedupe-all":
-        print(dedupe_dist_info(distributions(), targets=None))
-        return 0
+    if mode in ("dedupe", "dedupe-all"):
+        removed, failed = dedupe_dist_info(
+            distributions(), targets=TARGETS if mode == "dedupe" else None
+        )
+        print(removed)
+        # A RECORD-less dir that survived the prune still aborts every
+        # install; exit 1 so the caller logs "still corrupt" instead of
+        # retrying into the same wall as if the tree were healed.
+        return 1 if failed else 0
     print(f"unknown mode: {mode!r}", file=sys.stderr)
     return 2
 

--- a/src-tauri/scripts/device_builder_maintenance.py
+++ b/src-tauri/scripts/device_builder_maintenance.py
@@ -253,7 +253,42 @@ def dedupe_dist_info(
     at all, or no parseable version anywhere in it: its keeps count as
     unresolved even though they stay.
     """
+    groups, failed = _collect_entries(dists, targets)
     removed = 0
+    for entries in groups.values():
+        group_removed, group_failed = _prune_group(entries)
+        removed += group_removed
+        failed += group_failed
+    return removed, failed
+
+
+def _remove_counted(path: Path, kind: str) -> bool:
+    """Remove ``path``, returning whether it worked.
+
+    On failure prints the could-not-remove line for ``kind``: the two kinds
+    are worded apart so a bounded stderr tail says which failure drove the
+    exit 1.
+    """
+    try:
+        _rmtree(path)
+        return True
+    except OSError as err:
+        print(
+            f"dedupe: could not remove {kind} {path}: {err}",
+            file=sys.stderr,
+        )
+        return False
+
+
+def _collect_entries(
+    dists: Iterable[Distribution], targets: set[str] | None
+) -> tuple[dict[str, list[_Entry]], int]:
+    """Classify ``dists`` into per-package [`_Entry`] groups.
+
+    Returns the groups plus the count of entries that could not even be
+    classified (pathless, nameless in all-scope mode, unlistable) — the
+    collection-phase share of ``dedupe_dist_info``'s ``failed``.
+    """
     failed = 0
     groups: dict[str, list[_Entry]] = {}
     for dist in dists:
@@ -363,106 +398,96 @@ def dedupe_dist_info(
                 unreadable=unreadable,
             )
         )
+    return groups, failed
 
-    for entries in groups.values():
-        items: list[tuple[str | None, Path]] = []
-        kept_dir_name_only = 0
-        for entry in entries:
-            version, path = entry.version, entry.path
-            if not entry.has_record:
-                # No RECORD: pip can never uninstall this entry, so any
-                # install that tries aborts with uninstall-no-record-file,
-                # whether or not the version is still readable ("Cannot
-                # uninstall <pkg> None", or with the version when METADATA
-                # survived). A completed pip install always writes RECORD, so
-                # unlike the unrankable-but-managed case below this cannot be
-                # the real install, and removing the dist-info dir is the only
-                # way out of the abort loop.
-                print(f"dedupe: removing RECORD-less {path}", file=sys.stderr)
-                try:
-                    _rmtree(path)
-                    removed += 1
-                except OSError as err:
-                    # Counted, not just logged: this entry still blocks every
-                    # install, so the run must not report success around it.
-                    # Worded apart from the best-effort "skip" below so a
-                    # bounded stderr tail says which failure drove the exit 1.
-                    failed += 1
-                    print(
-                        f"dedupe: could not remove RECORD-less {path}: {err}",
-                        file=sys.stderr,
-                    )
-                continue
-            if entry.inferred:
-                if entry.unreadable:
-                    # METADATA exists but could not be read. pip can still
-                    # manage the entry (a RECORD got it past the branch
-                    # above), but its version is unknowable right now, so any
-                    # pileup it belongs to is unresolved: counted, not folded
-                    # into the deliberate keeps below.
-                    failed += 1
-                    print(
-                        f"dedupe: could not read METADATA in {path}",
-                        file=sys.stderr,
-                    )
-                    continue
-                # A directory name is identity enough to condemn a
-                # RECORD-less entry above (pip trusts it the same way when
-                # it aborts), but not to rank the entry against properly named
-                # siblings: a corrupted name landing in another package's
-                # group could evict that package's real dist-info. Keep it
-                # and keep it out of the ranking.
-                kept_dir_name_only += 1
-                print(f"dedupe: keeping dir-name-only {path}", file=sys.stderr)
-                continue
-            items.append((version, path))
-        if not items and kept_dir_name_only:
-            # The group ended up with nothing rankable: detect_version filters
-            # on the METADATA Name, so this package still resolves to no
-            # version — the same #190 consequence as a duplicate the prune
-            # could not remove, and on the builder path no install is ever
-            # offered that would let pip heal these keeps. They stand (deleting
-            # on a guess is still the one forbidden wrong), but the run must
-            # not call this resolved.
-            failed += kept_dir_name_only
-        if len(items) < 2:
-            continue  # a single healthy install is left untouched
-        items.sort(key=lambda item: vkey(item[0]))
-        keep_version, keep_path = items[-1]
-        if vkey(keep_version) == _UNRANKED:
-            # No entry in the group has a parseable version, so we can't tell
-            # which is the real install. Leave the whole group rather than
-            # risk a wrong rmtree — but count it, like the nothing-rankable
-            # case above: a version that still cannot be resolved afterwards
-            # is not a heal, whichever shape left it unresolvable.
-            failed += len(items)
-            print(
-                f"dedupe: keeping ambiguous group, no parseable version "
-                f"near {keep_path}",
-                file=sys.stderr,
-            )
-            continue
-        for version, path in items[:-1]:
-            if vkey(version) == _UNRANKED:
-                # An unparseable version with a RECORD (RECORD-less entries
-                # never reach this loop) might itself be the real install, so
-                # never delete it on the strength of the lowest-sort sentinel.
-                print(f"dedupe: keeping unrankable {path}", file=sys.stderr)
-                continue
-            try:
-                _rmtree(path)
+
+def _prune_group(entries: list[_Entry]) -> tuple[int, int]:
+    """Prune one package's entries; returns its ``(removed, failed)`` share."""
+    removed = 0
+    failed = 0
+    items: list[_Entry] = []
+    kept_dir_name_only = 0
+    for entry in entries:
+        path = entry.path
+        if not entry.has_record:
+            # No RECORD: pip can never uninstall this entry, so any install
+            # that tries aborts with uninstall-no-record-file, whether or not
+            # the version is still readable ("Cannot uninstall <pkg> None",
+            # or with the version when METADATA survived). A completed pip
+            # install always writes RECORD, so unlike the
+            # unrankable-but-managed case below this cannot be the real
+            # install, and removing the dist-info dir is the only way out of
+            # the abort loop. A failed removal is counted, not just logged:
+            # the entry still blocks every install, so the run must not
+            # report success around it.
+            print(f"dedupe: removing RECORD-less {path}", file=sys.stderr)
+            if _remove_counted(path, "RECORD-less"):
                 removed += 1
-            except OSError as err:
-                # Also counted: a surviving duplicate keeps the #190 pileup in
-                # place, so importlib still cannot resolve a single version
-                # and the updater loops on "version None". Worded apart from
-                # the RECORD-less and unlistable lines so a bounded stderr
-                # tail says which failure drove the exit 1.
+            else:
+                failed += 1
+            continue
+        if entry.inferred:
+            if entry.unreadable:
+                # METADATA exists but could not be read. pip can still
+                # manage the entry (a RECORD got it past the branch
+                # above), but its version is unknowable right now, so any
+                # pileup it belongs to is unresolved: counted, not folded
+                # into the deliberate keeps below.
                 failed += 1
                 print(
-                    f"dedupe: could not remove stale duplicate {path}: {err}",
+                    f"dedupe: could not read METADATA in {path}",
                     file=sys.stderr,
                 )
+                continue
+            # A directory name is identity enough to condemn a
+            # RECORD-less entry above (pip trusts it the same way when
+            # it aborts), but not to rank the entry against properly named
+            # siblings: a corrupted name landing in another package's
+            # group could evict that package's real dist-info. Keep it
+            # and keep it out of the ranking.
+            kept_dir_name_only += 1
+            print(f"dedupe: keeping dir-name-only {path}", file=sys.stderr)
+            continue
+        items.append(entry)
+    if not items and kept_dir_name_only:
+        # The group ended up with nothing rankable: detect_version filters
+        # on the METADATA Name, so this package still resolves to no
+        # version — the same #190 consequence as a duplicate the prune
+        # could not remove, and on the builder path no install is ever
+        # offered that would let pip heal these keeps. They stand (deleting
+        # on a guess is still the one forbidden wrong), but the run must
+        # not call this resolved.
+        failed += kept_dir_name_only
+    if len(items) < 2:
+        return removed, failed  # a single healthy install is left untouched
+    items.sort(key=lambda entry: vkey(entry.version))
+    keep = items[-1]
+    if vkey(keep.version) == _UNRANKED:
+        # No entry in the group has a parseable version, so we can't tell
+        # which is the real install. Leave the whole group rather than
+        # risk a wrong rmtree — but count it, like the nothing-rankable
+        # case above: a version that still cannot be resolved afterwards
+        # is not a heal, whichever shape left it unresolvable.
+        failed += len(items)
+        print(
+            f"dedupe: keeping ambiguous group, no parseable version near {keep.path}",
+            file=sys.stderr,
+        )
+        return removed, failed
+    for entry in items[:-1]:
+        if vkey(entry.version) == _UNRANKED:
+            # An unparseable version with a RECORD (RECORD-less entries
+            # never reach this loop) might itself be the real install, so
+            # never delete it on the strength of the lowest-sort sentinel.
+            print(f"dedupe: keeping unrankable {entry.path}", file=sys.stderr)
+            continue
+        # A failed removal is counted: a surviving duplicate keeps the #190
+        # pileup in place, so importlib still cannot resolve a single
+        # version and the updater loops on "version None".
+        if _remove_counted(entry.path, "stale duplicate"):
+            removed += 1
+        else:
+            failed += 1
     return removed, failed
 
 

--- a/src-tauri/scripts/device_builder_maintenance.py
+++ b/src-tauri/scripts/device_builder_maintenance.py
@@ -121,9 +121,14 @@ def _infer_name(path: Path) -> str:
     """Normalized package name from a ``*.dist-info`` directory name.
 
     ``pkg_name-1.2.3.dist-info`` -> ``pkg-name``; with no version separator the
-    whole stem is taken as the name. Only used when METADATA is missing or has
-    no Name header, and only for scope filtering and grouping; version ranking
-    never trusts the directory name.
+    whole stem is taken as the name. The wheel spec underscore-normalizes the
+    name part, so the last ``-`` always cuts at the version for anything pip
+    wrote, and pip resolves identity from the directory name the same way when
+    METADATA is gone ("Cannot uninstall esphome-device-builder-frontend None").
+
+    Only used when METADATA is missing or has no Name header, and only to
+    scope-filter the entry and attribute the metadata-dead removal; an
+    inferred name never ranks its entry against properly named siblings.
     """
     stem = path.name[: -len(".dist-info")]
     name, sep, _version = stem.rpartition("-")
@@ -173,7 +178,7 @@ def dedupe_dist_info(
     uninstall one, so it aborts every upgrade with ``uninstall-no-record-file``
     until it is gone. Returns the number of dist-info directories removed.
     """
-    groups: dict[str, list[tuple[str | None, Path, bool]]] = {}
+    groups: dict[str, list[tuple[str | None, Path, bool, bool]]] = {}
     for dist in dists:
         # ``_path`` is private; guard it so a future importlib change degrades to
         # a no-op rather than deleting the wrong directory.
@@ -200,10 +205,11 @@ def dedupe_dist_info(
                 f"dedupe: unreadable metadata in {path}: {err}",
                 file=sys.stderr,
             )
-        if not name:
+        inferred = not name
+        if inferred:
             # No METADATA, or one with no Name header. The directory name still
-            # identifies the package well enough to scope-filter and group the
-            # entry; without it the torn dist-info behind the permanent
+            # identifies the package well enough to scope-filter the entry;
+            # without it the torn dist-info behind the permanent
             # uninstall-no-record-file abort could never be considered at all.
             name = _infer_name(path)
         if not name:
@@ -214,12 +220,14 @@ def dedupe_dist_info(
             continue
         if targets is not None and name not in targets:
             continue
-        groups.setdefault(name, []).append((version, path, (path / "RECORD").is_file()))
+        groups.setdefault(name, []).append(
+            (version, path, (path / "RECORD").is_file(), inferred)
+        )
 
     removed = 0
     for entries in groups.values():
         items: list[tuple[str | None, Path]] = []
-        for version, path, has_record in entries:
+        for version, path, has_record, inferred in entries:
             if vkey(version) == _UNRANKED and not has_record:
                 # Metadata-dead: no readable version and no RECORD. pip cannot
                 # uninstall this entry, so any install that tries aborts with
@@ -234,6 +242,15 @@ def dedupe_dist_info(
                     removed += 1
                 except OSError as err:
                     print(f"skip {path}: {err}", file=sys.stderr)
+                continue
+            if inferred:
+                # A directory name is identity enough to condemn a
+                # metadata-dead entry above (pip trusts it the same way when
+                # it aborts), but not to rank the entry against properly named
+                # siblings: a corrupted name landing in another package's
+                # group could evict that package's real dist-info. Keep it
+                # and keep it out of the ranking.
+                print(f"dedupe: keeping dir-name-only {path}", file=sys.stderr)
                 continue
             items.append((version, path))
         if len(items) < 2:

--- a/src-tauri/scripts/device_builder_maintenance.py
+++ b/src-tauri/scripts/device_builder_maintenance.py
@@ -230,7 +230,9 @@ def dedupe_dist_info(
     reported as a heal. Deliberate conservative keeps
     (unrankable or dir-name-only entries that still have a RECORD, ambiguous
     groups) are not failures: pip can still manage those, and deleting on a
-    guess is the one wrong this prune must never commit.
+    guess is the one wrong this prune must never commit. The exception is a
+    group left with nothing rankable at all — its version still cannot be
+    resolved, so its keeps count as unresolved even though they stay.
     """
     removed = 0
     failed = 0
@@ -339,6 +341,7 @@ def dedupe_dist_info(
 
     for entries in groups.values():
         items: list[tuple[str | None, Path]] = []
+        kept_dir_name_only = 0
         for version, path, has_record, inferred, unreadable in entries:
             if not has_record:
                 # No RECORD: pip can never uninstall this entry, so any
@@ -383,9 +386,19 @@ def dedupe_dist_info(
                 # siblings: a corrupted name landing in another package's
                 # group could evict that package's real dist-info. Keep it
                 # and keep it out of the ranking.
+                kept_dir_name_only += 1
                 print(f"dedupe: keeping dir-name-only {path}", file=sys.stderr)
                 continue
             items.append((version, path))
+        if not items and kept_dir_name_only:
+            # The group ended up with nothing rankable: detect_version filters
+            # on the METADATA Name, so this package still resolves to no
+            # version — the same #190 consequence as a duplicate the prune
+            # could not remove, and on the builder path no install is ever
+            # offered that would let pip heal these keeps. They stand (deleting
+            # on a guess is still the one forbidden wrong), but the run must
+            # not call this resolved.
+            failed += kept_dir_name_only
         if len(items) < 2:
             continue  # a single healthy install is left untouched
         items.sort(key=lambda item: vkey(item[0]))

--- a/src-tauri/src/control/server.rs
+++ b/src-tauri/src/control/server.rs
@@ -504,7 +504,9 @@ async fn build_status(app: &AppHandle, state: &Arc<AppState>) -> StatusReply {
 
 /// Check every component for an available update without installing anything.
 /// Read-only, so it takes no [`UpdateGuard`] and is safe to run even while an
-/// update is in flight. The three checks hit the network (GitHub, PyPI) and
+/// update is in flight (the lazy dist-info heal inside version detection is
+/// the one destructive step on this path, and it stands down while a sequence
+/// holds the guard). The three checks hit the network (GitHub, PyPI) and
 /// spawn Python for the installed versions, so run them concurrently.
 async fn build_update_check(app: &AppHandle, state: &Arc<AppState>) -> UpdateCheckReply {
     let (channel, backend) = {

--- a/src-tauri/src/control/server.rs
+++ b/src-tauri/src/control/server.rs
@@ -504,10 +504,12 @@ async fn build_status(app: &AppHandle, state: &Arc<AppState>) -> StatusReply {
 
 /// Check every component for an available update without installing anything.
 /// Read-only, so it takes no [`UpdateGuard`] and is safe to run even while an
-/// update is in flight (the lazy dist-info heal inside version detection is
-/// the one destructive step on this path, and it stands down while a sequence
-/// holds the guard). The three checks hit the network (GitHub, PyPI) and
-/// spawn Python for the installed versions, so run them concurrently.
+/// update is in flight — this path reads versions through the non-healing
+/// `get_installed_device_builder_version`, so no destructive step ever runs
+/// here (the lazy dist-info heal lives on the tray and background check
+/// paths, gated by `HealPolicy`). The three checks hit the network (GitHub,
+/// PyPI) and spawn Python for the installed versions, so run them
+/// concurrently.
 async fn build_update_check(app: &AppHandle, state: &Arc<AppState>) -> UpdateCheckReply {
     let (channel, backend) = {
         let settings = state.settings.read().await;

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -619,6 +619,13 @@ mod tests {
             "Metadata-Version: 2.1\nName: esphome\nVersion: 0.0.1\n",
         )
         .unwrap();
+        // And the metadata-dead shape from the same overlay: a dist-info with
+        // no METADATA and no RECORD, which pip reports as "Cannot uninstall
+        // esphome-device-builder-frontend None" and aborts every upgrade on.
+        // A repair that reproduces it into the user tree makes the update
+        // retry fail identically forever, so the post-copy dedupe must drop it.
+        let dead_dist_info_name = "esphome_device_builder_frontend-0.0.0.dist-info";
+        std::fs::create_dir_all(e2e_purelib(&old_python).join(dead_dist_info_name)).unwrap();
 
         // 9. Refresh from the older source. The snapshot reads the newer
         //    version from the user tree, the copy lands the older one, and the
@@ -674,6 +681,11 @@ mod tests {
             esphome_dist_infos,
             [format!("esphome-{current}.dist-info")],
             "the refreshed tree must hold exactly one esphome dist-info"
+        );
+        assert!(
+            !purelib.join(dead_dist_info_name).exists(),
+            "the metadata-dead dist-info survived the copy; pip aborts every \
+             device-builder upgrade with uninstall-no-record-file while it exists"
         );
 
         let _ = std::fs::remove_dir_all(&base);

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -454,6 +454,31 @@ mod tests {
         PathBuf::from(out.trim())
     }
 
+    /// Dist-info dirs in `purelib` whose name starts with `prefix`.
+    fn e2e_dist_infos(purelib: &Path, prefix: &str) -> Vec<PathBuf> {
+        std::fs::read_dir(purelib)
+            .expect("could not list purelib")
+            .filter_map(|entry| {
+                let entry = entry.unwrap();
+                let name = entry.file_name().into_string().unwrap();
+                (name.starts_with(prefix) && name.ends_with(".dist-info")).then(|| entry.path())
+            })
+            .collect()
+    }
+
+    /// The exact pip invocation the updater runs for the device builder
+    /// (unpinned stable). One spelling shared by e2e steps 8b and 12: their
+    /// whole point is that the *identical* command aborts before the repair
+    /// and succeeds after it, so identity must be structural, not by
+    /// inspection of two literals.
+    const E2E_BUILDER_UPGRADE: &[&str] = &[
+        "-m",
+        "pip",
+        "install",
+        "--upgrade",
+        "esphome-device-builder",
+    ];
+
     /// The whole repair lifecycle against a real bundled Python tree: the
     /// first-run copy, detect the orphan, wipe and re-copy from the pristine
     /// bundle, prove it is fixed, then prove a refresh from an older bundle
@@ -640,30 +665,20 @@ mod tests {
         //     uninstall-no-record-file; this is the premise the whole fix
         //     rests on, so assert it rather than assume it. (Reaches PyPI:
         //     pip resolves the frontend wheel before the uninstall aborts.)
-        for entry in std::fs::read_dir(&purelib).unwrap() {
-            let entry = entry.unwrap();
-            let name = entry.file_name().into_string().unwrap();
-            if name.starts_with("esphome_device_builder_frontend") && name.ends_with(".dist-info") {
-                std::fs::remove_dir_all(entry.path()).unwrap();
-            }
+        for dist_info in e2e_dist_infos(&purelib, "esphome_device_builder_frontend") {
+            std::fs::remove_dir_all(dist_info).unwrap();
         }
         std::fs::create_dir_all(purelib.join(dead_dist_info_name)).unwrap();
-        let (ok, out) = e2e_pip(
-            &python,
-            &[
-                "-m",
-                "pip",
-                "install",
-                "--upgrade",
-                "esphome-device-builder",
-            ],
-        );
+        let (ok, out) = e2e_pip(&python, E2E_BUILDER_UPGRADE);
         assert!(
             !ok,
             "pip must abort on the RECORD-less frontend dist-info: {out}"
         );
+        // The production predicate, not a re-hardcoded pip phrase: what this
+        // step must prove is that the planted state produces the abort
+        // `install_with_record_recovery` keys its repair on.
         assert!(
-            out.contains("no RECORD file was found"),
+            crate::update::is_missing_record_error(&out),
             "pip failed, but not with the missing-RECORD abort this state must produce: {out}"
         );
 
@@ -710,12 +725,9 @@ mod tests {
         //     direct negation of the #389 symptom. The step-2 `purelib` path
         //     is still the right place to look: the refresh recreated the
         //     directory, but at the same location.
-        let esphome_dist_infos: Vec<_> = std::fs::read_dir(&purelib)
-            .expect("could not list the refreshed purelib")
-            .filter_map(|entry| {
-                let name = entry.unwrap().file_name().into_string().unwrap();
-                (name.starts_with("esphome-") && name.ends_with(".dist-info")).then_some(name)
-            })
+        let esphome_dist_infos: Vec<_> = e2e_dist_infos(&purelib, "esphome-")
+            .iter()
+            .map(|path| path.file_name().unwrap().to_string_lossy().into_owned())
             .collect();
         assert_eq!(
             esphome_dist_infos,
@@ -733,16 +745,7 @@ mod tests {
         //     it repaired from carried the same corruption, exactly the
         //     reported situation. The command that aborted in step 8b must
         //     now succeed. (Reaches PyPI.)
-        let (ok, out) = e2e_pip(
-            &python,
-            &[
-                "-m",
-                "pip",
-                "install",
-                "--upgrade",
-                "esphome-device-builder",
-            ],
-        );
+        let (ok, out) = e2e_pip(&python, E2E_BUILDER_UPGRADE);
         assert!(
             ok,
             "the update retry still fails after the repair from a dirty source: {out}"

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -476,7 +476,9 @@ mod tests {
     /// is built from the other side: a second bundle source, copied from the
     /// first and pip-downgraded, so the snapshot beats the incoming bundle and
     /// the restore must reinstall. The repair leg itself stays offline; the
-    /// downgrade and the restore are where this test reaches PyPI.
+    /// downgrade, the restore, and the metadata-dead abort/retry legs (8b and
+    /// 12, the reported "Cannot uninstall esphome-device-builder-frontend
+    /// None" failure and its recovery) are where this test reaches PyPI.
     ///
     /// One test rather than several because each step depends on the last
     /// leaving the tree in a particular state, and Rust does not order tests.
@@ -627,6 +629,39 @@ mod tests {
         let dead_dist_info_name = "esphome_device_builder_frontend-0.0.0.dist-info";
         std::fs::create_dir_all(e2e_purelib(&old_python).join(dead_dist_info_name)).unwrap();
 
+        // 8b. Reproduce the reported user state in the user tree: the only
+        //     frontend dist-info is the metadata-dead one. The exact command
+        //     the app's updater runs must abort the way the user saw, with
+        //     uninstall-no-record-file; this is the premise the whole fix
+        //     rests on, so assert it rather than assume it. (Reaches PyPI:
+        //     pip resolves the frontend wheel before the uninstall aborts.)
+        for entry in std::fs::read_dir(&purelib).unwrap() {
+            let entry = entry.unwrap();
+            let name = entry.file_name().into_string().unwrap();
+            if name.starts_with("esphome_device_builder_frontend") && name.ends_with(".dist-info") {
+                std::fs::remove_dir_all(entry.path()).unwrap();
+            }
+        }
+        std::fs::create_dir_all(purelib.join(dead_dist_info_name)).unwrap();
+        let (ok, out) = e2e_pip(
+            &python,
+            &[
+                "-m",
+                "pip",
+                "install",
+                "--upgrade",
+                "esphome-device-builder",
+            ],
+        );
+        assert!(
+            !ok,
+            "pip must abort on the metadata-dead frontend dist-info: {out}"
+        );
+        assert!(
+            out.contains("no RECORD file was found"),
+            "pip failed, but not with the missing-RECORD abort this state must produce: {out}"
+        );
+
         // 9. Refresh from the older source. The snapshot reads the newer
         //    version from the user tree, the copy lands the older one, and the
         //    restore must notice the downgrade and pip-reinstall the newer
@@ -686,6 +721,26 @@ mod tests {
             !purelib.join(dead_dist_info_name).exists(),
             "the metadata-dead dist-info survived the copy; pip aborts every \
              device-builder upgrade with uninstall-no-record-file while it exists"
+        );
+
+        // 12. The recovery the app performs is repair-then-retry with the
+        //     identical command (install_with_record_recovery), and the source
+        //     it repaired from carried the same corruption, exactly the
+        //     reported situation. The command that aborted in step 8b must
+        //     now succeed. (Reaches PyPI.)
+        let (ok, out) = e2e_pip(
+            &python,
+            &[
+                "-m",
+                "pip",
+                "install",
+                "--upgrade",
+                "esphome-device-builder",
+            ],
+        );
+        assert!(
+            ok,
+            "the update retry still fails after the repair from a dirty source: {out}"
         );
 
         let _ = std::fs::remove_dir_all(&base);

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -621,6 +621,11 @@ mod tests {
             "Metadata-Version: 2.1\nName: esphome\nVersion: 0.0.1\n",
         )
         .unwrap();
+        // With a RECORD, so the stale entry stays pip-manageable and this leg
+        // keeps proving the version-ranking dedupe: without one the
+        // RECORD-less rule would condemn it before ranking ever ran, and the
+        // ranking path would silently stop being tested against a real tree.
+        std::fs::write(stale_dist_info.join("RECORD"), "").unwrap();
         // And the RECORD-less shape from the same overlay: a dist-info with
         // no METADATA and no RECORD, which pip reports as "Cannot uninstall
         // esphome-device-builder-frontend None" and aborts every upgrade on.

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -476,7 +476,7 @@ mod tests {
     /// is built from the other side: a second bundle source, copied from the
     /// first and pip-downgraded, so the snapshot beats the incoming bundle and
     /// the restore must reinstall. The repair leg itself stays offline; the
-    /// downgrade, the restore, and the metadata-dead abort/retry legs (8b and
+    /// downgrade, the restore, and the RECORD-less abort/retry legs (8b and
     /// 12, the reported "Cannot uninstall esphome-device-builder-frontend
     /// None" failure and its recovery) are where this test reaches PyPI.
     ///
@@ -621,7 +621,7 @@ mod tests {
             "Metadata-Version: 2.1\nName: esphome\nVersion: 0.0.1\n",
         )
         .unwrap();
-        // And the metadata-dead shape from the same overlay: a dist-info with
+        // And the RECORD-less shape from the same overlay: a dist-info with
         // no METADATA and no RECORD, which pip reports as "Cannot uninstall
         // esphome-device-builder-frontend None" and aborts every upgrade on.
         // A repair that reproduces it into the user tree makes the update
@@ -630,7 +630,7 @@ mod tests {
         std::fs::create_dir_all(e2e_purelib(&old_python).join(dead_dist_info_name)).unwrap();
 
         // 8b. Reproduce the reported user state in the user tree: the only
-        //     frontend dist-info is the metadata-dead one. The exact command
+        //     frontend dist-info is the RECORD-less one. The exact command
         //     the app's updater runs must abort the way the user saw, with
         //     uninstall-no-record-file; this is the premise the whole fix
         //     rests on, so assert it rather than assume it. (Reaches PyPI:
@@ -655,7 +655,7 @@ mod tests {
         );
         assert!(
             !ok,
-            "pip must abort on the metadata-dead frontend dist-info: {out}"
+            "pip must abort on the RECORD-less frontend dist-info: {out}"
         );
         assert!(
             out.contains("no RECORD file was found"),
@@ -719,7 +719,7 @@ mod tests {
         );
         assert!(
             !purelib.join(dead_dist_info_name).exists(),
-            "the metadata-dead dist-info survived the copy; pip aborts every \
+            "the RECORD-less dist-info survived the copy; pip aborts every \
              device-builder upgrade with uninstall-no-record-file while it exists"
         );
 

--- a/src-tauri/src/platform/pip.rs
+++ b/src-tauri/src/platform/pip.rs
@@ -80,33 +80,32 @@ const PIP_CONFLICT_MARKER: &str = "The conflict is caused by:";
 /// headline and its own opening — the symptom and the cause — keeping only
 /// the boilerplate.
 ///
-/// pip's manual-recovery hints are stripped first: see
-/// [`strip_pip_recovery_hints`].
+/// pip's hint lines are stripped first: see [`strip_pip_hint_lines`].
 fn pip_failure_report(stdout: &str, stderr: &str) -> String {
-    let stderr = tail_for_log(&strip_pip_recovery_hints(stderr));
+    let stderr = tail_for_log(&strip_pip_hint_lines(stderr));
     match stdout.find(PIP_CONFLICT_MARKER) {
         Some(start) => format!("{stderr}\n{}", head_for_log(&stdout[start..])),
         None => stderr,
     }
 }
 
-/// Drop pip's "recover from this via: pip install ..." hint lines from a
-/// report the user will see.
+/// Drop pip's `hint:` lines from a report the user will see.
 ///
-/// Under the missing-RECORD abort pip prints `hint: You might be able to
-/// recover from this via: pip install --ignore-installed --no-deps <pkg>==<v>`
-/// (`--force-reinstall` on newer pips). Surfacing that in the failure dialog
-/// is bad advice twice over. The flags skip pip's uninstall bookkeeping, which
-/// piles more orphaned metadata onto an already-corrupt tree and moves the
-/// failure instead of fixing it — the same damage that got `--ignore-installed`
-/// removed from the app (#330). And a user typing the command into a terminal
-/// runs their system pip, not the bundled interpreter, so the "recovery" lands
-/// in a Python this app never imports from. Only command hints are dropped;
-/// hint lines that merely explain stay.
-fn strip_pip_recovery_hints(stderr: &str) -> String {
+/// The hints speak to whoever manages the installed environment directly, and
+/// in this app that is only ever the updater: the environment is the bundled
+/// tree, reachable through the app alone, so no hint is user-actionable. The
+/// worst of them is actively harmful: under the missing-RECORD abort pip
+/// prints `hint: You might be able to recover from this via: pip install
+/// --ignore-installed --no-deps <pkg>==<v>` (`--force-reinstall` on newer
+/// pips), which skips pip's uninstall bookkeeping and piles more orphaned
+/// metadata onto an already-corrupt tree — the same damage that got
+/// `--ignore-installed` removed from the app (#330) — and a user typing it
+/// into a terminal reaches their system pip, not the bundled interpreter. The
+/// error lines above the hint keep carrying the facts a bug report needs.
+fn strip_pip_hint_lines(stderr: &str) -> String {
     stderr
         .lines()
-        .filter(|line| !(line.trim_start().starts_with("hint:") && line.contains("pip install")))
+        .filter(|line| !line.trim_start().starts_with("hint:"))
         .collect::<Vec<_>>()
         .join("\n")
 }
@@ -404,14 +403,17 @@ mod tests {
     }
 
     #[test]
-    fn pip_failure_report_keeps_hints_that_are_not_commands() {
-        // Only command hints are misleading; a hint that merely explains is
-        // context worth keeping in a bug report.
+    fn pip_failure_report_drops_every_hint_line() {
+        // Not just the recovery command: every pip hint addresses whoever
+        // manages the installed environment directly, and here that is only
+        // ever the updater. The error lines above it stay, since they carry
+        // the facts a bug report needs.
         let report = pip_failure_report(
             "",
             "ERROR: something broke\nhint: See above for the traceback.\n",
         );
-        assert!(report.contains("hint: See above for the traceback."));
+        assert!(report.contains("ERROR: something broke"), "{report}");
+        assert!(!report.contains("hint:"), "{report}");
     }
 
     #[test]

--- a/src-tauri/src/platform/pip.rs
+++ b/src-tauri/src/platform/pip.rs
@@ -102,10 +102,27 @@ fn pip_failure_report(stdout: &str, stderr: &str) -> String {
 /// `--ignore-installed` removed from the app (#330) — and a user typing it
 /// into a terminal reaches their system pip, not the bundled interpreter. The
 /// error lines above the hint keep carrying the facts a bug report needs.
+///
+/// Indented lines following a `hint:` line are dropped with it: pip does not
+/// wrap the hint when its output is captured, but if a renderer change ever
+/// does, the continuation is where the command itself would land. pip's own
+/// diagnostic lines (`ERROR:`, `×`, `╰─>`) all start flush left, so nothing
+/// factual is indented in real stderr.
 fn strip_pip_hint_lines(stderr: &str) -> String {
+    let mut in_hint = false;
     stderr
         .lines()
-        .filter(|line| !line.trim_start().starts_with("hint:"))
+        .filter(|line| {
+            if line.trim_start().starts_with("hint:") {
+                in_hint = true;
+                return false;
+            }
+            if in_hint && line.starts_with(|c: char| c.is_whitespace()) && !line.trim().is_empty() {
+                return false;
+            }
+            in_hint = false;
+            true
+        })
         .collect::<Vec<_>>()
         .join("\n")
 }
@@ -400,6 +417,30 @@ mod tests {
             assert!(!report.contains("pip install"), "{report}");
             assert!(!report.contains(flag), "{report}");
         }
+    }
+
+    #[test]
+    fn pip_failure_report_drops_a_wrapped_hint_continuation() {
+        // pip does not wrap the hint when captured, but a renderer change
+        // could; the continuation line is where the pip install command
+        // itself would land, so the block is dropped through its indented
+        // continuations. The blank line and the flush-left diagnostics
+        // around it survive.
+        let report = pip_failure_report(
+            "",
+            "error: uninstall-no-record-file\n\
+             hint: You might be able to recover from this via: pip install\n\
+             \x20     --ignore-installed --no-deps esphome-device-builder-frontend==0.1.172\n\
+             \n\
+             ERROR: some closing line\n",
+        );
+        assert!(
+            report.contains("error: uninstall-no-record-file"),
+            "{report}"
+        );
+        assert!(report.contains("ERROR: some closing line"), "{report}");
+        assert!(!report.contains("pip install"), "{report}");
+        assert!(!report.contains("--ignore-installed"), "{report}");
     }
 
     #[test]

--- a/src-tauri/src/platform/pip.rs
+++ b/src-tauri/src/platform/pip.rs
@@ -79,12 +79,36 @@ const PIP_CONFLICT_MARKER: &str = "The conflict is caused by:";
 /// Bounding the joined report instead would let a long diagnostic evict the
 /// headline and its own opening — the symptom and the cause — keeping only
 /// the boilerplate.
+///
+/// pip's manual-recovery hints are stripped first: see
+/// [`strip_pip_recovery_hints`].
 fn pip_failure_report(stdout: &str, stderr: &str) -> String {
-    let stderr = tail_for_log(stderr);
+    let stderr = tail_for_log(&strip_pip_recovery_hints(stderr));
     match stdout.find(PIP_CONFLICT_MARKER) {
         Some(start) => format!("{stderr}\n{}", head_for_log(&stdout[start..])),
         None => stderr,
     }
+}
+
+/// Drop pip's "recover from this via: pip install ..." hint lines from a
+/// report the user will see.
+///
+/// Under the missing-RECORD abort pip prints `hint: You might be able to
+/// recover from this via: pip install --ignore-installed --no-deps <pkg>==<v>`
+/// (`--force-reinstall` on newer pips). Surfacing that in the failure dialog
+/// is bad advice twice over. The flags skip pip's uninstall bookkeeping, which
+/// piles more orphaned metadata onto an already-corrupt tree and moves the
+/// failure instead of fixing it — the same damage that got `--ignore-installed`
+/// removed from the app (#330). And a user typing the command into a terminal
+/// runs their system pip, not the bundled interpreter, so the "recovery" lands
+/// in a Python this app never imports from. Only command hints are dropped;
+/// hint lines that merely explain stay.
+fn strip_pip_recovery_hints(stderr: &str) -> String {
+    stderr
+        .lines()
+        .filter(|line| !(line.trim_start().starts_with("hint:") && line.contains("pip install")))
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 /// [`pip_failure_report`] over a captured pip [`std::process::Output`].
@@ -354,6 +378,40 @@ mod tests {
             report.len() <= 2 * LOG_TAIL_BYTES + 100,
             "report is bounded"
         );
+    }
+
+    #[test]
+    fn pip_failure_report_drops_pips_manual_recovery_hint() {
+        // The hint is pip talking to a developer at a terminal. In this app it
+        // is wrong twice over: the suggested flags skip pip's uninstall
+        // bookkeeping (the very damage that got --ignore-installed removed,
+        // #330), and a user's terminal pip is the system one, not the bundled
+        // interpreter. A user was sent chasing exactly this "recovery".
+        for flag in ["--ignore-installed", "--force-reinstall"] {
+            let stderr = format!(
+                "error: uninstall-no-record-file\n\n\
+                 × Cannot uninstall esphome-device-builder-frontend None\n\
+                 ╰─> The package's contents are unknown: no RECORD file was \
+                 found for esphome-device-builder-frontend.\n\n\
+                 hint: You might be able to recover from this via: pip install \
+                 {flag} --no-deps esphome-device-builder-frontend==0.1.172\n"
+            );
+            let report = pip_failure_report("", &stderr);
+            assert!(report.contains("no RECORD file was found"), "{report}");
+            assert!(!report.contains("pip install"), "{report}");
+            assert!(!report.contains(flag), "{report}");
+        }
+    }
+
+    #[test]
+    fn pip_failure_report_keeps_hints_that_are_not_commands() {
+        // Only command hints are misleading; a hint that merely explains is
+        // context worth keeping in a bug report.
+        let report = pip_failure_report(
+            "",
+            "ERROR: something broke\nhint: See above for the traceback.\n",
+        );
+        assert!(report.contains("hint: See above for the traceback."));
     }
 
     #[test]

--- a/src-tauri/src/platform/pip.rs
+++ b/src-tauri/src/platform/pip.rs
@@ -103,18 +103,24 @@ fn pip_failure_report(stdout: &str, stderr: &str) -> String {
 /// into a terminal reaches their system pip, not the bundled interpreter. The
 /// error lines above the hint keep carrying the facts a bug report needs.
 ///
-/// Indented lines following a `hint:` line are dropped with it: pip does not
-/// wrap the hint when its output is captured, but if a renderer change ever
-/// does, the continuation is where the command itself would land. pip does
-/// indent some factual output (a nested subprocess build-error block), but
-/// those blocks precede any hint — hints are terminal in pip's diagnostics —
-/// so an indented line after a `hint:` can only belong to the hint.
+/// Only flush-left `hint:` lines start a dropped block: those are pip's own.
+/// An *indented* `hint:` is subprocess output pip relays inside its nested
+/// build-error block — git emits them, and the dev channel installs from
+/// `git+` — and swallowing from there would eat the rest of that factual
+/// block.
+///
+/// Indented lines following pip's own `hint:` are dropped with it: pip does
+/// not wrap the hint when its output is captured, but if a renderer change
+/// ever does, the continuation is where the command itself would land. pip's
+/// indented factual blocks precede any hint — hints are terminal in pip's
+/// diagnostics — so an indented line after a flush-left `hint:` can only
+/// belong to the hint.
 fn strip_pip_hint_lines(stderr: &str) -> String {
     let mut in_hint = false;
     stderr
         .lines()
         .filter(|line| {
-            if line.trim_start().starts_with("hint:") {
+            if line.starts_with("hint:") {
                 in_hint = true;
                 return false;
             }
@@ -442,6 +448,30 @@ mod tests {
         assert!(report.contains("ERROR: some closing line"), "{report}");
         assert!(!report.contains("pip install"), "{report}");
         assert!(!report.contains("--ignore-installed"), "{report}");
+    }
+
+    #[test]
+    fn pip_failure_report_keeps_an_indented_subprocess_hint_block() {
+        // An indented hint: is not pip talking — it is subprocess output
+        // (git emits hint: lines; the dev channel installs from git+) that
+        // pip relays inside its nested build-error block. Treating it as a
+        // hint start would swallow the rest of that factual block.
+        let report = pip_failure_report(
+            "",
+            "ERROR: command errored out\n\
+             \x20 hint: Using 'master' as the name for the initial branch\n\
+             \x20 fatal: repository not found\n\
+             hint: You might be able to recover from this via: pip install --ignore-installed x\n",
+        );
+        assert!(
+            report.contains("hint: Using 'master'"),
+            "relayed subprocess output was eaten: {report}"
+        );
+        assert!(
+            report.contains("fatal: repository not found"),
+            "the factual block after the relayed hint was eaten: {report}"
+        );
+        assert!(!report.contains("pip install"), "{report}");
     }
 
     #[test]

--- a/src-tauri/src/platform/pip.rs
+++ b/src-tauri/src/platform/pip.rs
@@ -105,9 +105,10 @@ fn pip_failure_report(stdout: &str, stderr: &str) -> String {
 ///
 /// Indented lines following a `hint:` line are dropped with it: pip does not
 /// wrap the hint when its output is captured, but if a renderer change ever
-/// does, the continuation is where the command itself would land. pip's own
-/// diagnostic lines (`ERROR:`, `×`, `╰─>`) all start flush left, so nothing
-/// factual is indented in real stderr.
+/// does, the continuation is where the command itself would land. pip does
+/// indent some factual output (a nested subprocess build-error block), but
+/// those blocks precede any hint — hints are terminal in pip's diagnostics —
+/// so an indented line after a `hint:` can only belong to the hint.
 fn strip_pip_hint_lines(stderr: &str) -> String {
     let mut in_hint = false;
     stderr

--- a/src-tauri/src/platform/python_env.rs
+++ b/src-tauri/src/platform/python_env.rs
@@ -20,10 +20,11 @@ use tracing::{debug, info, warn};
 pub(super) const PYTHON_VERSION_MARKER: &str = ".esphome-desktop-version";
 
 /// Hard bound on one dist-info dedupe run. Local filesystem work only —
-/// enumerate site-packages, remove a few directories — so a minute is
-/// generous even under a slow disk or an antivirus scan; see the call site
-/// for why the bound is load-bearing (the lazy heal holds the `UpdateGuard`
-/// across this child).
+/// enumerate site-packages, remove a few directories of metadata text — so a
+/// minute is generous even under a slow disk or an antivirus scan. Both
+/// callers get the bound; it is load-bearing for the lazy heal, which holds
+/// the `UpdateGuard` across this child, and merely tidy for the post-copy
+/// self-clean, which nothing waits behind.
 const DIST_INFO_DEDUPE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
 
 /// Filename of the counter tracking consecutive launches that deferred the
@@ -247,10 +248,13 @@ pub(super) fn refresh_python_tree(
     // them (#389). Prune to one dist-info per package before anything reads
     // the fresh tree — the version restore below and every later pip
     // uninstall rely on `importlib.metadata`, which duplicates make
-    // ambiguous. Best-effort: duplicate metadata does not fail the health
-    // probe, so failing the refresh over it would turn an ambiguity into a
-    // broken tree. Runs before the marker write so a crash mid-prune leaves
-    // no marker and the next launch re-copies and re-prunes.
+    // ambiguous. Best-effort even though an `Err` can now also mean a
+    // RECORD-less dir survived (the shape that aborts installs): the tree
+    // still works for everything except that install, whose retry surfaces
+    // pip's own report to the user, while failing the refresh here would
+    // trade a degraded tree for none. Runs before the marker write so a
+    // crash mid-prune leaves no marker and the next launch re-copies and
+    // re-prunes.
     if let Err(e) = dedupe_dist_info(&python_check, DistInfoDedupeScope::All) {
         warn!(
             "dist-info dedup after the bundle copy failed ({e:#}); continuing with the copied tree"

--- a/src-tauri/src/platform/python_env.rs
+++ b/src-tauri/src/platform/python_env.rs
@@ -820,13 +820,14 @@ mod tests {
 
     #[test]
     fn maint_script_pins_the_argv_mode_contract() {
-        // Behavior is covered in depth by tests/test_device_builder_maintenance.py;
-        // here we only pin the argv modes the two runners above invoke, so a
-        // rename of the modes (not the internal functions) can't pass silently.
-        // The bare `dedupe` mode is matched by its dispatch line because any
-        // string containing "dedupe-all" trivially contains "dedupe".
-        assert!(DEVICE_BUILDER_MAINT_PY.contains("detect"));
-        assert!(DEVICE_BUILDER_MAINT_PY.contains("if mode in (\"dedupe\", \"dedupe-all\"):"));
+        // Behavior, including main()'s dispatch and exit codes, is covered by
+        // tests/test_device_builder_maintenance.py; here we only pin the mode
+        // *names* the two runners above pass on argv, so a rename can't pass
+        // silently. Quoted, so the bare "dedupe" can't be satisfied by the
+        // "dedupe-all" literal, and no statement shape is pinned.
+        assert!(DEVICE_BUILDER_MAINT_PY.contains("\"detect\""));
+        assert!(DEVICE_BUILDER_MAINT_PY.contains("\"dedupe\""));
+        assert!(DEVICE_BUILDER_MAINT_PY.contains("\"dedupe-all\""));
         assert!(DEVICE_BUILDER_MAINT_PY.contains("esphome-device-builder-frontend"));
     }
 

--- a/src-tauri/src/platform/python_env.rs
+++ b/src-tauri/src/platform/python_env.rs
@@ -22,9 +22,10 @@ pub(super) const PYTHON_VERSION_MARKER: &str = ".esphome-desktop-version";
 /// Hard bound on one dist-info dedupe run. Local filesystem work only —
 /// enumerate site-packages, remove a few directories of metadata text — so a
 /// minute is generous even under a slow disk or an antivirus scan. Both
-/// callers get the bound; it is load-bearing for the lazy heal, which holds
-/// the `UpdateGuard` across this child, and merely tidy for the post-copy
-/// self-clean, which nothing waits behind.
+/// callers get the bound. It is load-bearing for the lazy heal, which holds
+/// the `UpdateGuard` across this child; for the post-copy self-clean it caps
+/// how long a wedged child can stall the launch and repair paths, which
+/// block on the refresh.
 const DIST_INFO_DEDUPE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
 
 /// Filename of the counter tracking consecutive launches that deferred the
@@ -252,9 +253,12 @@ pub(super) fn refresh_python_tree(
     // RECORD-less dir survived (the shape that aborts installs): the tree
     // still works for everything except that install, whose retry surfaces
     // pip's own report to the user, while failing the refresh here would
-    // trade a degraded tree for none. Runs before the marker write so a
-    // crash mid-prune leaves no marker and the next launch re-copies and
-    // re-prunes.
+    // trade a degraded tree for none. A graceful failure does reach the
+    // marker write below, so later launches will not re-prune on their own;
+    // the damage is still retried by the lazy heal (on a None version) and
+    // by the repair re-copy, which forces this whole path again. Runs before
+    // the marker write so a crash mid-prune leaves no marker and the next
+    // launch re-copies and re-prunes.
     if let Err(e) = dedupe_dist_info(&python_check, DistInfoDedupeScope::All) {
         warn!(
             "dist-info dedup after the bundle copy failed ({e:#}); continuing with the copied tree"

--- a/src-tauri/src/platform/python_env.rs
+++ b/src-tauri/src/platform/python_env.rs
@@ -424,10 +424,10 @@ pub(crate) enum DistInfoDedupeScope {
 /// pinned-version snapshot/restore around a tree refresh compares against a
 /// stale version (#389). The prune itself lives in
 /// [`DEVICE_BUILDER_MAINT_PY`], which never deletes an entry pip can still
-/// manage but cannot be ranked; a metadata-dead entry (no readable version
-/// and no RECORD) is removed, because pip aborts every upgrade with
-/// `uninstall-no-record-file` while one exists and the bundled tree itself
-/// can carry one (#389). See the pytest suite for the guard behavior.
+/// manage but cannot be ranked; a RECORD-less entry is removed, because pip
+/// aborts every upgrade with `uninstall-no-record-file` while one exists and
+/// the bundled tree itself can carry one (#389). See the pytest suite for the
+/// guard behavior.
 ///
 /// `Err` covers both a failed spawn and a non-zero exit; callers on paths that
 /// must not fail (the copy in [`refresh_python_tree`], the best-effort heal in
@@ -826,8 +826,7 @@ mod tests {
         // The bare `dedupe` mode is matched by its dispatch line because any
         // string containing "dedupe-all" trivially contains "dedupe".
         assert!(DEVICE_BUILDER_MAINT_PY.contains("detect"));
-        assert!(DEVICE_BUILDER_MAINT_PY.contains("if mode == \"dedupe\":"));
-        assert!(DEVICE_BUILDER_MAINT_PY.contains("dedupe-all"));
+        assert!(DEVICE_BUILDER_MAINT_PY.contains("if mode in (\"dedupe\", \"dedupe-all\"):"));
         assert!(DEVICE_BUILDER_MAINT_PY.contains("esphome-device-builder-frontend"));
     }
 

--- a/src-tauri/src/platform/python_env.rs
+++ b/src-tauri/src/platform/python_env.rs
@@ -423,8 +423,11 @@ pub(crate) enum DistInfoDedupeScope {
 /// device-builder update check loops on "version None" (#190), and the
 /// pinned-version snapshot/restore around a tree refresh compares against a
 /// stale version (#389). The prune itself lives in
-/// [`DEVICE_BUILDER_MAINT_PY`], which never deletes an entry it cannot rank —
-/// see its pytest suite for the guard behavior.
+/// [`DEVICE_BUILDER_MAINT_PY`], which never deletes an entry pip can still
+/// manage but cannot be ranked; a metadata-dead entry (no readable version
+/// and no RECORD) is removed, because pip aborts every upgrade with
+/// `uninstall-no-record-file` while one exists and the bundled tree itself
+/// can carry one (#389). See the pytest suite for the guard behavior.
 ///
 /// `Err` covers both a failed spawn and a non-zero exit; callers on paths that
 /// must not fail (the copy in [`refresh_python_tree`], the best-effort heal in

--- a/src-tauri/src/platform/python_env.rs
+++ b/src-tauri/src/platform/python_env.rs
@@ -19,6 +19,13 @@ use tracing::{debug, info, warn};
 /// user Python tree. Lives at `<user_python>/.esphome-desktop-version`.
 pub(super) const PYTHON_VERSION_MARKER: &str = ".esphome-desktop-version";
 
+/// Hard bound on one dist-info dedupe run. Local filesystem work only —
+/// enumerate site-packages, remove a few directories — so a minute is
+/// generous even under a slow disk or an antivirus scan; see the call site
+/// for why the bound is load-bearing (the lazy heal holds the `UpdateGuard`
+/// across this child).
+const DIST_INFO_DEDUPE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+
 /// Filename of the counter tracking consecutive launches that deferred the
 /// bundled-Python refresh because the version probe failed on a still-usable
 /// interpreter. Lives inside the user Python tree, so it is reset for free the
@@ -440,8 +447,18 @@ pub(crate) fn dedupe_dist_info(python_bin: &Path, scope: DistInfoDedupeScope) ->
     // `-I` (isolated) keeps user site-packages, PYTHONPATH and sitecustomize off
     // sys.path so this destructive prune can only ever touch the managed bundled
     // install, never a user-site or externally-injected tree.
-    let output = run_python_capture(python_bin, ["-I", "-c", DEVICE_BUILDER_MAINT_PY, mode])
-        .context("Failed to run dist-info dedup")?;
+    //
+    // Bounded: the lazy heal holds the UpdateGuard across this child, so a
+    // wedged prune (an rmtree stuck on a handle-held path) would otherwise pin
+    // `update_in_flight` for the session and silently no-op every later
+    // update/switch arm. The work is local filesystem only — enumerate
+    // site-packages, remove a few directories — so the bound is generous.
+    let output = run_python_capture_bounded(
+        python_bin,
+        ["-I", "-c", DEVICE_BUILDER_MAINT_PY, mode],
+        DIST_INFO_DEDUPE_TIMEOUT,
+    )
+    .context("Failed to run dist-info dedup")?;
     if !output.status.success() {
         anyhow::bail!(
             "dist-info dedup ({mode}) exited non-zero: {}",

--- a/src-tauri/src/platform/python_env.rs
+++ b/src-tauri/src/platform/python_env.rs
@@ -255,10 +255,12 @@ pub(super) fn refresh_python_tree(
     // pip's own report to the user, while failing the refresh here would
     // trade a degraded tree for none. A graceful failure does reach the
     // marker write below, so later launches will not re-prune on their own;
-    // the damage is still retried by the lazy heal (on a None version) and
-    // by the repair re-copy, which forces this whole path again. Runs before
-    // the marker write so a crash mid-prune leaves no marker and the next
-    // launch re-copies and re-prunes.
+    // the route out is the install that hits the surviving damage, whose
+    // missing-RECORD recovery forces this whole path again for any package
+    // (the builder-scoped lazy heal also retries its two). Skipping the
+    // marker instead would re-copy the full tree on every launch for as long
+    // as the prune kept failing. Runs before the marker write so a crash
+    // mid-prune leaves no marker and the next launch re-copies and re-prunes.
     if let Err(e) = dedupe_dist_info(&python_check, DistInfoDedupeScope::All) {
         warn!(
             "dist-info dedup after the bundle copy failed ({e:#}); continuing with the copied tree"

--- a/src-tauri/src/platform/python_env.rs
+++ b/src-tauri/src/platform/python_env.rs
@@ -454,9 +454,13 @@ pub(crate) fn dedupe_dist_info(python_bin: &Path, scope: DistInfoDedupeScope) ->
         DistInfoDedupeScope::DeviceBuilder => "dedupe",
         DistInfoDedupeScope::All => "dedupe-all",
     };
-    // `-I` (isolated) keeps user site-packages, PYTHONPATH and sitecustomize off
-    // sys.path so this destructive prune can only ever touch the managed bundled
-    // install, never a user-site or externally-injected tree.
+    // `-I` (isolated) keeps user site-packages, PYTHONPATH and sitecustomize
+    // off sys.path, so the prune sees only the interpreter's own
+    // site-packages. Which interpreter is the caller's choice: the post-copy
+    // self-clean passes the managed tree's own binary, while the lazy heal
+    // resolves through `get_python_path` — the managed tree in production,
+    // but the bare system fallback in a bundle-less dev build, where the
+    // TARGETS scope is what limits the prune's reach.
     //
     // Bounded: the lazy heal holds the UpdateGuard across this child, so a
     // wedged prune (an rmtree stuck on a handle-held path) would otherwise pin

--- a/src-tauri/src/tray/events.rs
+++ b/src-tauri/src/tray/events.rs
@@ -56,7 +56,9 @@ pub(super) fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<Ap
             let state = state.clone();
             let app = app_handle.clone();
             async_runtime::spawn(async move {
-                let _guard = guard_or_return!(state, "Check for Updates");
+                // Named (not `_guard`): passed down so the device-builder
+                // check can prove it holds the guard (`HealPolicy::GuardHeld`).
+                let guard = guard_or_return!(state, "Check for Updates");
                 // Always check the desktop app first. Installing a self-update
                 // replaces the bundled `python/` directory, which would wipe
                 // any pip bump we do here. If the user accepts the app update
@@ -164,7 +166,7 @@ pub(super) fn handle_menu_event(app_handle: &AppHandle, id: &str, state: &Arc<Ap
                 // ESPHome release channel.
                 let Some(builder_version) = state
                     .update_checker
-                    .check_device_builder_for_user(&app, backend)
+                    .check_device_builder_for_user(&app, backend, &guard)
                     .await
                 else {
                     return;

--- a/src-tauri/src/update/install.rs
+++ b/src-tauri/src/update/install.rs
@@ -110,38 +110,57 @@ fn acquire_heal_permit(
     }
 }
 
-/// Detect the installed device-builder version, healing a duplicate dist-info
-/// pileup once if the first lookup cannot determine a version.
+/// Orchestrate detect → permit → heal → re-detect.
 ///
-/// A `None` result is the exact symptom of the pileup (#190), so prune the
+/// A `None` detection is the exact symptom of the pileup (#190), so prune the
 /// duplicates and re-query before giving up. A genuinely-absent package stays
-/// `None` (dedup finds nothing to remove), at the cost of one extra Python spawn
-/// only on the already-unusual not-determinable path.
+/// `None` (dedup finds nothing to remove), at the cost of one extra Python
+/// spawn only on the already-unusual not-determinable path. A denied permit
+/// skips the heal: an undeterminable version then is far more likely a
+/// concurrent install's transient state than the #190 pileup, and a real
+/// pileup is still healed by the next check once the guard frees. A failed
+/// heal still re-queries — best-effort, but not invisible.
 ///
-/// Whether the heal may run is the caller's knowledge, not this function's:
-/// see [`HealPolicy`] and [`acquire_heal_permit`]. When it stands down, an
-/// undeterminable version is far more likely a concurrent install's transient
-/// state than the #190 pileup, and a real pileup is still healed by the next
-/// check once the guard frees.
-fn detect_device_builder_version_with_heal(
-    app_handle: &AppHandle,
-    caller_holds_guard: bool,
-) -> Result<Option<String>> {
-    let installed = get_installed_device_builder_version(app_handle)?;
+/// The steps are injected, exactly like [`install_with_record_recovery`]'s,
+/// so this policy stays testable without an `AppHandle` or a live
+/// interpreter.
+fn heal_and_redetect<D, H, P>(detect: D, heal: H, permit: P) -> Result<Option<String>>
+where
+    D: Fn() -> Result<Option<String>>,
+    H: FnOnce() -> Result<()>,
+    P: FnOnce() -> Option<Option<UpdateGuard>>,
+{
+    let installed = detect()?;
     if installed.is_some() {
         return Ok(installed);
     }
-    let Some(_permit) = acquire_heal_permit(caller_holds_guard, update_guard_flag(app_handle))
-    else {
+    let Some(_permit) = permit() else {
         info!("skipping the dist-info heal: another update sequence is in flight");
         return Ok(installed);
     };
-    if let Err(e) = dedupe_device_builder_dist_info(app_handle) {
+    if let Err(e) = heal() {
         // The heal is best-effort, but a failed attempt shouldn't be invisible:
         // the re-query below will just return the same undeterminable result.
         warn!("device-builder dist-info heal failed: {e}");
     }
-    get_installed_device_builder_version(app_handle)
+    detect()
+}
+
+/// Detect the installed device-builder version, healing a duplicate dist-info
+/// pileup once if the first lookup cannot determine a version.
+///
+/// The policy lives in [`heal_and_redetect`]; whether the heal may run is the
+/// caller's knowledge, not this function's (see [`HealPolicy`] and
+/// [`acquire_heal_permit`]).
+fn detect_device_builder_version_with_heal(
+    app_handle: &AppHandle,
+    caller_holds_guard: bool,
+) -> Result<Option<String>> {
+    heal_and_redetect(
+        || get_installed_device_builder_version(app_handle),
+        || dedupe_device_builder_dist_info(app_handle),
+        || acquire_heal_permit(caller_holds_guard, update_guard_flag(app_handle)),
+    )
 }
 
 /// Async wrapper around the blocking [`detect_device_builder_version_with_heal`].
@@ -569,6 +588,90 @@ mod tests {
 
         // No managed state (unit tests): no guard exists to take.
         assert!(matches!(acquire_heal_permit(false, None), Some(None)));
+    }
+
+    /// Drive [`heal_and_redetect`] against canned detections. `detections` is
+    /// what each successive detect returns; `permit` grants or denies the
+    /// heal. Returns the result plus (detects run, heals run).
+    fn drive_heal(
+        detections: Vec<Result<Option<String>>>,
+        permit_granted: bool,
+        heal: Result<()>,
+    ) -> (Result<Option<String>>, (usize, usize)) {
+        use std::cell::{Cell, RefCell};
+
+        let queue = RefCell::new(detections.into_iter());
+        let detects = Cell::new(0);
+        let heals = Cell::new(0);
+        let heal = RefCell::new(Some(heal));
+
+        let result = heal_and_redetect(
+            || {
+                detects.set(detects.get() + 1);
+                queue
+                    .borrow_mut()
+                    .next()
+                    .expect("detect ran more times than the test planned for")
+            },
+            || {
+                heals.set(heals.get() + 1);
+                heal.borrow_mut().take().expect("healed twice")
+            },
+            || permit_granted.then_some(None),
+        );
+        (result, (detects.get(), heals.get()))
+    }
+
+    #[test]
+    fn heal_and_redetect_returns_a_determinable_version_without_healing() {
+        // A version the first lookup resolves needs no heal: the destructive
+        // prune must not run on a healthy tree.
+        let (result, counts) = drive_heal(vec![Ok(Some("1.8.2".into()))], true, Ok(()));
+        assert_eq!(result.unwrap().as_deref(), Some("1.8.2"));
+        assert_eq!(counts, (1, 0));
+    }
+
+    #[test]
+    fn heal_and_redetect_heals_once_and_requeries() {
+        // The #190 shape: undeterminable, then the prune clears the pileup
+        // and the re-query resolves.
+        let (result, counts) = drive_heal(vec![Ok(None), Ok(Some("1.8.2".into()))], true, Ok(()));
+        assert_eq!(result.unwrap().as_deref(), Some("1.8.2"));
+        assert_eq!(counts, (2, 1));
+    }
+
+    #[test]
+    fn heal_and_redetect_stands_down_without_a_permit() {
+        // A denied permit means an update sequence is in flight, and an
+        // undeterminable version is then more likely pip mid-install than
+        // the pileup: no heal, no second spawn, the None is reported as is.
+        let (result, counts) = drive_heal(vec![Ok(None)], false, Ok(()));
+        assert_eq!(result.unwrap(), None);
+        assert_eq!(counts, (1, 0));
+    }
+
+    #[test]
+    fn heal_and_redetect_requeries_even_after_a_failed_heal() {
+        // Best-effort, but not silent, and never a reason to skip the
+        // re-query: the second lookup reports whatever is true afterwards.
+        let (result, counts) = drive_heal(
+            vec![Ok(None), Ok(None)],
+            true,
+            Err(anyhow::anyhow!("interpreter is broken")),
+        );
+        assert_eq!(result.unwrap(), None);
+        assert_eq!(counts, (2, 1));
+    }
+
+    #[test]
+    fn heal_and_redetect_propagates_a_failed_detection_unhealed() {
+        // Err means the check itself could not run (Python missing), which
+        // implicates nothing about the tree: pruning on it would be
+        // destructive action on zero evidence.
+        let (result, counts) =
+            drive_heal(vec![Err(anyhow::anyhow!("no interpreter"))], true, Ok(()));
+        assert!(result.is_err());
+        assert_eq!(counts, (1, 0));
     }
 
     #[test]

--- a/src-tauri/src/update/install.rs
+++ b/src-tauri/src/update/install.rs
@@ -39,6 +39,13 @@ pub fn get_installed_device_builder_version(app_handle: &AppHandle) -> Result<Op
 /// so this lazy device-builder-scoped heal mostly covers trees that predate
 /// that self-clean; duplicate metadata does not fail an install or the
 /// `esphome config` health probe, so nothing else would recover them.
+///
+/// The prune also removes metadata-dead dist-info dirs (no readable version,
+/// no RECORD). Those do fail an install — pip aborts with
+/// `uninstall-no-record-file` — and when the overlay plants one in the bundled
+/// tree, the repair re-copy restores it, so without this removal the
+/// [`install_with_record_recovery`] retry would hit the identical abort
+/// forever ("Cannot uninstall esphome-device-builder-frontend None").
 pub fn dedupe_device_builder_dist_info(app_handle: &AppHandle) -> Result<()> {
     let python_path = platform::get_python_path(app_handle)?;
     platform::dedupe_dist_info(&python_path, platform::DistInfoDedupeScope::DeviceBuilder)
@@ -276,6 +283,12 @@ fn is_missing_record_error(stderr: &str) -> bool {
 /// more against the clean tree. Any other failure bails immediately, reported
 /// through [`platform::pip_output_report`] so a resolution failure carries its
 /// cause from both of pip's streams.
+///
+/// The retry can only succeed if the repair actually clears the offending
+/// dist-info, and a re-copy alone does not when the bundled tree itself
+/// carries it (the installer overlay, #389): the post-copy dedupe's removal
+/// of metadata-dead dist-info dirs is what breaks that loop (see
+/// [`dedupe_device_builder_dist_info`]).
 ///
 /// The repair puts back the version the user had and `run` then installs the
 /// target over it, so this path can pip-install twice. That is deliberate, not

--- a/src-tauri/src/update/install.rs
+++ b/src-tauri/src/update/install.rs
@@ -406,8 +406,10 @@ pub(super) fn notify_repair_needed(app_handle: &AppHandle, body: String) {
 ///
 /// This is the signal that the tree is corrupt rather than the install being
 /// wrong, so it is what selects the repair path in
-/// [`install_with_record_recovery`].
-fn is_missing_record_error(stderr: &str) -> bool {
+/// [`install_with_record_recovery`]. `pub(crate)` so the repair e2e can
+/// assert the abort it plants is the one this predicate keys on, rather than
+/// re-hardcoding pip's wording and drifting from it.
+pub(crate) fn is_missing_record_error(stderr: &str) -> bool {
     stderr.contains("uninstall-no-record-file") || stderr.contains("no RECORD file was found")
 }
 

--- a/src-tauri/src/update/install.rs
+++ b/src-tauri/src/update/install.rs
@@ -4,10 +4,13 @@
 //! the user that a managed Python tree could not be repaired.
 
 use anyhow::{Context, Result};
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
 use tauri::AppHandle;
 use tauri_plugin_notification::NotificationExt;
 use tracing::{info, warn};
 
+use crate::control::ops::UpdateGuard;
 use crate::i18n::{t, t_with};
 use crate::platform;
 use crate::settings::Backend;
@@ -51,20 +54,13 @@ pub fn dedupe_device_builder_dist_info(app_handle: &AppHandle) -> Result<()> {
     platform::dedupe_dist_info(&python_path, platform::DistInfoDedupeScope::DeviceBuilder)
 }
 
-/// Whether an update/switch sequence currently holds the `UpdateGuard`.
-///
-/// Read-only observation of the flag, not an acquisition: the update checks
-/// must stay non-blocking. `false` when the state is not managed (unit
-/// tests), matching the pre-guard behavior there.
-fn update_sequence_in_flight(app_handle: &AppHandle) -> bool {
+/// The `UpdateGuard` flag, when the app state is managed (it is not in unit
+/// tests).
+fn update_guard_flag(app_handle: &AppHandle) -> Option<Arc<AtomicBool>> {
     use tauri::Manager;
     app_handle
-        .try_state::<std::sync::Arc<crate::AppState>>()
-        .is_some_and(|state| {
-            state
-                .update_in_flight
-                .load(std::sync::atomic::Ordering::Acquire)
-        })
+        .try_state::<Arc<crate::AppState>>()
+        .map(|state| state.update_in_flight.clone())
 }
 
 /// What the caller of [`detect_device_builder_version_with_heal_async`] knows
@@ -75,27 +71,42 @@ fn update_sequence_in_flight(app_handle: &AppHandle) -> bool {
 /// "someone else's sequence is running" from "my own caller holds the guard",
 /// and the two mean opposite things for the heal (a guard the caller holds is
 /// proof that no pip install can be racing).
-#[derive(Clone, Copy, Debug)]
-pub(super) enum HealPolicy {
+#[derive(Clone, Copy)]
+pub(super) enum HealPolicy<'g> {
     /// The caller holds the `UpdateGuard` (the tray's Check for Updates arm),
     /// so its sequence is the only one running and the steps are sequential:
     /// no pip install can be concurrently in flight when the heal runs. This
     /// is also the main user-facing recovery for the #190 pileup, so the heal
-    /// must not stand down here.
-    GuardHeld,
-    /// The caller runs without the guard (the daily background check). Heal
-    /// only while no update/switch sequence is in flight: pip writes `RECORD`
-    /// last, so a package mid-install passes through exactly the RECORD-less
-    /// shape the prune condemns.
+    /// must not stand down here. The reference is the proof: a guardless
+    /// caller cannot claim this variant without acquiring a guard first. It
+    /// is never read — possession at construction is its whole job.
+    GuardHeld(#[allow(dead_code)] &'g UpdateGuard),
+    /// The caller runs without the guard (the daily background check). The
+    /// heal takes the guard itself for its duration, or stands down if one is
+    /// in flight: pip writes `RECORD` last, so a package mid-install passes
+    /// through exactly the RECORD-less shape the prune condemns.
     WhenIdle,
 }
 
-/// Whether the heal may run under `policy`, given the observed guard flag.
-/// Split out so the policy is testable without an `AppHandle`.
-fn heal_allowed(policy: HealPolicy, sequence_in_flight: bool) -> bool {
-    match policy {
-        HealPolicy::GuardHeld => true,
-        HealPolicy::WhenIdle => !sequence_in_flight,
+/// Secure permission to run the destructive heal. `None` means denied.
+///
+/// On the guardless path this *takes* the `UpdateGuard` (returned inside the
+/// permit so it is held, RAII, for the heal's duration) rather than sampling
+/// the flag: a read alone is check-then-act, and a sequence acquiring between
+/// the read and the Python spawn would race the rmtree into a live pip
+/// install. `try_acquire` keeps it non-blocking. A caller that already holds
+/// the guard must not re-acquire (it would deny against itself), and with no
+/// managed state (unit tests) there is no guard to take.
+fn acquire_heal_permit(
+    caller_holds_guard: bool,
+    guard_flag: Option<Arc<AtomicBool>>,
+) -> Option<Option<UpdateGuard>> {
+    if caller_holds_guard {
+        return Some(None);
+    }
+    match guard_flag {
+        None => Some(None),
+        Some(flag) => UpdateGuard::try_acquire(flag).map(Some),
     }
 }
 
@@ -108,21 +119,23 @@ fn heal_allowed(policy: HealPolicy, sequence_in_flight: bool) -> bool {
 /// only on the already-unusual not-determinable path.
 ///
 /// Whether the heal may run is the caller's knowledge, not this function's:
-/// see [`HealPolicy`]. When it stands down, an undeterminable version is far
-/// more likely a concurrent install's transient state than the #190 pileup,
-/// and a real pileup is still healed by the next check once the guard frees.
+/// see [`HealPolicy`] and [`acquire_heal_permit`]. When it stands down, an
+/// undeterminable version is far more likely a concurrent install's transient
+/// state than the #190 pileup, and a real pileup is still healed by the next
+/// check once the guard frees.
 fn detect_device_builder_version_with_heal(
     app_handle: &AppHandle,
-    policy: HealPolicy,
+    caller_holds_guard: bool,
 ) -> Result<Option<String>> {
     let installed = get_installed_device_builder_version(app_handle)?;
     if installed.is_some() {
         return Ok(installed);
     }
-    if !heal_allowed(policy, update_sequence_in_flight(app_handle)) {
+    let Some(_permit) = acquire_heal_permit(caller_holds_guard, update_guard_flag(app_handle))
+    else {
         info!("skipping the dist-info heal: another update sequence is in flight");
         return Ok(installed);
-    }
+    };
     if let Err(e) = dedupe_device_builder_dist_info(app_handle) {
         // The heal is best-effort, but a failed attempt shouldn't be invisible:
         // the re-query below will just return the same undeterminable result.
@@ -139,12 +152,18 @@ fn detect_device_builder_version_with_heal(
 /// `spawn_blocking` instead.
 pub(super) async fn detect_device_builder_version_with_heal_async(
     app_handle: &AppHandle,
-    policy: HealPolicy,
+    policy: HealPolicy<'_>,
 ) -> Result<Option<String>> {
+    // The guard reference proves possession at the call site but cannot cross
+    // spawn_blocking's 'static boundary; reduce it to the fact the blocking
+    // side acts on.
+    let caller_holds_guard = matches!(policy, HealPolicy::GuardHeld(_));
     let app = app_handle.clone();
-    tokio::task::spawn_blocking(move || detect_device_builder_version_with_heal(&app, policy))
-        .await
-        .context("device-builder version detection task panicked or was cancelled")?
+    tokio::task::spawn_blocking(move || {
+        detect_device_builder_version_with_heal(&app, caller_holds_guard)
+    })
+    .await
+    .context("device-builder version detection task panicked or was cancelled")?
 }
 
 /// Build the `pip install` argument list (appended after the `-m pip install`
@@ -513,18 +532,43 @@ mod tests {
     }
 
     #[test]
-    fn the_heal_yields_only_to_sequences_the_caller_does_not_own() {
+    fn the_heal_permit_takes_the_guard_rather_than_sampling_it() {
+        use std::sync::atomic::Ordering;
+
         // A caller holding the UpdateGuard is proof no pip install can be
-        // racing, and the tray's Check for Updates arm is the main
-        // user-facing recovery for the #190 pileup: the global flag it set
-        // itself must not stand its own heal down. The guardless background
-        // check is the opposite: while any sequence is in flight, pip may be
-        // mid-install and RECORD is written last, so the destructive prune
-        // must wait.
-        assert!(heal_allowed(HealPolicy::GuardHeld, true));
-        assert!(heal_allowed(HealPolicy::GuardHeld, false));
-        assert!(!heal_allowed(HealPolicy::WhenIdle, true));
-        assert!(heal_allowed(HealPolicy::WhenIdle, false));
+        // racing, and re-acquiring would deny against itself: permitted
+        // without touching the flag.
+        let flag = Arc::new(AtomicBool::new(false));
+        assert!(matches!(acquire_heal_permit(true, None), Some(None)));
+        assert!(matches!(
+            acquire_heal_permit(true, Some(flag.clone())),
+            Some(None)
+        ));
+        assert!(
+            !flag.load(Ordering::Acquire),
+            "GuardHeld must not acquire: its caller owns the flag"
+        );
+
+        // The guardless path with the flag free: the permit HOLDS the guard
+        // for the heal's duration — sampling alone would be check-then-act,
+        // letting a sequence start between the read and the rmtree — and
+        // releases it on drop.
+        let permit =
+            acquire_heal_permit(false, Some(flag.clone())).expect("a free flag permits the heal");
+        assert!(
+            flag.load(Ordering::Acquire),
+            "the permit must hold the flag, not sample it"
+        );
+        drop(permit);
+        assert!(!flag.load(Ordering::Acquire), "released on drop");
+
+        // The guardless path while a sequence is in flight: denied.
+        let held = UpdateGuard::try_acquire(flag.clone()).expect("flag is free");
+        assert!(acquire_heal_permit(false, Some(flag.clone())).is_none());
+        drop(held);
+
+        // No managed state (unit tests): no guard exists to take.
+        assert!(matches!(acquire_heal_permit(false, None), Some(None)));
     }
 
     #[test]

--- a/src-tauri/src/update/install.rs
+++ b/src-tauri/src/update/install.rs
@@ -88,6 +88,16 @@ pub(super) enum HealPolicy<'g> {
     WhenIdle,
 }
 
+/// Permission to run the destructive heal, alive for the heal's duration.
+enum HealPermit {
+    /// Allowed without holding anything: the caller already holds the
+    /// `UpdateGuard`, or no state is managed (unit tests).
+    Unguarded,
+    /// Allowed, holding the guard until dropped. Never read — the RAII
+    /// release on drop is its whole job.
+    Held(#[allow(dead_code)] UpdateGuard),
+}
+
 /// Secure permission to run the destructive heal. `None` means denied.
 ///
 /// On the guardless path this *takes* the `UpdateGuard` (returned inside the
@@ -95,18 +105,24 @@ pub(super) enum HealPolicy<'g> {
 /// the flag: a read alone is check-then-act, and a sequence acquiring between
 /// the read and the Python spawn would race the rmtree into a live pip
 /// install. `try_acquire` keeps it non-blocking. A caller that already holds
-/// the guard must not re-acquire (it would deny against itself), and with no
-/// managed state (unit tests) there is no guard to take.
+/// the guard must not re-acquire (it would deny against itself).
 fn acquire_heal_permit(
     caller_holds_guard: bool,
     guard_flag: Option<Arc<AtomicBool>>,
-) -> Option<Option<UpdateGuard>> {
+) -> Option<HealPermit> {
     if caller_holds_guard {
-        return Some(None);
+        return Some(HealPermit::Unguarded);
     }
     match guard_flag {
-        None => Some(None),
-        Some(flag) => UpdateGuard::try_acquire(flag).map(Some),
+        None => {
+            // Only unit tests run unmanaged; in production the state is
+            // managed before any check can reach here, so a miss would be a
+            // bug — say so rather than silently waiving the serialization
+            // guarantee.
+            warn!("update guard state not managed; running the dist-info heal unguarded");
+            Some(HealPermit::Unguarded)
+        }
+        Some(flag) => UpdateGuard::try_acquire(flag).map(HealPermit::Held),
     }
 }
 
@@ -144,7 +160,7 @@ fn heal_and_redetect<D, H, P>(detect: D, heal: H, permit: P) -> Result<HealOutco
 where
     D: Fn() -> Result<Option<String>>,
     H: FnOnce() -> Result<()>,
-    P: FnOnce() -> Option<Option<UpdateGuard>>,
+    P: FnOnce() -> Option<HealPermit>,
 {
     let installed = detect()?;
     if installed.is_some() {
@@ -577,10 +593,13 @@ mod tests {
         // racing, and re-acquiring would deny against itself: permitted
         // without touching the flag.
         let flag = Arc::new(AtomicBool::new(false));
-        assert!(matches!(acquire_heal_permit(true, None), Some(None)));
+        assert!(matches!(
+            acquire_heal_permit(true, None),
+            Some(HealPermit::Unguarded)
+        ));
         assert!(matches!(
             acquire_heal_permit(true, Some(flag.clone())),
-            Some(None)
+            Some(HealPermit::Unguarded)
         ));
         assert!(
             !flag.load(Ordering::Acquire),
@@ -593,6 +612,7 @@ mod tests {
         // releases it on drop.
         let permit =
             acquire_heal_permit(false, Some(flag.clone())).expect("a free flag permits the heal");
+        assert!(matches!(permit, HealPermit::Held(_)));
         assert!(
             flag.load(Ordering::Acquire),
             "the permit must hold the flag, not sample it"
@@ -606,7 +626,10 @@ mod tests {
         drop(held);
 
         // No managed state (unit tests): no guard exists to take.
-        assert!(matches!(acquire_heal_permit(false, None), Some(None)));
+        assert!(matches!(
+            acquire_heal_permit(false, None),
+            Some(HealPermit::Unguarded)
+        ));
     }
 
     /// Drive [`heal_and_redetect`] against canned detections. `detections` is
@@ -636,7 +659,7 @@ mod tests {
                 heals.set(heals.get() + 1);
                 heal.borrow_mut().take().expect("healed twice")
             },
-            || permit_granted.then_some(None),
+            || permit_granted.then_some(HealPermit::Unguarded),
         );
         (result, (detects.get(), heals.get()))
     }

--- a/src-tauri/src/update/install.rs
+++ b/src-tauri/src/update/install.rs
@@ -110,21 +110,37 @@ fn acquire_heal_permit(
     }
 }
 
+/// What a healed detection concluded — kept three-armed so a deferred heal
+/// never masquerades as "not installed".
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum HealOutcome {
+    /// The detection ran to completion: `Some(version)` when installed,
+    /// `None` when genuinely absent or still undeterminable after the heal.
+    Determined(Option<String>),
+    /// The pre-heal lookup was undeterminable and the heal stood down
+    /// (another sequence holds the guard). Says nothing about the package;
+    /// only the `WhenIdle` policy can produce it.
+    Deferred,
+}
+
 /// Orchestrate detect → permit → heal → re-detect.
 ///
 /// A `None` detection is the exact symptom of the pileup (#190), so prune the
 /// duplicates and re-query before giving up. A genuinely-absent package stays
 /// `None` (dedup finds nothing to remove), at the cost of one extra Python
 /// spawn only on the already-unusual not-determinable path. A denied permit
-/// skips the heal: an undeterminable version then is far more likely a
+/// defers the heal: an undeterminable version then is far more likely a
 /// concurrent install's transient state than the #190 pileup, and a real
 /// pileup is still healed by the next check once the guard frees. A failed
 /// heal still re-queries — best-effort, but not invisible.
 ///
+/// The permit is scoped to the heal alone: the re-detect is read-only, so
+/// there is no reason to keep the guard across a second Python spawn.
+///
 /// The steps are injected, exactly like [`install_with_record_recovery`]'s,
 /// so this policy stays testable without an `AppHandle` or a live
 /// interpreter.
-fn heal_and_redetect<D, H, P>(detect: D, heal: H, permit: P) -> Result<Option<String>>
+fn heal_and_redetect<D, H, P>(detect: D, heal: H, permit: P) -> Result<HealOutcome>
 where
     D: Fn() -> Result<Option<String>>,
     H: FnOnce() -> Result<()>,
@@ -132,18 +148,21 @@ where
 {
     let installed = detect()?;
     if installed.is_some() {
-        return Ok(installed);
+        return Ok(HealOutcome::Determined(installed));
     }
-    let Some(_permit) = permit() else {
-        info!("skipping the dist-info heal: another update sequence is in flight");
-        return Ok(installed);
-    };
-    if let Err(e) = heal() {
-        // The heal is best-effort, but a failed attempt shouldn't be invisible:
-        // the re-query below will just return the same undeterminable result.
-        warn!("device-builder dist-info heal failed: {e}");
+    {
+        let Some(_permit) = permit() else {
+            info!("deferring the dist-info heal: another update sequence is in flight");
+            return Ok(HealOutcome::Deferred);
+        };
+        if let Err(e) = heal() {
+            // The heal is best-effort, but a failed attempt shouldn't be
+            // invisible: the re-query below will just return the same
+            // undeterminable result.
+            warn!("device-builder dist-info heal failed: {e}");
+        }
     }
-    detect()
+    detect().map(HealOutcome::Determined)
 }
 
 /// Detect the installed device-builder version, healing a duplicate dist-info
@@ -155,7 +174,7 @@ where
 fn detect_device_builder_version_with_heal(
     app_handle: &AppHandle,
     caller_holds_guard: bool,
-) -> Result<Option<String>> {
+) -> Result<HealOutcome> {
     heal_and_redetect(
         || get_installed_device_builder_version(app_handle),
         || dedupe_device_builder_dist_info(app_handle),
@@ -172,7 +191,7 @@ fn detect_device_builder_version_with_heal(
 pub(super) async fn detect_device_builder_version_with_heal_async(
     app_handle: &AppHandle,
     policy: HealPolicy<'_>,
-) -> Result<Option<String>> {
+) -> Result<HealOutcome> {
     // The guard reference proves possession at the call site but cannot cross
     // spawn_blocking's 'static boundary; reduce it to the fact the blocking
     // side acts on.
@@ -597,7 +616,7 @@ mod tests {
         detections: Vec<Result<Option<String>>>,
         permit_granted: bool,
         heal: Result<()>,
-    ) -> (Result<Option<String>>, (usize, usize)) {
+    ) -> (Result<HealOutcome>, (usize, usize)) {
         use std::cell::{Cell, RefCell};
 
         let queue = RefCell::new(detections.into_iter());
@@ -627,7 +646,10 @@ mod tests {
         // A version the first lookup resolves needs no heal: the destructive
         // prune must not run on a healthy tree.
         let (result, counts) = drive_heal(vec![Ok(Some("1.8.2".into()))], true, Ok(()));
-        assert_eq!(result.unwrap().as_deref(), Some("1.8.2"));
+        assert_eq!(
+            result.unwrap(),
+            HealOutcome::Determined(Some("1.8.2".into()))
+        );
         assert_eq!(counts, (1, 0));
     }
 
@@ -636,17 +658,21 @@ mod tests {
         // The #190 shape: undeterminable, then the prune clears the pileup
         // and the re-query resolves.
         let (result, counts) = drive_heal(vec![Ok(None), Ok(Some("1.8.2".into()))], true, Ok(()));
-        assert_eq!(result.unwrap().as_deref(), Some("1.8.2"));
+        assert_eq!(
+            result.unwrap(),
+            HealOutcome::Determined(Some("1.8.2".into()))
+        );
         assert_eq!(counts, (2, 1));
     }
 
     #[test]
-    fn heal_and_redetect_stands_down_without_a_permit() {
+    fn heal_and_redetect_defers_without_a_permit() {
         // A denied permit means an update sequence is in flight, and an
         // undeterminable version is then more likely pip mid-install than
-        // the pileup: no heal, no second spawn, the None is reported as is.
+        // the pileup: no heal, no second spawn, and the outcome says
+        // "deferred" rather than masquerading as "not installed".
         let (result, counts) = drive_heal(vec![Ok(None)], false, Ok(()));
-        assert_eq!(result.unwrap(), None);
+        assert_eq!(result.unwrap(), HealOutcome::Deferred);
         assert_eq!(counts, (1, 0));
     }
 
@@ -659,7 +685,7 @@ mod tests {
             true,
             Err(anyhow::anyhow!("interpreter is broken")),
         );
-        assert_eq!(result.unwrap(), None);
+        assert_eq!(result.unwrap(), HealOutcome::Determined(None));
         assert_eq!(counts, (2, 1));
     }
 

--- a/src-tauri/src/update/install.rs
+++ b/src-tauri/src/update/install.rs
@@ -40,12 +40,12 @@ pub fn get_installed_device_builder_version(app_handle: &AppHandle) -> Result<Op
 /// that self-clean; duplicate metadata does not fail an install or the
 /// `esphome config` health probe, so nothing else would recover them.
 ///
-/// The prune also removes metadata-dead dist-info dirs (no readable version,
-/// no RECORD). Those do fail an install — pip aborts with
-/// `uninstall-no-record-file` — and when the overlay plants one in the bundled
-/// tree, the repair re-copy restores it, so without this removal the
-/// [`install_with_record_recovery`] retry would hit the identical abort
-/// forever ("Cannot uninstall esphome-device-builder-frontend None").
+/// The prune also removes RECORD-less dist-info dirs. Those do fail an
+/// install — pip aborts with `uninstall-no-record-file` — and when the
+/// overlay plants one in the bundled tree, the repair re-copy restores it, so
+/// without this removal the [`install_with_record_recovery`] retry would hit
+/// the identical abort forever ("Cannot uninstall
+/// esphome-device-builder-frontend None").
 pub fn dedupe_device_builder_dist_info(app_handle: &AppHandle) -> Result<()> {
     let python_path = platform::get_python_path(app_handle)?;
     platform::dedupe_dist_info(&python_path, platform::DistInfoDedupeScope::DeviceBuilder)
@@ -287,7 +287,7 @@ fn is_missing_record_error(stderr: &str) -> bool {
 /// The retry can only succeed if the repair actually clears the offending
 /// dist-info, and a re-copy alone does not when the bundled tree itself
 /// carries it (the installer overlay, #389): the post-copy dedupe's removal
-/// of metadata-dead dist-info dirs is what breaks that loop (see
+/// of RECORD-less dist-info dirs is what breaks that loop (see
 /// [`dedupe_device_builder_dist_info`]).
 ///
 /// The repair puts back the version the user had and `run` then installs the

--- a/src-tauri/src/update/install.rs
+++ b/src-tauri/src/update/install.rs
@@ -84,7 +84,10 @@ pub(super) enum HealPolicy<'g> {
     /// The caller runs without the guard (the daily background check). The
     /// heal takes the guard itself for its duration, or stands down if one is
     /// in flight: pip writes `RECORD` last, so a package mid-install passes
-    /// through exactly the RECORD-less shape the prune condemns.
+    /// through exactly the RECORD-less shape the prune condemns. While held,
+    /// a coincident click on any guard-taking tray arm (update, switch,
+    /// Quit) is refused with a log line; the prune's 60s bound is what caps
+    /// that window.
     WhenIdle,
 }
 

--- a/src-tauri/src/update/install.rs
+++ b/src-tauri/src/update/install.rs
@@ -51,6 +51,22 @@ pub fn dedupe_device_builder_dist_info(app_handle: &AppHandle) -> Result<()> {
     platform::dedupe_dist_info(&python_path, platform::DistInfoDedupeScope::DeviceBuilder)
 }
 
+/// Whether an update/switch sequence currently holds the `UpdateGuard`.
+///
+/// Read-only observation of the flag, not an acquisition: the update checks
+/// must stay non-blocking. `false` when the state is not managed (unit
+/// tests), matching the pre-guard behavior there.
+fn update_sequence_in_flight(app_handle: &AppHandle) -> bool {
+    use tauri::Manager;
+    app_handle
+        .try_state::<std::sync::Arc<crate::AppState>>()
+        .is_some_and(|state| {
+            state
+                .update_in_flight
+                .load(std::sync::atomic::Ordering::Acquire)
+        })
+}
+
 /// Detect the installed device-builder version, healing a duplicate dist-info
 /// pileup once if the first lookup cannot determine a version.
 ///
@@ -58,9 +74,22 @@ pub fn dedupe_device_builder_dist_info(app_handle: &AppHandle) -> Result<()> {
 /// duplicates and re-query before giving up. A genuinely-absent package stays
 /// `None` (dedup finds nothing to remove), at the cost of one extra Python spawn
 /// only on the already-unusual not-determinable path.
+///
+/// The heal stands down while an update/switch sequence is in flight. The
+/// prune deletes dist-info dirs, and pip writes `RECORD` last, so a package
+/// mid-install passes through exactly the RECORD-less shape the prune
+/// condemns; the update checks run without the `UpdateGuard` (they are
+/// otherwise read-only), so this is the one destructive step they could race
+/// into a live install. An undeterminable version during a sequence is far
+/// more likely that transient state than the #190 pileup, and a real pileup
+/// is still healed by the next check once the guard is free.
 fn detect_device_builder_version_with_heal(app_handle: &AppHandle) -> Result<Option<String>> {
     let installed = get_installed_device_builder_version(app_handle)?;
     if installed.is_some() {
+        return Ok(installed);
+    }
+    if update_sequence_in_flight(app_handle) {
+        info!("skipping the dist-info heal: an update sequence is in flight");
         return Ok(installed);
     }
     if let Err(e) = dedupe_device_builder_dist_info(app_handle) {

--- a/src-tauri/src/update/install.rs
+++ b/src-tauri/src/update/install.rs
@@ -67,6 +67,38 @@ fn update_sequence_in_flight(app_handle: &AppHandle) -> bool {
         })
 }
 
+/// What the caller of [`detect_device_builder_version_with_heal_async`] knows
+/// about the `UpdateGuard`, which decides whether the destructive dist-info
+/// heal may run.
+///
+/// A global flag read alone cannot make this decision: it cannot tell
+/// "someone else's sequence is running" from "my own caller holds the guard",
+/// and the two mean opposite things for the heal (a guard the caller holds is
+/// proof that no pip install can be racing).
+#[derive(Clone, Copy, Debug)]
+pub(super) enum HealPolicy {
+    /// The caller holds the `UpdateGuard` (the tray's Check for Updates arm),
+    /// so its sequence is the only one running and the steps are sequential:
+    /// no pip install can be concurrently in flight when the heal runs. This
+    /// is also the main user-facing recovery for the #190 pileup, so the heal
+    /// must not stand down here.
+    GuardHeld,
+    /// The caller runs without the guard (the daily background check). Heal
+    /// only while no update/switch sequence is in flight: pip writes `RECORD`
+    /// last, so a package mid-install passes through exactly the RECORD-less
+    /// shape the prune condemns.
+    WhenIdle,
+}
+
+/// Whether the heal may run under `policy`, given the observed guard flag.
+/// Split out so the policy is testable without an `AppHandle`.
+fn heal_allowed(policy: HealPolicy, sequence_in_flight: bool) -> bool {
+    match policy {
+        HealPolicy::GuardHeld => true,
+        HealPolicy::WhenIdle => !sequence_in_flight,
+    }
+}
+
 /// Detect the installed device-builder version, healing a duplicate dist-info
 /// pileup once if the first lookup cannot determine a version.
 ///
@@ -75,21 +107,20 @@ fn update_sequence_in_flight(app_handle: &AppHandle) -> bool {
 /// `None` (dedup finds nothing to remove), at the cost of one extra Python spawn
 /// only on the already-unusual not-determinable path.
 ///
-/// The heal stands down while an update/switch sequence is in flight. The
-/// prune deletes dist-info dirs, and pip writes `RECORD` last, so a package
-/// mid-install passes through exactly the RECORD-less shape the prune
-/// condemns; the update checks run without the `UpdateGuard` (they are
-/// otherwise read-only), so this is the one destructive step they could race
-/// into a live install. An undeterminable version during a sequence is far
-/// more likely that transient state than the #190 pileup, and a real pileup
-/// is still healed by the next check once the guard is free.
-fn detect_device_builder_version_with_heal(app_handle: &AppHandle) -> Result<Option<String>> {
+/// Whether the heal may run is the caller's knowledge, not this function's:
+/// see [`HealPolicy`]. When it stands down, an undeterminable version is far
+/// more likely a concurrent install's transient state than the #190 pileup,
+/// and a real pileup is still healed by the next check once the guard frees.
+fn detect_device_builder_version_with_heal(
+    app_handle: &AppHandle,
+    policy: HealPolicy,
+) -> Result<Option<String>> {
     let installed = get_installed_device_builder_version(app_handle)?;
     if installed.is_some() {
         return Ok(installed);
     }
-    if update_sequence_in_flight(app_handle) {
-        info!("skipping the dist-info heal: an update sequence is in flight");
+    if !heal_allowed(policy, update_sequence_in_flight(app_handle)) {
+        info!("skipping the dist-info heal: another update sequence is in flight");
         return Ok(installed);
     }
     if let Err(e) = dedupe_device_builder_dist_info(app_handle) {
@@ -108,9 +139,10 @@ fn detect_device_builder_version_with_heal(app_handle: &AppHandle) -> Result<Opt
 /// `spawn_blocking` instead.
 pub(super) async fn detect_device_builder_version_with_heal_async(
     app_handle: &AppHandle,
+    policy: HealPolicy,
 ) -> Result<Option<String>> {
     let app = app_handle.clone();
-    tokio::task::spawn_blocking(move || detect_device_builder_version_with_heal(&app))
+    tokio::task::spawn_blocking(move || detect_device_builder_version_with_heal(&app, policy))
         .await
         .context("device-builder version detection task panicked or was cancelled")?
 }
@@ -478,6 +510,21 @@ mod tests {
             args.last().map(String::as_str),
             Some("esphome-device-builder==1.2.3")
         );
+    }
+
+    #[test]
+    fn the_heal_yields_only_to_sequences_the_caller_does_not_own() {
+        // A caller holding the UpdateGuard is proof no pip install can be
+        // racing, and the tray's Check for Updates arm is the main
+        // user-facing recovery for the #190 pileup: the global flag it set
+        // itself must not stand its own heal down. The guardless background
+        // check is the opposite: while any sequence is in flight, pip may be
+        // mid-install and RECORD is written last, so the destructive prune
+        // must wait.
+        assert!(heal_allowed(HealPolicy::GuardHeld, true));
+        assert!(heal_allowed(HealPolicy::GuardHeld, false));
+        assert!(!heal_allowed(HealPolicy::WhenIdle, true));
+        assert!(heal_allowed(HealPolicy::WhenIdle, false));
     }
 
     #[test]

--- a/src-tauri/src/update/mod.rs
+++ b/src-tauri/src/update/mod.rs
@@ -27,7 +27,7 @@ use install::{
     detect_device_builder_version_with_heal_async, install_with_record_recovery,
     installed_esphome_version_async, interpreter_usable, notify_repair_incomplete,
     notify_repair_needed, probe_esphome, repair_hint, run_dev_install, run_device_builder_install,
-    run_esphome_install, HealPolicy,
+    run_esphome_install, HealOutcome, HealPolicy,
 };
 use notify::{notify_if_newer, prompt_if_newer};
 use version::{find_latest_any, select_beta_target};
@@ -597,15 +597,26 @@ impl UpdateChecker {
         tray_available: bool,
     ) {
         // The daily background check runs without the UpdateGuard; the heal
-        // takes the guard itself for its duration, or stands down if a
-        // sequence is in flight (see HealPolicy).
+        // takes the guard itself for its duration, or defers if a sequence
+        // is in flight (see HealPolicy).
         let installed =
             match detect_device_builder_version_with_heal_async(app_handle, HealPolicy::WhenIdle)
                 .await
             {
-                Ok(Some(v)) => v,
-                Ok(None) => {
+                Ok(HealOutcome::Determined(Some(v))) => v,
+                Ok(HealOutcome::Determined(None)) => {
                     debug!("esphome-device-builder is not installed; skipping update check");
+                    return;
+                }
+                Ok(HealOutcome::Deferred) => {
+                    // Says nothing about the package — the version was
+                    // undeterminable while a sequence held the guard, which
+                    // is most likely pip mid-install. The next daily check
+                    // heals a real pileup.
+                    debug!(
+                        "device-builder version undeterminable while an update sequence \
+                         is in flight; skipping update check"
+                    );
                     return;
                 }
                 Err(e) => {
@@ -652,9 +663,15 @@ impl UpdateChecker {
         )
         .await
         {
-            Ok(Some(v)) => v,
-            Ok(None) => {
+            Ok(HealOutcome::Determined(Some(v))) => v,
+            Ok(HealOutcome::Determined(None)) => {
                 warn!("esphome-device-builder is not installed");
+                return None;
+            }
+            Ok(HealOutcome::Deferred) => {
+                // Unreachable under GuardHeld — a held guard is never denied
+                // a permit — but if it ever fires, silence is the safe UX.
+                warn!("device-builder heal deferred under a held guard; treating as undetermined");
                 return None;
             }
             Err(e) => {

--- a/src-tauri/src/update/mod.rs
+++ b/src-tauri/src/update/mod.rs
@@ -596,8 +596,9 @@ impl UpdateChecker {
         backend: Backend,
         tray_available: bool,
     ) {
-        // The daily background check runs without the UpdateGuard, so the
-        // heal must yield to any sequence that holds it (see HealPolicy).
+        // The daily background check runs without the UpdateGuard; the heal
+        // takes the guard itself for its duration, or stands down if a
+        // sequence is in flight (see HealPolicy).
         let installed =
             match detect_device_builder_version_with_heal_async(app_handle, HealPolicy::WhenIdle)
                 .await
@@ -634,32 +635,36 @@ impl UpdateChecker {
     /// `Some(version)` if the user wants to update, `None` otherwise.
     /// Stays silent when there is no update — the caller is responsible
     /// for the "everything is up to date" UX.
-    pub async fn check_device_builder_for_user(
+    ///
+    /// `guard` is the caller's held `UpdateGuard`: proof that its sequence is
+    /// the only one running, which is what lets the dist-info heal run here
+    /// (see `HealPolicy`). This path is the main user-facing recovery for the
+    /// #190 pileup, so the heal must not stand down on it.
+    pub(crate) async fn check_device_builder_for_user(
         &self,
         app_handle: &AppHandle,
         backend: Backend,
+        guard: &crate::control::ops::UpdateGuard,
     ) -> Option<String> {
-        // The tray's Check for Updates arm holds the UpdateGuard for its
-        // whole sequence, which is proof no pip install can be racing; this
-        // is also the main user-facing recovery for the #190 pileup, so the
-        // heal must run here (see HealPolicy).
-        let installed =
-            match detect_device_builder_version_with_heal_async(app_handle, HealPolicy::GuardHeld)
-                .await
-            {
-                Ok(Some(v)) => v,
-                Ok(None) => {
-                    warn!("esphome-device-builder is not installed");
-                    return None;
-                }
-                Err(e) => {
-                    warn!(
-                        "Could not detect installed esphome-device-builder version: {}",
-                        e
-                    );
-                    return None;
-                }
-            };
+        let installed = match detect_device_builder_version_with_heal_async(
+            app_handle,
+            HealPolicy::GuardHeld(guard),
+        )
+        .await
+        {
+            Ok(Some(v)) => v,
+            Ok(None) => {
+                warn!("esphome-device-builder is not installed");
+                return None;
+            }
+            Err(e) => {
+                warn!(
+                    "Could not detect installed esphome-device-builder version: {}",
+                    e
+                );
+                return None;
+            }
+        };
 
         let latest = match self.check_device_builder(backend).await {
             Ok(v) => v,

--- a/src-tauri/src/update/mod.rs
+++ b/src-tauri/src/update/mod.rs
@@ -27,7 +27,7 @@ use install::{
     detect_device_builder_version_with_heal_async, install_with_record_recovery,
     installed_esphome_version_async, interpreter_usable, notify_repair_incomplete,
     notify_repair_needed, probe_esphome, repair_hint, run_dev_install, run_device_builder_install,
-    run_esphome_install,
+    run_esphome_install, HealPolicy,
 };
 use notify::{notify_if_newer, prompt_if_newer};
 use version::{find_latest_any, select_beta_target};
@@ -596,17 +596,22 @@ impl UpdateChecker {
         backend: Backend,
         tray_available: bool,
     ) {
-        let installed = match detect_device_builder_version_with_heal_async(app_handle).await {
-            Ok(Some(v)) => v,
-            Ok(None) => {
-                debug!("esphome-device-builder is not installed; skipping update check");
-                return;
-            }
-            Err(e) => {
-                warn!("esphome-device-builder version detection failed: {}", e);
-                return;
-            }
-        };
+        // The daily background check runs without the UpdateGuard, so the
+        // heal must yield to any sequence that holds it (see HealPolicy).
+        let installed =
+            match detect_device_builder_version_with_heal_async(app_handle, HealPolicy::WhenIdle)
+                .await
+            {
+                Ok(Some(v)) => v,
+                Ok(None) => {
+                    debug!("esphome-device-builder is not installed; skipping update check");
+                    return;
+                }
+                Err(e) => {
+                    warn!("esphome-device-builder version detection failed: {}", e);
+                    return;
+                }
+            };
 
         let latest = match self.check_device_builder(backend).await {
             Ok(v) => v,
@@ -634,20 +639,27 @@ impl UpdateChecker {
         app_handle: &AppHandle,
         backend: Backend,
     ) -> Option<String> {
-        let installed = match detect_device_builder_version_with_heal_async(app_handle).await {
-            Ok(Some(v)) => v,
-            Ok(None) => {
-                warn!("esphome-device-builder is not installed");
-                return None;
-            }
-            Err(e) => {
-                warn!(
-                    "Could not detect installed esphome-device-builder version: {}",
-                    e
-                );
-                return None;
-            }
-        };
+        // The tray's Check for Updates arm holds the UpdateGuard for its
+        // whole sequence, which is proof no pip install can be racing; this
+        // is also the main user-facing recovery for the #190 pileup, so the
+        // heal must run here (see HealPolicy).
+        let installed =
+            match detect_device_builder_version_with_heal_async(app_handle, HealPolicy::GuardHeld)
+                .await
+            {
+                Ok(Some(v)) => v,
+                Ok(None) => {
+                    warn!("esphome-device-builder is not installed");
+                    return None;
+                }
+                Err(e) => {
+                    warn!(
+                        "Could not detect installed esphome-device-builder version: {}",
+                        e
+                    );
+                    return None;
+                }
+            };
 
         let latest = match self.check_device_builder(backend).await {
             Ok(v) => v,

--- a/src-tauri/src/update/mod.rs
+++ b/src-tauri/src/update/mod.rs
@@ -19,6 +19,10 @@ mod install;
 mod notify;
 mod version;
 
+// Test-only: the repair e2e asserts the abort it plants is the one this
+// predicate keys the recovery on, rather than re-hardcoding pip's wording.
+#[cfg(test)]
+pub(crate) use install::is_missing_record_error;
 pub use install::{get_installed_device_builder_version, installed_esphome_version};
 pub(crate) use notify::notify_update_available;
 pub(crate) use version::is_newer_version;

--- a/tests/test_device_builder_maintenance.py
+++ b/tests/test_device_builder_maintenance.py
@@ -393,6 +393,17 @@ def test_dedupe_skips_unlistable_dist_info(
     assert dead.is_dir()
 
 
+def test_dedupe_infers_name_from_a_version_less_directory(tmp_path: Path) -> None:
+    # A hand-damaged dir name with dashes and no version tail: the segment
+    # after the last dash is not a version, so the whole stem is the name and
+    # the scoped heal still condemns the RECORD-less entry instead of
+    # mis-attributing it to "esphome-device" and skipping it.
+    dead = tmp_path / "esphome-device-builder.dist-info"
+    dead.mkdir()
+    assert maint.dedupe_dist_info(_dists(tmp_path)) == (1, 0)
+    assert not dead.exists()
+
+
 def test_dedupe_keeps_metadata_less_entry_with_record(tmp_path: Path) -> None:
     # Torn the other way: METADATA gone but RECORD intact. pip can still
     # uninstall this one, so the next upgrade heals it without our help;
@@ -468,6 +479,14 @@ def test_retry_handler_reraises_when_the_path_is_writable(tmp_path: Path) -> Non
     assert target.exists()
 
 
+_ROOT_SEES_EVERYTHING_WRITABLE = pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0,
+    reason="os.access(W_OK) is always true for root, so the handler re-raises "
+    "instead of retrying; the test's premise needs an unprivileged user",
+)
+
+
+@_ROOT_SEES_EVERYTHING_WRITABLE
 def test_retry_handler_clears_the_flag_and_retries(tmp_path: Path) -> None:
     target = tmp_path / "file.txt"
     target.write_text("")
@@ -476,6 +495,7 @@ def test_retry_handler_clears_the_flag_and_retries(tmp_path: Path) -> None:
     assert not target.exists()
 
 
+@_ROOT_SEES_EVERYTHING_WRITABLE
 def test_retry_handler_chains_a_failed_retry(tmp_path: Path) -> None:
     # The retry failing anew must not silently replace the original cause; the
     # chain keeps both in the traceback the "could not remove" line reports.

--- a/tests/test_device_builder_maintenance.py
+++ b/tests/test_device_builder_maintenance.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 from importlib.metadata import Distribution, distributions
 from pathlib import Path
 
+import pytest
 from script_loader import load_script_module
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -135,7 +136,7 @@ def test_dedupe_keeps_highest_and_removes_rest(tmp_path: Path) -> None:
         version: _make_dist_info(tmp_path, "esphome-device-builder", version)
         for version in ("1.0.1", "1.0.9", "1.0.10", "1.0.10b1")
     }
-    assert maint.dedupe_dist_info(_dists(tmp_path)) == 3
+    assert maint.dedupe_dist_info(_dists(tmp_path)) == (3, 0)
     assert paths["1.0.10"].is_dir()
     for version in ("1.0.1", "1.0.9", "1.0.10b1"):
         assert not paths[version].exists()
@@ -152,7 +153,7 @@ def test_dedupe_never_deletes_an_unparseable_duplicate(tmp_path: Path) -> None:
     broken = _make_dist_info(
         tmp_path, "esphome-device-builder", "1.0.9", with_version=False
     )
-    assert maint.dedupe_dist_info(_dists(tmp_path)) == 0
+    assert maint.dedupe_dist_info(_dists(tmp_path)) == (0, 0)
     assert keep.is_dir()
     assert broken.is_dir()
     assert maint.detect_version(_dists(tmp_path)) == "1.0.10"
@@ -166,7 +167,7 @@ def test_dedupe_prunes_parseable_but_spares_unparseable_sibling(tmp_path: Path) 
     broken = _make_dist_info(
         tmp_path, "esphome-device-builder", "1.0.8", with_version=False
     )
-    assert maint.dedupe_dist_info(_dists(tmp_path)) == 1
+    assert maint.dedupe_dist_info(_dists(tmp_path)) == (1, 0)
     assert keep.is_dir()
     assert not stale.exists()
     assert broken.is_dir()
@@ -178,14 +179,14 @@ def test_dedupe_skips_group_with_no_parseable_version(tmp_path: Path) -> None:
     b = _make_dist_info(
         tmp_path, "esphome-device-builder", "1.0.10", with_version=False
     )
-    assert maint.dedupe_dist_info(_dists(tmp_path)) == 0
+    assert maint.dedupe_dist_info(_dists(tmp_path)) == (0, 0)
     assert a.is_dir()
     assert b.is_dir()
 
 
 def test_dedupe_leaves_single_install_untouched(tmp_path: Path) -> None:
     only = _make_dist_info(tmp_path, "esphome-device-builder", "1.0.10")
-    assert maint.dedupe_dist_info(_dists(tmp_path)) == 0
+    assert maint.dedupe_dist_info(_dists(tmp_path)) == (0, 0)
     assert only.is_dir()
 
 
@@ -194,7 +195,7 @@ def test_dedupe_groups_frontend_independently(tmp_path: Path) -> None:
     _make_dist_info(tmp_path, "esphome-device-builder", "1.0.9")
     fe_keep = _make_dist_info(tmp_path, "esphome-device-builder-frontend", "0.1.170")
     _make_dist_info(tmp_path, "esphome-device-builder-frontend", "0.1.158")
-    assert maint.dedupe_dist_info(_dists(tmp_path)) == 2
+    assert maint.dedupe_dist_info(_dists(tmp_path)) == (2, 0)
     assert main_keep.is_dir()
     assert fe_keep.is_dir()
 
@@ -210,7 +211,7 @@ def test_dedupe_default_scope_ignores_non_target_duplicates(tmp_path: Path) -> N
     # check's.
     old = _make_dist_info(tmp_path, "esphome", "2026.7.0")
     new = _make_dist_info(tmp_path, "esphome", "2026.7.1")
-    assert maint.dedupe_dist_info(_dists(tmp_path)) == 0
+    assert maint.dedupe_dist_info(_dists(tmp_path)) == (0, 0)
     assert old.is_dir()
     assert new.is_dir()
 
@@ -224,7 +225,7 @@ def test_dedupe_all_prunes_any_package(tmp_path: Path) -> None:
     aioesp_old = _make_dist_info(tmp_path, "aioesphomeapi", "45.6.0")
     aioesp_new = _make_dist_info(tmp_path, "aioesphomeapi", "45.6.2")
     single = _make_dist_info(tmp_path, "bleak", "2.1.1")
-    assert maint.dedupe_dist_info(_dists(tmp_path), targets=None) == 2
+    assert maint.dedupe_dist_info(_dists(tmp_path), targets=None) == (2, 0)
     assert esphome_new.is_dir()
     assert aioesp_new.is_dir()
     assert single.is_dir()
@@ -242,7 +243,7 @@ def test_dedupe_all_never_groups_nameless_dist_infos(tmp_path: Path) -> None:
     orphan_b = _make_dist_info(tmp_path, "pkg-b", "2.0.0", with_name=False)
     keep = _make_dist_info(tmp_path, "esphome", "2026.7.1")
     stale = _make_dist_info(tmp_path, "esphome", "2026.7.0")
-    assert maint.dedupe_dist_info(_dists(tmp_path), targets=None) == 1
+    assert maint.dedupe_dist_info(_dists(tmp_path), targets=None) == (1, 0)
     assert orphan_a.is_dir()
     assert orphan_b.is_dir()
     assert keep.is_dir()
@@ -257,19 +258,19 @@ def test_dedupe_all_keeps_safety_guards(tmp_path: Path) -> None:
     amb_b = _make_dist_info(tmp_path, "aioesphomeapi", "45.6.2", with_version=False)
     keep = _make_dist_info(tmp_path, "esphome", "2026.7.1")
     broken = _make_dist_info(tmp_path, "esphome", "2026.7.0", with_version=False)
-    assert maint.dedupe_dist_info(_dists(tmp_path), targets=None) == 0
+    assert maint.dedupe_dist_info(_dists(tmp_path), targets=None) == (0, 0)
     for path in (amb_a, amb_b, keep, broken):
         assert path.is_dir()
 
 
 # --------------------------------------------------------------------------- #
-# metadata-dead dist-infos: no readable version and no RECORD. pip can never
-# uninstall one, so every upgrade aborts with uninstall-no-record-file
-# ("Cannot uninstall <pkg> None") until it is removed.
+# RECORD-less dist-infos: pip can never uninstall one, so every upgrade aborts
+# with uninstall-no-record-file ("Cannot uninstall <pkg> None", or with the
+# version when METADATA survived) until it is removed.
 # --------------------------------------------------------------------------- #
 
 
-def test_dedupe_removes_metadata_dead_frontend_beside_healthy(tmp_path: Path) -> None:
+def test_dedupe_removes_record_less_frontend_beside_healthy(tmp_path: Path) -> None:
     # The reported Windows failure: the installer overlay leaves a torn
     # frontend dist-info (no METADATA, no RECORD) in the bundled tree, the
     # repair re-copy faithfully restores it, and the retried install hits the
@@ -284,13 +285,13 @@ def test_dedupe_removes_metadata_dead_frontend_beside_healthy(tmp_path: Path) ->
         with_metadata=False,
         with_record=False,
     )
-    assert maint.dedupe_dist_info(_dists(tmp_path)) == 1
+    assert maint.dedupe_dist_info(_dists(tmp_path)) == (1, 0)
     assert keep.is_dir()
     assert not dead.exists()
     assert (keep / "RECORD").is_file()
 
 
-def test_dedupe_removes_lone_metadata_dead_entry(tmp_path: Path) -> None:
+def test_dedupe_removes_lone_record_less_entry(tmp_path: Path) -> None:
     # No healthy sibling to compare against: the entry is condemned on its own
     # evidence. A completed pip install always writes RECORD, so this cannot
     # be the real install, and pip aborts the upgrade as long as it exists.
@@ -301,7 +302,7 @@ def test_dedupe_removes_lone_metadata_dead_entry(tmp_path: Path) -> None:
         with_metadata=False,
         with_record=False,
     )
-    assert maint.dedupe_dist_info(_dists(tmp_path)) == 1
+    assert maint.dedupe_dist_info(_dists(tmp_path)) == (1, 0)
     assert not dead.exists()
 
 
@@ -324,10 +325,71 @@ def test_dedupe_removes_dist_info_with_read_only_contents(tmp_path: Path) -> Non
         locked = dist_info / "locked.txt"
         locked.write_text("")
         locked.chmod(0o444)
-    assert maint.dedupe_dist_info(_dists(tmp_path)) == 2
+    assert maint.dedupe_dist_info(_dists(tmp_path)) == (2, 0)
     assert keep.is_dir()
     assert not stale.exists()
     assert not dead.exists()
+
+
+def test_dedupe_removes_record_less_entry_with_healthy_metadata(tmp_path: Path) -> None:
+    # The other torn shape: METADATA intact, RECORD gone. pip aborts the
+    # upgrade identically (the message just carries the version instead of
+    # None), so version readability must not shield the entry; the abort keys
+    # off the missing RECORD alone.
+    keep = _make_dist_info(tmp_path, "esphome-device-builder", "1.0.10")
+    torn = _make_dist_info(
+        tmp_path, "esphome-device-builder", "1.0.9", with_record=False
+    )
+    assert maint.dedupe_dist_info(_dists(tmp_path)) == (1, 0)
+    assert keep.is_dir()
+    assert not torn.exists()
+
+
+def test_dedupe_counts_a_record_less_entry_it_cannot_remove(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A RECORD-less dir that survives the prune still aborts every install, so
+    # it must be reported as a failure (the CLI exits non-zero on it), never
+    # folded into "nothing to remove".
+    dead = _make_dist_info(
+        tmp_path,
+        "esphome-device-builder-frontend",
+        "0.1.150",
+        with_metadata=False,
+        with_record=False,
+    )
+
+    def refuse(_path: Path) -> None:
+        raise OSError("locked")
+
+    monkeypatch.setattr(maint, "_rmtree", refuse)
+    assert maint.dedupe_dist_info(_dists(tmp_path)) == (0, 1)
+    assert dead.is_dir()
+
+
+def test_dedupe_skips_unlistable_dist_info(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A directory that cannot be listed decides nothing: a transient read
+    # failure must not turn "RECORD not seen" into "RECORD absent" and delete
+    # what might be a real install.
+    dead = _make_dist_info(
+        tmp_path,
+        "esphome-device-builder",
+        "1.0.9",
+        with_metadata=False,
+        with_record=False,
+    )
+    real_iterdir = Path.iterdir
+
+    def failing_iterdir(self: Path) -> object:
+        if self == dead:
+            raise OSError("transient read failure")
+        return real_iterdir(self)
+
+    monkeypatch.setattr(Path, "iterdir", failing_iterdir)
+    assert maint.dedupe_dist_info(_dists(tmp_path)) == (0, 0)
+    assert dead.is_dir()
 
 
 def test_dedupe_keeps_metadata_less_entry_with_record(tmp_path: Path) -> None:
@@ -339,13 +401,13 @@ def test_dedupe_keeps_metadata_less_entry_with_record(tmp_path: Path) -> None:
     torn = _make_dist_info(
         tmp_path, "esphome-device-builder", "1.0.9", with_metadata=False
     )
-    assert maint.dedupe_dist_info(_dists(tmp_path)) == 0
+    assert maint.dedupe_dist_info(_dists(tmp_path)) == (0, 0)
     assert keep.is_dir()
     assert torn.is_dir()
 
 
 def test_dedupe_inferred_name_never_ranks(tmp_path: Path) -> None:
-    # A dir-name-only identity is enough to condemn a metadata-dead entry, but
+    # A dir-name-only identity is enough to condemn a RECORD-less entry, but
     # never to rank one: a corrupted dist-info whose METADATA lost its Name but
     # kept a high-sorting Version, and whose directory name collides with a
     # real package, must not evict that package's genuine dist-info, and must
@@ -353,25 +415,25 @@ def test_dedupe_inferred_name_never_ranks(tmp_path: Path) -> None:
     imposter = _make_dist_info(tmp_path, "esphome", "9999.0.0", with_name=False)
     real = _make_dist_info(tmp_path, "esphome", "2026.7.1")
     stale = _make_dist_info(tmp_path, "esphome", "2026.7.0")
-    assert maint.dedupe_dist_info(_dists(tmp_path), targets=None) == 1
+    assert maint.dedupe_dist_info(_dists(tmp_path), targets=None) == (1, 0)
     assert imposter.is_dir()
     assert real.is_dir()
     assert not stale.exists()
 
 
-def test_dedupe_default_scope_leaves_non_target_metadata_dead(tmp_path: Path) -> None:
+def test_dedupe_default_scope_leaves_non_target_record_less(tmp_path: Path) -> None:
     # The lazy update-check heal stays scoped to the builder packages even for
-    # metadata-dead entries; the post-copy dedupe-all owns the whole tree.
+    # RECORD-less entries; the post-copy dedupe-all owns the whole tree.
     dead = _make_dist_info(
         tmp_path, "zeroconf", "0.147.0", with_metadata=False, with_record=False
     )
-    assert maint.dedupe_dist_info(_dists(tmp_path)) == 0
+    assert maint.dedupe_dist_info(_dists(tmp_path)) == (0, 0)
     assert dead.is_dir()
 
 
-def test_dedupe_all_removes_any_metadata_dead(tmp_path: Path) -> None:
+def test_dedupe_all_removes_any_record_less(tmp_path: Path) -> None:
     # The #183 dev-channel shape was a torn zeroconf; dedupe-all must clear a
-    # metadata-dead entry for any package, healthy sibling or not.
+    # RECORD-less entry for any package, healthy sibling or not.
     dead = _make_dist_info(
         tmp_path, "zeroconf", "0.147.0", with_metadata=False, with_record=False
     )
@@ -379,7 +441,7 @@ def test_dedupe_all_removes_any_metadata_dead(tmp_path: Path) -> None:
         tmp_path, "bleak", "2.1.0", with_metadata=False, with_record=False
     )
     keep = _make_dist_info(tmp_path, "zeroconf", "0.148.0")
-    assert maint.dedupe_dist_info(_dists(tmp_path), targets=None) == 2
+    assert maint.dedupe_dist_info(_dists(tmp_path), targets=None) == (2, 0)
     assert keep.is_dir()
     assert not dead.exists()
     assert not lone_dead.exists()

--- a/tests/test_device_builder_maintenance.py
+++ b/tests/test_device_builder_maintenance.py
@@ -18,8 +18,9 @@ pytest suite (maintainer-requested framework, fully typed, no classes).
 from __future__ import annotations
 
 import os
-from importlib.metadata import Distribution, distributions
+from importlib.metadata import Distribution, PathDistribution, distributions
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from script_loader import load_script_module
@@ -661,3 +662,31 @@ def test_dedupe_scoped_skips_an_unattributable_dist_info(tmp_path: Path) -> None
     weird.mkdir()
     assert maint.dedupe_dist_info(_dists(tmp_path)) == (0, 0)
     assert weird.is_dir()
+
+
+def test_dedupe_all_counts_a_distribution_without_a_usable_path() -> None:
+    # The private _path guard: if importlib ever changes shape, every entry
+    # lands here and the prune can do nothing at all; a total no-op must not
+    # read as a heal in all-scope mode. Target scope skips it uncounted,
+    # since without a path there is no name to scope-filter on.
+    pathless = SimpleNamespace(_path="not-a-path")
+    assert maint.dedupe_dist_info([pathless], targets=None) == (0, 1)
+    assert maint.dedupe_dist_info([pathless]) == (0, 0)
+
+
+def test_dedupe_counts_an_unreadable_metadata_entry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # METADATA exists but cannot be read: unlike the absent-METADATA torn
+    # shape (a deliberate keep), a transient read failure hides whether this
+    # entry drives the version-None pileup, so the run must not report a
+    # heal around it. The entry itself is kept; deleting on a read failure
+    # is the one wrong the prune must never commit.
+    entry = _make_dist_info(tmp_path, "esphome-device-builder", "1.0.9")
+
+    def unreadable_metadata(self: PathDistribution) -> object:
+        raise OSError("transient read failure")
+
+    monkeypatch.setattr(PathDistribution, "metadata", property(unreadable_metadata))
+    assert maint.dedupe_dist_info(_dists(tmp_path)) == (0, 1)
+    assert entry.is_dir()

--- a/tests/test_device_builder_maintenance.py
+++ b/tests/test_device_builder_maintenance.py
@@ -239,13 +239,15 @@ def test_dedupe_all_never_groups_nameless_dist_infos(tmp_path: Path) -> None:
     # Two unrelated dist-infos whose METADATA lost its Name header are
     # attributed by their directory names, so they land in separate groups
     # rather than being pruned as "duplicates" of one another. Both must
-    # survive (each is the only entry for its package and both still have a
-    # RECORD), and a healthy pair must still dedupe normally alongside them.
+    # survive (each still has a RECORD), and a healthy pair must still dedupe
+    # normally alongside them. Each survivor is its package's only entry, so
+    # its group has nothing rankable and both count as unresolved: their
+    # versions still cannot be read through the Name filter.
     orphan_a = _make_dist_info(tmp_path, "pkg-a", "1.0.0", with_name=False)
     orphan_b = _make_dist_info(tmp_path, "pkg-b", "2.0.0", with_name=False)
     keep = _make_dist_info(tmp_path, "esphome", "2026.7.1")
     stale = _make_dist_info(tmp_path, "esphome", "2026.7.0")
-    assert maint.dedupe_dist_info(_dists(tmp_path), targets=None) == (1, 0)
+    assert maint.dedupe_dist_info(_dists(tmp_path), targets=None) == (1, 2)
     assert orphan_a.is_dir()
     assert orphan_b.is_dir()
     assert keep.is_dir()
@@ -448,13 +450,26 @@ def test_dedupe_keeps_metadata_less_entry_with_record(tmp_path: Path) -> None:
     # Torn the other way: METADATA gone but RECORD intact. pip can still
     # uninstall this one, so the next upgrade heals it without our help;
     # deleting it here would discard the file list pip needs for that
-    # uninstall.
+    # uninstall. Uncounted because the healthy sibling keeps the group
+    # resolvable; without one it would count (see the lone-entry test below).
     keep = _make_dist_info(tmp_path, "esphome-device-builder", "1.0.10")
     torn = _make_dist_info(
         tmp_path, "esphome-device-builder", "1.0.9", with_metadata=False
     )
     assert maint.dedupe_dist_info(_dists(tmp_path)) == (0, 0)
     assert keep.is_dir()
+    assert torn.is_dir()
+
+
+def test_dedupe_counts_a_group_with_no_rankable_entry(tmp_path: Path) -> None:
+    # A lone METADATA-less-with-RECORD entry is kept (pip can manage it), but
+    # its group has nothing rankable, so detect_version still resolves no
+    # version and the updater never offers the install that would let pip
+    # heal it. The run must not call that resolved.
+    torn = _make_dist_info(
+        tmp_path, "esphome-device-builder", "1.0.9", with_metadata=False
+    )
+    assert maint.dedupe_dist_info(_dists(tmp_path)) == (0, 1)
     assert torn.is_dir()
 
 

--- a/tests/test_device_builder_maintenance.py
+++ b/tests/test_device_builder_maintenance.py
@@ -547,7 +547,9 @@ def test_rmtree_wires_the_onerror_adapter_below_312(
         captured["onerror"] = onerror
 
     monkeypatch.setattr(maint.shutil, "rmtree", fake_rmtree)
-    monkeypatch.setattr(maint.sys, "version_info", (3, 11, 0))
+    # The import-time constant, not sys.version_info: patching the latter is
+    # process-wide and can confuse anything else that reads it mid-test.
+    monkeypatch.setattr(maint, "_RMTREE_HAS_ONEXC", False)
     maint._rmtree(tmp_path)
     onerror = captured["onerror"]
     assert callable(onerror)

--- a/tests/test_device_builder_maintenance.py
+++ b/tests/test_device_builder_maintenance.py
@@ -664,14 +664,15 @@ def test_dedupe_scoped_skips_an_unattributable_dist_info(tmp_path: Path) -> None
     assert weird.is_dir()
 
 
-def test_dedupe_all_counts_a_distribution_without_a_usable_path() -> None:
+def test_dedupe_counts_a_distribution_without_a_usable_path() -> None:
     # The private _path guard: if importlib ever changes shape, every entry
     # lands here and the prune can do nothing at all; a total no-op must not
-    # read as a heal in all-scope mode. Target scope skips it uncounted,
-    # since without a path there is no name to scope-filter on.
+    # read as a heal in either mode. Unlike a single nameless directory, a
+    # pathless entry is a systemic contract break that hits the target
+    # packages by definition, so the scoped heal counts it too.
     pathless = SimpleNamespace(_path="not-a-path")
     assert maint.dedupe_dist_info([pathless], targets=None) == (0, 1)
-    assert maint.dedupe_dist_info([pathless]) == (0, 0)
+    assert maint.dedupe_dist_info([pathless]) == (0, 1)
 
 
 def test_dedupe_counts_an_unreadable_metadata_entry(

--- a/tests/test_device_builder_maintenance.py
+++ b/tests/test_device_builder_maintenance.py
@@ -36,16 +36,26 @@ def _make_dist_info(
     *,
     with_version: bool = True,
     with_name: bool = True,
+    with_record: bool = True,
+    with_metadata: bool = True,
 ) -> Path:
-    """Create a *.dist-info dir for ``package`` and return its path."""
+    """Create a *.dist-info dir for ``package`` and return its path.
+
+    ``with_record=False`` and ``with_metadata=False`` fabricate the torn shapes
+    the installer overlay leaves behind; the default is a pip-manageable entry
+    (a completed pip install always writes RECORD).
+    """
     dist_info = site / f"{package.replace('-', '_')}-{version}.dist-info"
     dist_info.mkdir(parents=True)
-    lines = ["Metadata-Version: 2.1"]
-    if with_name:
-        lines.append(f"Name: {package}")
-    if with_version and version is not None:
-        lines.append(f"Version: {version}")
-    (dist_info / "METADATA").write_text("\n".join(lines) + "\n")
+    if with_metadata:
+        lines = ["Metadata-Version: 2.1"]
+        if with_name:
+            lines.append(f"Name: {package}")
+        if with_version and version is not None:
+            lines.append(f"Version: {version}")
+        (dist_info / "METADATA").write_text("\n".join(lines) + "\n")
+    if with_record:
+        (dist_info / "RECORD").write_text("")
     return dist_info
 
 
@@ -134,9 +144,10 @@ def test_dedupe_keeps_highest_and_removes_rest(tmp_path: Path) -> None:
 
 
 def test_dedupe_never_deletes_an_unparseable_duplicate(tmp_path: Path) -> None:
-    # A dist-info whose version can't be parsed might itself be the real install,
-    # so the destructive prune must keep it rather than trust the lowest-sort
-    # sentinel. detect_version still reports the real version regardless.
+    # A dist-info whose version can't be parsed but that pip can still manage
+    # (it has a RECORD) might itself be the real install, so the destructive
+    # prune must keep it rather than trust the lowest-sort sentinel.
+    # detect_version still reports the real version regardless.
     keep = _make_dist_info(tmp_path, "esphome-device-builder", "1.0.10")
     broken = _make_dist_info(
         tmp_path, "esphome-device-builder", "1.0.9", with_version=False
@@ -222,10 +233,11 @@ def test_dedupe_all_prunes_any_package(tmp_path: Path) -> None:
 
 
 def test_dedupe_all_never_groups_nameless_dist_infos(tmp_path: Path) -> None:
-    # Two unrelated dist-infos whose METADATA lost its Name header normalize
-    # to ""; grouping them would prune one as a "duplicate" of the other even
-    # though they belong to different packages. Both must survive, and a
-    # healthy pair must still dedupe normally alongside them.
+    # Two unrelated dist-infos whose METADATA lost its Name header are
+    # attributed by their directory names, so they land in separate groups
+    # rather than being pruned as "duplicates" of one another. Both must
+    # survive (each is the only entry for its package and both still have a
+    # RECORD), and a healthy pair must still dedupe normally alongside them.
     orphan_a = _make_dist_info(tmp_path, "pkg-a", "1.0.0", with_name=False)
     orphan_b = _make_dist_info(tmp_path, "pkg-b", "2.0.0", with_name=False)
     keep = _make_dist_info(tmp_path, "esphome", "2026.7.1")
@@ -239,8 +251,8 @@ def test_dedupe_all_never_groups_nameless_dist_infos(tmp_path: Path) -> None:
 
 def test_dedupe_all_keeps_safety_guards(tmp_path: Path) -> None:
     # The guard behavior must survive the scope widening: an all-unparseable
-    # group is left whole, and an unparseable sibling is never deleted on the
-    # strength of the lowest-sort sentinel.
+    # group of managed entries is left whole, and an unparseable sibling with
+    # a RECORD is never deleted on the strength of the lowest-sort sentinel.
     amb_a = _make_dist_info(tmp_path, "aioesphomeapi", "45.6.0", with_version=False)
     amb_b = _make_dist_info(tmp_path, "aioesphomeapi", "45.6.2", with_version=False)
     keep = _make_dist_info(tmp_path, "esphome", "2026.7.1")
@@ -248,3 +260,86 @@ def test_dedupe_all_keeps_safety_guards(tmp_path: Path) -> None:
     assert maint.dedupe_dist_info(_dists(tmp_path), targets=None) == 0
     for path in (amb_a, amb_b, keep, broken):
         assert path.is_dir()
+
+
+# --------------------------------------------------------------------------- #
+# metadata-dead dist-infos: no readable version and no RECORD. pip can never
+# uninstall one, so every upgrade aborts with uninstall-no-record-file
+# ("Cannot uninstall <pkg> None") until it is removed.
+# --------------------------------------------------------------------------- #
+
+
+def test_dedupe_removes_metadata_dead_frontend_beside_healthy(tmp_path: Path) -> None:
+    # The reported Windows failure: the installer overlay leaves a torn
+    # frontend dist-info (no METADATA, no RECORD) in the bundled tree, the
+    # repair re-copy faithfully restores it, and the retried install hits the
+    # same abort forever. The name comes from the directory alone, so the
+    # prune must still attribute and remove it while keeping the healthy
+    # install.
+    keep = _make_dist_info(tmp_path, "esphome-device-builder-frontend", "0.1.172")
+    dead = _make_dist_info(
+        tmp_path,
+        "esphome-device-builder-frontend",
+        "0.1.150",
+        with_metadata=False,
+        with_record=False,
+    )
+    assert maint.dedupe_dist_info(_dists(tmp_path)) == 1
+    assert keep.is_dir()
+    assert not dead.exists()
+    assert (keep / "RECORD").is_file()
+
+
+def test_dedupe_removes_lone_metadata_dead_entry(tmp_path: Path) -> None:
+    # No healthy sibling to compare against: the entry is condemned on its own
+    # evidence. A completed pip install always writes RECORD, so this cannot
+    # be the real install, and pip aborts the upgrade as long as it exists.
+    dead = _make_dist_info(
+        tmp_path,
+        "esphome-device-builder-frontend",
+        "0.1.150",
+        with_metadata=False,
+        with_record=False,
+    )
+    assert maint.dedupe_dist_info(_dists(tmp_path)) == 1
+    assert not dead.exists()
+
+
+def test_dedupe_keeps_metadata_less_entry_with_record(tmp_path: Path) -> None:
+    # Torn the other way: METADATA gone but RECORD intact. pip can still
+    # uninstall this one, so the next upgrade heals it without our help;
+    # deleting it here would discard the file list pip needs for that
+    # uninstall.
+    keep = _make_dist_info(tmp_path, "esphome-device-builder", "1.0.10")
+    torn = _make_dist_info(
+        tmp_path, "esphome-device-builder", "1.0.9", with_metadata=False
+    )
+    assert maint.dedupe_dist_info(_dists(tmp_path)) == 0
+    assert keep.is_dir()
+    assert torn.is_dir()
+
+
+def test_dedupe_default_scope_leaves_non_target_metadata_dead(tmp_path: Path) -> None:
+    # The lazy update-check heal stays scoped to the builder packages even for
+    # metadata-dead entries; the post-copy dedupe-all owns the whole tree.
+    dead = _make_dist_info(
+        tmp_path, "zeroconf", "0.147.0", with_metadata=False, with_record=False
+    )
+    assert maint.dedupe_dist_info(_dists(tmp_path)) == 0
+    assert dead.is_dir()
+
+
+def test_dedupe_all_removes_any_metadata_dead(tmp_path: Path) -> None:
+    # The #183 dev-channel shape was a torn zeroconf; dedupe-all must clear a
+    # metadata-dead entry for any package, healthy sibling or not.
+    dead = _make_dist_info(
+        tmp_path, "zeroconf", "0.147.0", with_metadata=False, with_record=False
+    )
+    lone_dead = _make_dist_info(
+        tmp_path, "bleak", "2.1.0", with_metadata=False, with_record=False
+    )
+    keep = _make_dist_info(tmp_path, "zeroconf", "0.148.0")
+    assert maint.dedupe_dist_info(_dists(tmp_path), targets=None) == 2
+    assert keep.is_dir()
+    assert not dead.exists()
+    assert not lone_dead.exists()

--- a/tests/test_device_builder_maintenance.py
+++ b/tests/test_device_builder_maintenance.py
@@ -690,3 +690,22 @@ def test_dedupe_counts_an_unreadable_metadata_entry(
     monkeypatch.setattr(PathDistribution, "metadata", property(unreadable_metadata))
     assert maint.dedupe_dist_info(_dists(tmp_path)) == (0, 1)
     assert entry.is_dir()
+
+
+@pytest.mark.skipif(
+    os.name == "nt" or (hasattr(os, "geteuid") and os.geteuid() == 0),
+    reason="chmod 000 does not block reads on Windows, and root reads anything",
+)
+def test_dedupe_counts_a_permission_denied_metadata(tmp_path: Path) -> None:
+    # importlib suppresses PermissionError into an empty answer, so no
+    # exception marks this entry; only the direct probe can tell a file that
+    # denies reads from a file that is absent. It must count as unresolved,
+    # and it must be kept: deleting on a read failure is the one wrong the
+    # prune must never commit.
+    entry = _make_dist_info(tmp_path, "esphome-device-builder", "1.0.9")
+    (entry / "METADATA").chmod(0)
+    try:
+        assert maint.dedupe_dist_info(_dists(tmp_path)) == (0, 1)
+        assert entry.is_dir()
+    finally:
+        (entry / "METADATA").chmod(0o644)

--- a/tests/test_device_builder_maintenance.py
+++ b/tests/test_device_builder_maintenance.py
@@ -17,6 +17,7 @@ pytest suite (maintainer-requested framework, fully typed, no classes).
 
 from __future__ import annotations
 
+import os
 from importlib.metadata import Distribution, distributions
 from pathlib import Path
 
@@ -445,3 +446,110 @@ def test_dedupe_all_removes_any_record_less(tmp_path: Path) -> None:
     assert keep.is_dir()
     assert not dead.exists()
     assert not lone_dead.exists()
+
+
+# --------------------------------------------------------------------------- #
+# _clear_readonly_and_retry: the rmtree error handler. The flag-clearing leg
+# only ever fires on Windows, so its contract is pinned directly here where it
+# runs on every platform.
+# --------------------------------------------------------------------------- #
+
+
+def test_retry_handler_reraises_when_the_path_is_writable(tmp_path: Path) -> None:
+    # A writable path that still failed means the read-only flag was not the
+    # problem; the original error must surface unchanged and nothing may be
+    # retried against the same wall.
+    target = tmp_path / "file.txt"
+    target.write_text("")
+    original = OSError("boom")
+    with pytest.raises(OSError) as caught:
+        maint._clear_readonly_and_retry(os.unlink, str(target), original)
+    assert caught.value is original
+    assert target.exists()
+
+
+def test_retry_handler_clears_the_flag_and_retries(tmp_path: Path) -> None:
+    target = tmp_path / "file.txt"
+    target.write_text("")
+    target.chmod(0o444)
+    maint._clear_readonly_and_retry(os.unlink, str(target), OSError("original"))
+    assert not target.exists()
+
+
+def test_retry_handler_chains_a_failed_retry(tmp_path: Path) -> None:
+    # The retry failing anew must not silently replace the original cause; the
+    # chain keeps both in the traceback the "could not remove" line reports.
+    target = tmp_path / "file.txt"
+    target.write_text("")
+    target.chmod(0o444)
+    original = OSError("original")
+
+    def refuse(_path: str) -> None:
+        raise OSError("still locked")
+
+    with pytest.raises(OSError) as caught:
+        maint._clear_readonly_and_retry(refuse, str(target), original)
+    assert caught.value.__cause__ is original
+
+
+# --------------------------------------------------------------------------- #
+# main(): the argv contract the Rust runners invoke, including the exit code
+# that is the only channel by which "still corrupt" reaches the caller.
+# --------------------------------------------------------------------------- #
+
+
+def test_main_detect_prints_the_version(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _make_dist_info(tmp_path, "esphome-device-builder", "1.0.10")
+    monkeypatch.setattr(maint, "distributions", lambda: _dists(tmp_path))
+    assert maint.main(["detect"]) == 0
+    assert capsys.readouterr().out.strip() == "1.0.10"
+
+
+def test_main_dedupe_scopes_to_targets(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # dedupe must leave a non-target RECORD-less entry to dedupe-all: a swap
+    # of the scope selection would turn the scoped heal into a whole-tree
+    # prune on a live user tree.
+    dead = _make_dist_info(
+        tmp_path, "zeroconf", "0.147.0", with_metadata=False, with_record=False
+    )
+    monkeypatch.setattr(maint, "distributions", lambda: _dists(tmp_path))
+    assert maint.main(["dedupe"]) == 0
+    assert capsys.readouterr().out.strip() == "0"
+    assert dead.is_dir()
+    assert maint.main(["dedupe-all"]) == 0
+    assert capsys.readouterr().out.strip() == "1"
+    assert not dead.exists()
+
+
+def test_main_exits_non_zero_when_a_record_less_entry_survives(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # The Rust caller only looks at the exit status; a surviving RECORD-less
+    # entry reported through exit 0 would read as a heal.
+    _make_dist_info(
+        tmp_path,
+        "esphome-device-builder-frontend",
+        "0.1.150",
+        with_metadata=False,
+        with_record=False,
+    )
+    monkeypatch.setattr(maint, "distributions", lambda: _dists(tmp_path))
+
+    def refuse(_path: Path) -> None:
+        raise OSError("locked")
+
+    monkeypatch.setattr(maint, "_rmtree", refuse)
+    assert maint.main(["dedupe"]) == 1
+    captured = capsys.readouterr()
+    assert captured.out.strip() == "0"
+    assert "could not remove RECORD-less" in captured.err
+
+
+def test_main_rejects_an_unknown_mode(capsys: pytest.CaptureFixture[str]) -> None:
+    assert maint.main(["bogus"]) == 2
+    assert maint.main([]) == 2
+    assert "unknown mode" in capsys.readouterr().err

--- a/tests/test_device_builder_maintenance.py
+++ b/tests/test_device_builder_maintenance.py
@@ -728,3 +728,16 @@ def test_main_detect_prints_nothing_when_absent(
     monkeypatch.setattr(maint, "distributions", lambda: _dists(tmp_path))
     assert maint.main(["detect"]) == 0
     assert capsys.readouterr().out.strip() == ""
+
+
+def test_dedupe_counts_a_lone_unparseable_entry(tmp_path: Path) -> None:
+    # A single in-scope entry whose METADATA kept its Name but lost a
+    # parseable Version: detect_version still resolves nothing, the same
+    # consequence as the counted group shapes, so the lone spelling must not
+    # be the one that slips through as a heal.
+    torn = _make_dist_info(
+        tmp_path, "esphome-device-builder", "1.0.9", with_version=False
+    )
+    assert maint.dedupe_dist_info(_dists(tmp_path)) == (0, 1)
+    assert torn.is_dir()
+    assert maint.detect_version(_dists(tmp_path)) is None

--- a/tests/test_device_builder_maintenance.py
+++ b/tests/test_device_builder_maintenance.py
@@ -640,3 +640,22 @@ def test_main_rejects_an_unknown_mode(capsys: pytest.CaptureFixture[str]) -> Non
     assert maint.main(["bogus"]) == 2
     assert maint.main([]) == 2
     assert "unknown mode" in capsys.readouterr().err
+
+
+def test_dedupe_all_counts_an_unattributable_dist_info(tmp_path: Path) -> None:
+    # A directory name that yields no package name at all cannot be
+    # attributed, ranked, or condemned; in all-scope mode that is unresolved
+    # damage and must not read as a heal.
+    weird = tmp_path / "-1.0.dist-info"
+    weird.mkdir()
+    assert maint.dedupe_dist_info(_dists(tmp_path), targets=None) == (0, 1)
+    assert weird.is_dir()
+
+
+def test_dedupe_scoped_skips_an_unattributable_dist_info(tmp_path: Path) -> None:
+    # In target scope the nameless entry cannot be tied to the builder
+    # packages, so it is left for dedupe-all without failing the scoped heal.
+    weird = tmp_path / "-1.0.dist-info"
+    weird.mkdir()
+    assert maint.dedupe_dist_info(_dists(tmp_path)) == (0, 0)
+    assert weird.is_dir()

--- a/tests/test_device_builder_maintenance.py
+++ b/tests/test_device_builder_maintenance.py
@@ -176,12 +176,14 @@ def test_dedupe_prunes_parseable_but_spares_unparseable_sibling(tmp_path: Path) 
 
 
 def test_dedupe_skips_group_with_no_parseable_version(tmp_path: Path) -> None:
-    # If nothing in the group parses, we can't pick a winner; leave it all alone.
+    # If nothing in the group parses, we can't pick a winner; leave it all
+    # alone — but counted, since the version still cannot be resolved and
+    # that must not read as a heal.
     a = _make_dist_info(tmp_path, "esphome-device-builder", "1.0.9", with_version=False)
     b = _make_dist_info(
         tmp_path, "esphome-device-builder", "1.0.10", with_version=False
     )
-    assert maint.dedupe_dist_info(_dists(tmp_path)) == (0, 0)
+    assert maint.dedupe_dist_info(_dists(tmp_path)) == (0, 2)
     assert a.is_dir()
     assert b.is_dir()
 
@@ -256,13 +258,15 @@ def test_dedupe_all_never_groups_nameless_dist_infos(tmp_path: Path) -> None:
 
 def test_dedupe_all_keeps_safety_guards(tmp_path: Path) -> None:
     # The guard behavior must survive the scope widening: an all-unparseable
-    # group of managed entries is left whole, and an unparseable sibling with
-    # a RECORD is never deleted on the strength of the lowest-sort sentinel.
+    # group of managed entries is left whole (though counted, its version
+    # being still unresolvable), and an unparseable sibling with a RECORD is
+    # never deleted on the strength of the lowest-sort sentinel — nor counted,
+    # since its rankable sibling keeps that group resolvable.
     amb_a = _make_dist_info(tmp_path, "aioesphomeapi", "45.6.0", with_version=False)
     amb_b = _make_dist_info(tmp_path, "aioesphomeapi", "45.6.2", with_version=False)
     keep = _make_dist_info(tmp_path, "esphome", "2026.7.1")
     broken = _make_dist_info(tmp_path, "esphome", "2026.7.0", with_version=False)
-    assert maint.dedupe_dist_info(_dists(tmp_path), targets=None) == (0, 0)
+    assert maint.dedupe_dist_info(_dists(tmp_path), targets=None) == (0, 2)
     for path in (amb_a, amb_b, keep, broken):
         assert path.is_dir()
 

--- a/tests/test_device_builder_maintenance.py
+++ b/tests/test_device_builder_maintenance.py
@@ -344,6 +344,21 @@ def test_dedupe_keeps_metadata_less_entry_with_record(tmp_path: Path) -> None:
     assert torn.is_dir()
 
 
+def test_dedupe_inferred_name_never_ranks(tmp_path: Path) -> None:
+    # A dir-name-only identity is enough to condemn a metadata-dead entry, but
+    # never to rank one: a corrupted dist-info whose METADATA lost its Name but
+    # kept a high-sorting Version, and whose directory name collides with a
+    # real package, must not evict that package's genuine dist-info, and must
+    # not be evicted itself on the strength of the collision.
+    imposter = _make_dist_info(tmp_path, "esphome", "9999.0.0", with_name=False)
+    real = _make_dist_info(tmp_path, "esphome", "2026.7.1")
+    stale = _make_dist_info(tmp_path, "esphome", "2026.7.0")
+    assert maint.dedupe_dist_info(_dists(tmp_path), targets=None) == 1
+    assert imposter.is_dir()
+    assert real.is_dir()
+    assert not stale.exists()
+
+
 def test_dedupe_default_scope_leaves_non_target_metadata_dead(tmp_path: Path) -> None:
     # The lazy update-check heal stays scoped to the builder packages even for
     # metadata-dead entries; the post-copy dedupe-all owns the whole tree.

--- a/tests/test_device_builder_maintenance.py
+++ b/tests/test_device_builder_maintenance.py
@@ -534,6 +534,34 @@ def test_retry_handler_clears_the_flag_and_retries(tmp_path: Path) -> None:
     assert not target.exists()
 
 
+def test_rmtree_wires_the_onerror_adapter_below_312(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The onerror fallback only ever runs on a dev system Python older than
+    # 3.12, where CI never executes, so pin the adapter's exc_info indexing
+    # here: a wrong index would otherwise surface only on the machine the
+    # branch was written to protect, as a TypeError inside the rmtree walk.
+    captured: dict[str, object] = {}
+
+    def fake_rmtree(path: Path, onerror: object = None) -> None:
+        captured["onerror"] = onerror
+
+    monkeypatch.setattr(maint.shutil, "rmtree", fake_rmtree)
+    monkeypatch.setattr(maint.sys, "version_info", (3, 11, 0))
+    maint._rmtree(tmp_path)
+    onerror = captured["onerror"]
+    assert callable(onerror)
+    # The writable early-out must re-raise the exception *instance* out of
+    # the (type, value, traceback) triple, which is what proves the [1].
+    target = tmp_path / "file.txt"
+    target.write_text("")
+    original = OSError("boom")
+    with pytest.raises(OSError) as caught:
+        onerror(os.unlink, str(target), (OSError, original, None))
+    assert caught.value is original
+    assert target.exists()
+
+
 @_ROOT_SEES_EVERYTHING_WRITABLE
 def test_retry_handler_chains_a_failed_retry(tmp_path: Path) -> None:
     # The retry failing anew must not silently replace the original cause; the

--- a/tests/test_device_builder_maintenance.py
+++ b/tests/test_device_builder_maintenance.py
@@ -66,6 +66,22 @@ def _dists(site: Path) -> list[Distribution]:
     return list(distributions(path=[str(site)]))
 
 
+def _make_torn(site: Path, package: str, version: str) -> Path:
+    """The reported overlay shape: a dist-info with no METADATA and no RECORD."""
+    return _make_dist_info(
+        site, package, version, with_metadata=False, with_record=False
+    )
+
+
+def _refuse_rmtree(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make the prune's removal fail, the way a locked directory does."""
+
+    def refuse(_path: Path) -> None:
+        raise OSError("locked")
+
+    monkeypatch.setattr(maint, "_rmtree", refuse)
+
+
 # --------------------------------------------------------------------------- #
 # vkey: self-contained version ranking (no packaging dependency).
 # --------------------------------------------------------------------------- #
@@ -286,13 +302,7 @@ def test_dedupe_removes_record_less_frontend_beside_healthy(tmp_path: Path) -> N
     # prune must still attribute and remove it while keeping the healthy
     # install.
     keep = _make_dist_info(tmp_path, "esphome-device-builder-frontend", "0.1.172")
-    dead = _make_dist_info(
-        tmp_path,
-        "esphome-device-builder-frontend",
-        "0.1.150",
-        with_metadata=False,
-        with_record=False,
-    )
+    dead = _make_torn(tmp_path, "esphome-device-builder-frontend", "0.1.150")
     assert maint.dedupe_dist_info(_dists(tmp_path)) == (1, 0)
     assert keep.is_dir()
     assert not dead.exists()
@@ -303,13 +313,7 @@ def test_dedupe_removes_lone_record_less_entry(tmp_path: Path) -> None:
     # No healthy sibling to compare against: the entry is condemned on its own
     # evidence. A completed pip install always writes RECORD, so this cannot
     # be the real install, and pip aborts the upgrade as long as it exists.
-    dead = _make_dist_info(
-        tmp_path,
-        "esphome-device-builder-frontend",
-        "0.1.150",
-        with_metadata=False,
-        with_record=False,
-    )
+    dead = _make_torn(tmp_path, "esphome-device-builder-frontend", "0.1.150")
     assert maint.dedupe_dist_info(_dists(tmp_path)) == (1, 0)
     assert not dead.exists()
 
@@ -322,13 +326,7 @@ def test_dedupe_removes_dist_info_with_read_only_contents(tmp_path: Path) -> Non
     # leg, where the original failure lived).
     keep = _make_dist_info(tmp_path, "esphome-device-builder", "1.0.10")
     stale = _make_dist_info(tmp_path, "esphome-device-builder", "1.0.9")
-    dead = _make_dist_info(
-        tmp_path,
-        "esphome-device-builder-frontend",
-        "0.1.150",
-        with_metadata=False,
-        with_record=False,
-    )
+    dead = _make_torn(tmp_path, "esphome-device-builder-frontend", "0.1.150")
     for dist_info in (stale, dead):
         locked = dist_info / "locked.txt"
         locked.write_text("")
@@ -359,18 +357,9 @@ def test_dedupe_counts_a_record_less_entry_it_cannot_remove(
     # A RECORD-less dir that survives the prune still aborts every install, so
     # it must be reported as a failure (the CLI exits non-zero on it), never
     # folded into "nothing to remove".
-    dead = _make_dist_info(
-        tmp_path,
-        "esphome-device-builder-frontend",
-        "0.1.150",
-        with_metadata=False,
-        with_record=False,
-    )
+    dead = _make_torn(tmp_path, "esphome-device-builder-frontend", "0.1.150")
 
-    def refuse(_path: Path) -> None:
-        raise OSError("locked")
-
-    monkeypatch.setattr(maint, "_rmtree", refuse)
+    _refuse_rmtree(monkeypatch)
     assert maint.dedupe_dist_info(_dists(tmp_path)) == (0, 1)
     assert dead.is_dir()
 
@@ -395,13 +384,7 @@ def test_dedupe_counts_an_unlistable_dist_info(
     # what might be a real install. But it may be the RECORD-less blocker, so
     # it counts as unresolved; "could not determine the tree is clean" must
     # not read as clean.
-    dead = _make_dist_info(
-        tmp_path,
-        "esphome-device-builder",
-        "1.0.9",
-        with_metadata=False,
-        with_record=False,
-    )
+    dead = _make_torn(tmp_path, "esphome-device-builder", "1.0.9")
     _fail_iterdir_for(monkeypatch, dead)
     assert maint.dedupe_dist_info(_dists(tmp_path)) == (0, 1)
     assert dead.is_dir()
@@ -413,9 +396,7 @@ def test_dedupe_scoped_ignores_an_unlistable_non_target(
     # The unresolved count only covers in-scope entries: the scoped
     # device-builder heal must not fail over an unlistable directory it was
     # never going to touch.
-    broken = _make_dist_info(
-        tmp_path, "zeroconf", "0.147.0", with_metadata=False, with_record=False
-    )
+    broken = _make_torn(tmp_path, "zeroconf", "0.147.0")
     _fail_iterdir_for(monkeypatch, broken)
     assert maint.dedupe_dist_info(_dists(tmp_path)) == (0, 0)
     assert broken.is_dir()
@@ -430,10 +411,7 @@ def test_dedupe_counts_a_stale_duplicate_it_cannot_remove(
     keep = _make_dist_info(tmp_path, "esphome-device-builder", "1.0.10")
     stale = _make_dist_info(tmp_path, "esphome-device-builder", "1.0.9")
 
-    def refuse(_path: Path) -> None:
-        raise OSError("locked")
-
-    monkeypatch.setattr(maint, "_rmtree", refuse)
+    _refuse_rmtree(monkeypatch)
     assert maint.dedupe_dist_info(_dists(tmp_path)) == (0, 1)
     assert keep.is_dir()
     assert stale.is_dir()
@@ -495,9 +473,7 @@ def test_dedupe_inferred_name_never_ranks(tmp_path: Path) -> None:
 def test_dedupe_default_scope_leaves_non_target_record_less(tmp_path: Path) -> None:
     # The lazy update-check heal stays scoped to the builder packages even for
     # RECORD-less entries; the post-copy dedupe-all owns the whole tree.
-    dead = _make_dist_info(
-        tmp_path, "zeroconf", "0.147.0", with_metadata=False, with_record=False
-    )
+    dead = _make_torn(tmp_path, "zeroconf", "0.147.0")
     assert maint.dedupe_dist_info(_dists(tmp_path)) == (0, 0)
     assert dead.is_dir()
 
@@ -505,12 +481,8 @@ def test_dedupe_default_scope_leaves_non_target_record_less(tmp_path: Path) -> N
 def test_dedupe_all_removes_any_record_less(tmp_path: Path) -> None:
     # The #183 dev-channel shape was a torn zeroconf; dedupe-all must clear a
     # RECORD-less entry for any package, healthy sibling or not.
-    dead = _make_dist_info(
-        tmp_path, "zeroconf", "0.147.0", with_metadata=False, with_record=False
-    )
-    lone_dead = _make_dist_info(
-        tmp_path, "bleak", "2.1.0", with_metadata=False, with_record=False
-    )
+    dead = _make_torn(tmp_path, "zeroconf", "0.147.0")
+    lone_dead = _make_torn(tmp_path, "bleak", "2.1.0")
     keep = _make_dist_info(tmp_path, "zeroconf", "0.148.0")
     assert maint.dedupe_dist_info(_dists(tmp_path), targets=None) == (2, 0)
     assert keep.is_dir()
@@ -622,9 +594,7 @@ def test_main_dedupe_scopes_to_targets(
     # dedupe must leave a non-target RECORD-less entry to dedupe-all: a swap
     # of the scope selection would turn the scoped heal into a whole-tree
     # prune on a live user tree.
-    dead = _make_dist_info(
-        tmp_path, "zeroconf", "0.147.0", with_metadata=False, with_record=False
-    )
+    dead = _make_torn(tmp_path, "zeroconf", "0.147.0")
     monkeypatch.setattr(maint, "distributions", lambda: _dists(tmp_path))
     assert maint.main(["dedupe"]) == 0
     assert capsys.readouterr().out.strip() == "0"
@@ -639,19 +609,10 @@ def test_main_exits_non_zero_when_a_record_less_entry_survives(
 ) -> None:
     # The Rust caller only looks at the exit status; a surviving RECORD-less
     # entry reported through exit 0 would read as a heal.
-    _make_dist_info(
-        tmp_path,
-        "esphome-device-builder-frontend",
-        "0.1.150",
-        with_metadata=False,
-        with_record=False,
-    )
+    _make_torn(tmp_path, "esphome-device-builder-frontend", "0.1.150")
     monkeypatch.setattr(maint, "distributions", lambda: _dists(tmp_path))
 
-    def refuse(_path: Path) -> None:
-        raise OSError("locked")
-
-    monkeypatch.setattr(maint, "_rmtree", refuse)
+    _refuse_rmtree(monkeypatch)
     assert maint.main(["dedupe"]) == 1
     captured = capsys.readouterr()
     assert captured.out.strip() == "0"

--- a/tests/test_device_builder_maintenance.py
+++ b/tests/test_device_builder_maintenance.py
@@ -690,3 +690,41 @@ def test_dedupe_counts_a_permission_denied_metadata(tmp_path: Path) -> None:
         assert entry.is_dir()
     finally:
         (entry / "METADATA").chmod(0o644)
+
+
+def test_detect_version_survives_an_unreadable_distribution(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # One unreadable distribution must not abort detection: silently dropping
+    # the real target would reintroduce the #190 loop with no trace, so the
+    # broken sibling is logged and skipped while the healthy one answers.
+    _make_dist_info(tmp_path, "esphome-device-builder", "1.0.10")
+    broken = _make_dist_info(tmp_path, "esphome-device-builder", "1.0.9")
+    real_metadata = PathDistribution.metadata
+
+    def selective(self: PathDistribution) -> object:
+        if getattr(self, "_path", None) == broken:
+            raise OSError("transient read failure")
+        return real_metadata.fget(self)  # type: ignore[union-attr]
+
+    monkeypatch.setattr(PathDistribution, "metadata", property(selective))
+    assert maint.detect_version(_dists(tmp_path)) == "1.0.10"
+
+
+def test_dedupe_quietly_skips_non_dist_info_entries() -> None:
+    # egg-info metadata is out of the prune's contract: skipped without a log
+    # line or a count, by design, in both scopes.
+    egg = SimpleNamespace(_path=Path("site-packages/legacy_pkg-1.0.egg-info"))
+    assert maint.dedupe_dist_info([egg], targets=None) == (0, 0)
+    assert maint.dedupe_dist_info([egg]) == (0, 0)
+
+
+def test_main_detect_prints_nothing_when_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # The Rust caller's contract: detect exits 0 with empty stdout when the
+    # package is absent, so a non-zero exit always means the check itself
+    # could not run.
+    monkeypatch.setattr(maint, "distributions", lambda: _dists(tmp_path))
+    assert maint.main(["detect"]) == 0
+    assert capsys.readouterr().out.strip() == ""

--- a/tests/test_device_builder_maintenance.py
+++ b/tests/test_device_builder_maintenance.py
@@ -368,12 +368,26 @@ def test_dedupe_counts_a_record_less_entry_it_cannot_remove(
     assert dead.is_dir()
 
 
-def test_dedupe_skips_unlistable_dist_info(
+def _fail_iterdir_for(monkeypatch: pytest.MonkeyPatch, broken: Path) -> None:
+    """Make ``Path.iterdir`` raise for ``broken`` and pass through otherwise."""
+    real_iterdir = Path.iterdir
+
+    def failing_iterdir(self: Path) -> object:
+        if self == broken:
+            raise OSError("transient read failure")
+        return real_iterdir(self)
+
+    monkeypatch.setattr(Path, "iterdir", failing_iterdir)
+
+
+def test_dedupe_counts_an_unlistable_dist_info(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     # A directory that cannot be listed decides nothing: a transient read
     # failure must not turn "RECORD not seen" into "RECORD absent" and delete
-    # what might be a real install.
+    # what might be a real install. But it may be the RECORD-less blocker, so
+    # it counts as unresolved; "could not determine the tree is clean" must
+    # not read as clean.
     dead = _make_dist_info(
         tmp_path,
         "esphome-device-builder",
@@ -381,16 +395,41 @@ def test_dedupe_skips_unlistable_dist_info(
         with_metadata=False,
         with_record=False,
     )
-    real_iterdir = Path.iterdir
-
-    def failing_iterdir(self: Path) -> object:
-        if self == dead:
-            raise OSError("transient read failure")
-        return real_iterdir(self)
-
-    monkeypatch.setattr(Path, "iterdir", failing_iterdir)
-    assert maint.dedupe_dist_info(_dists(tmp_path)) == (0, 0)
+    _fail_iterdir_for(monkeypatch, dead)
+    assert maint.dedupe_dist_info(_dists(tmp_path)) == (0, 1)
     assert dead.is_dir()
+
+
+def test_dedupe_scoped_ignores_an_unlistable_non_target(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The unresolved count only covers in-scope entries: the scoped
+    # device-builder heal must not fail over an unlistable directory it was
+    # never going to touch.
+    broken = _make_dist_info(
+        tmp_path, "zeroconf", "0.147.0", with_metadata=False, with_record=False
+    )
+    _fail_iterdir_for(monkeypatch, broken)
+    assert maint.dedupe_dist_info(_dists(tmp_path)) == (0, 0)
+    assert broken.is_dir()
+
+
+def test_dedupe_counts_a_stale_duplicate_it_cannot_remove(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A surviving duplicate keeps the #190 pileup in place, so importlib still
+    # cannot resolve a single version; reporting that run as a success would
+    # let the lazy heal claim it fixed a tree it did not.
+    keep = _make_dist_info(tmp_path, "esphome-device-builder", "1.0.10")
+    stale = _make_dist_info(tmp_path, "esphome-device-builder", "1.0.9")
+
+    def refuse(_path: Path) -> None:
+        raise OSError("locked")
+
+    monkeypatch.setattr(maint, "_rmtree", refuse)
+    assert maint.dedupe_dist_info(_dists(tmp_path)) == (0, 1)
+    assert keep.is_dir()
+    assert stale.is_dir()
 
 
 def test_dedupe_infers_name_from_a_version_less_directory(tmp_path: Path) -> None:

--- a/tests/test_device_builder_maintenance.py
+++ b/tests/test_device_builder_maintenance.py
@@ -305,6 +305,31 @@ def test_dedupe_removes_lone_metadata_dead_entry(tmp_path: Path) -> None:
     assert not dead.exists()
 
 
+def test_dedupe_removes_dist_info_with_read_only_contents(tmp_path: Path) -> None:
+    # On Windows a read-only file inside the dist-info fails a plain
+    # shutil.rmtree, which would leave the abort loop in place with only a
+    # "skip" line on stderr. The remover must clear the flag and retry (on
+    # POSIX the delete succeeds either way, so this bites on the Windows CI
+    # leg, where the original failure lived).
+    keep = _make_dist_info(tmp_path, "esphome-device-builder", "1.0.10")
+    stale = _make_dist_info(tmp_path, "esphome-device-builder", "1.0.9")
+    dead = _make_dist_info(
+        tmp_path,
+        "esphome-device-builder-frontend",
+        "0.1.150",
+        with_metadata=False,
+        with_record=False,
+    )
+    for dist_info in (stale, dead):
+        locked = dist_info / "locked.txt"
+        locked.write_text("")
+        locked.chmod(0o444)
+    assert maint.dedupe_dist_info(_dists(tmp_path)) == 2
+    assert keep.is_dir()
+    assert not stale.exists()
+    assert not dead.exists()
+
+
 def test_dedupe_keeps_metadata_less_entry_with_record(tmp_path: Path) -> None:
     # Torn the other way: METADATA gone but RECORD intact. pip can still
     # uninstall this one, so the next upgrade heals it without our help;


### PR DESCRIPTION
# What does this implement/fix?

A Windows 10 user could not update the device builder from 1.8.1 to 1.8.2; every attempt failed with pip's `uninstall-no-record-file` ("Cannot uninstall esphome-device-builder-frontend None, no RECORD file was found"), and it survived uninstalling and reinstalling the app.

The updater already handles this error by re-copying the bundled tree and retrying, but the installer overlay can plant the torn dist-info in the bundle itself (#389), so the repair restores it and the retry fails the same way forever. The dedupe helper was the one thing positioned to remove it, and it deliberately refused: the entry has no METADATA, so it was skipped as nameless, and its version is unreadable, so the unrankable guard kept it.

Changes:

- The dedupe helper now removes RECORD-less dist-info dirs. A completed pip install always writes RECORD, so this shape is torn metadata rather than a real install; pip can never uninstall it and aborts every upgrade until it is gone, whether or not the version is still readable. RECORD presence is read from a directory listing, an unlistable directory is skipped so a transient read failure cannot become a delete, and any in-scope damage the prune cannot resolve (a failed removal, an unlistable directory) fails the run instead of counting as success. Entries pip can still manage keep all the existing conservative guards, and `--ignore-installed` stays gone (#331).
- The name of a METADATA-less entry is inferred from its directory name, the same way pip attributes it when it aborts. The inferred name is only used to condemn a RECORD-less entry or scope-filter it; it never ranks an entry against properly named siblings, so a corrupted name can neither evict nor be evicted.
- Removal goes through a chmod-and-retry rmtree (same handling as `esphome.helpers.rmtree`), since a read-only file inside the dist-info fails a plain delete on Windows.
- The failure dialog no longer surfaces pip's `hint:` lines. They address whoever manages the installed environment directly, which here is only ever the updater; the worst of them ("recover via pip install --ignore-installed / --force-reinstall") corrupts the tree further, and typed into a terminal it reaches the system pip, not the bundled interpreter.
- The lazy heal in version detection stands down while an update sequence holds the UpdateGuard. pip writes RECORD last, so a package mid-install passes through exactly the RECORD-less shape the prune condemns; the checks stay read-only in practice and a real pileup is healed by the next check. The prune child itself is bounded to 60 seconds, since the heal holds the guard across it; a wedged child would otherwise pin the guard and silently disable the tray's update and switch arms for the session.
- The e2e repair test now rebuilds the reported state end to end: the real updater pip command aborts with `uninstall-no-record-file` against the torn tree, the repair runs from a source carrying the same corruption, and the identical command succeeds afterwards.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes a Discord report of the 1.8.1 to 1.8.2 update failing on Windows 10

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).
