### PR TITLE
Wipe stale bundled trees at install time so the repair can converge

### DIFF
--- a/.github/scripts/e2e_windows_common.ps1
+++ b/.github/scripts/e2e_windows_common.ps1
@@ -49,13 +49,23 @@ function Wait-Until {
 }
 
 function Install-Bundle {
+    # $TargetDir installs somewhere other than the default location via /D=
+    # (which NSIS requires to be the last argument). Keep such paths free of
+    # spaces: /D= takes the rest of the line verbatim and unquoted.
+    param([string]$TargetDir)
     $installer = Get-ChildItem 'src-tauri/target/release/bundle/nsis/*.exe' -ErrorAction SilentlyContinue |
         Select-Object -First 1
     if (-not $installer) { throw 'no NSIS installer found; did the bundle step run?' }
+    $arguments = @('/S')
+    $expected = $BundledPython
+    if ($TargetDir) {
+        $arguments += "/D=$TargetDir"
+        $expected = Join-Path $TargetDir (Join-Path $BundledPythonDirName 'python.exe')
+    }
     Write-Host "Installing $($installer.Name)"
-    $proc = Start-Process -FilePath $installer.FullName -ArgumentList '/S' -Wait -PassThru
+    $proc = Start-Process -FilePath $installer.FullName -ArgumentList $arguments -Wait -PassThru
     if ($proc.ExitCode -ne 0) { throw "silent install failed with exit code $($proc.ExitCode)" }
-    if (-not (Test-Path $BundledPython)) { throw "installer reported success but $BundledPython does not exist" }
+    if (-not (Test-Path $expected)) { throw "installer reported success but $expected does not exist" }
 }
 
 # Discover the main binary rather than assuming the product name: it is

--- a/.github/scripts/e2e_windows_overlay_wipe.ps1
+++ b/.github/scripts/e2e_windows_overlay_wipe.ps1
@@ -79,3 +79,34 @@ if (-not (Wait-Until { -not (Test-Path $InstallDir) } 30)) {
     throw "a real uninstall stranded $InstallDir (leftovers: $leftover)"
 }
 Write-Host 'PASS: the real uninstall removed the orphaned trees and the install dir'
+
+# --- the wipes must NOT fire on a directory that was never ours -------------
+# The negative half of the destructive contract. $INSTDIR is user-selectable
+# (/D=), so a merged directory can hold a python/ tree that predates the
+# install: the preinstall wipe must stand down (no previous-install
+# sentinel), and a custom-dir uninstall must strand rather than recurse
+# (the post-uninstall wipe is gated to the default location).
+$scratch = Join-Path ([IO.Path]::GetTempPath()) 'esphb-overlay-scratch'
+if (Test-Path $scratch) { Remove-Item -Recurse -Force $scratch }
+$keepme = Join-Path $scratch (Join-Path $BundledPythonDirName 'keepme.txt')
+New-Item -ItemType Directory -Force (Split-Path $keepme) | Out-Null
+Set-Content -Path $keepme -Value 'pre-existing user file' -Encoding ascii
+try {
+    Install-Bundle -TargetDir $scratch
+    if (-not (Test-Path $keepme)) {
+        throw "the preinstall wipe deleted $keepme from a directory that held no previous install"
+    }
+    Start-Process -FilePath (Join-Path $scratch 'uninstall.exe') -ArgumentList '/S' -Wait
+    $scratchPython = Join-Path $scratch (Join-Path $BundledPythonDirName 'python.exe')
+    if (-not (Wait-Until { -not (Test-Path $scratchPython) } 90)) {
+        throw 'the custom-dir uninstall did not remove the bundled interpreter'
+    }
+    [void](Wait-Until { -not (Get-Process -Name 'Un_*' -ErrorAction SilentlyContinue) } 60)
+    if (-not (Test-Path $keepme)) {
+        throw "the post-uninstall wipe deleted $keepme outside the default install location"
+    }
+    Write-Host 'PASS: the wipes left a directory that was never ours alone'
+}
+finally {
+    Remove-Item -Recurse -Force $scratch -ErrorAction SilentlyContinue
+}

--- a/.github/scripts/e2e_windows_overlay_wipe.ps1
+++ b/.github/scripts/e2e_windows_overlay_wipe.ps1
@@ -87,8 +87,9 @@ Write-Host 'PASS: the real uninstall removed the orphaned trees and the install 
 # and no main exe beside it: the third sentinel must fire the wipe anyway.
 # This gate fails closed and silently (a comparison typo just skips the
 # wipe and the installer still exits 0), so only this case evaluates it.
-$strandedOrphan = Join-Path $InstallDir `
-    "$BundledPythonDirName\Lib\site-packages\esphome\components\rp2040\overlay_orphan_probe.py"
+# The deep, field-failure-shaped probe is the last $Probes entry; reuse it
+# rather than spelling the path a second time.
+$strandedOrphan = $Probes[-1]
 New-Item -ItemType Directory -Force (Split-Path $strandedOrphan) | Out-Null
 Set-Content -Path $strandedOrphan -Value 'stranded by an old uninstaller' -Encoding ascii
 Install-Bundle

--- a/.github/scripts/e2e_windows_overlay_wipe.ps1
+++ b/.github/scripts/e2e_windows_overlay_wipe.ps1
@@ -72,7 +72,9 @@ Write-Host 'PASS: the overlay install wiped the planted orphans and reset the re
 Add-Orphans
 Uninstall-Bundle
 if (-not (Wait-Until { -not (Test-Path $InstallDir) } 30)) {
-    $leftover = (Get-ChildItem $InstallDir -Recurse -File |
+    # Dirs too, not -File: a stranded-but-emptied tree (the exact regression
+    # the post-uninstall RMDir "$INSTDIR" retry exists for) has no files.
+    $leftover = (Get-ChildItem $InstallDir -Recurse |
         Select-Object -First 5 -ExpandProperty FullName) -join ', '
     throw "a real uninstall stranded $InstallDir (leftovers: $leftover)"
 }

--- a/.github/scripts/e2e_windows_overlay_wipe.ps1
+++ b/.github/scripts/e2e_windows_overlay_wipe.ps1
@@ -1,0 +1,79 @@
+# End-to-end check of the installer's overlay wipe (#417) against the real
+# NSIS bundle.
+#
+# The generated installer lays resources down file by file over $INSTDIR
+# without deleting the previous release's files. A file the new release no
+# longer ships therefore survives every update — which is how a stranded
+# esphome/components/rp2040/ package shadowed the rp2 alias, failed every
+# config read, and made the app's wipe-and-recopy repair loop forever
+# (the repair re-copies the polluted bundle). The preinstall hook wipes the
+# bundled trees and resets the repair budget; the post-uninstall hook keeps a
+# real uninstall from stranding orphaned trees. The drift tests in
+# src/platform/windows.rs prove those hook lines were typed; only this proves
+# them against an actual install.
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. "$PSScriptRoot/e2e_windows_common.ps1"
+
+# Read the marker name from the Rust source rather than duplicating it; this
+# script asserting against its own copy would let the two drift without
+# anything failing.
+$healthSrc = Get-Content 'src-tauri/src/platform/health.rs' -Raw
+if ($healthSrc -notmatch 'REPAIR_COUNT_MARKER: &str = "([^"]+)"') {
+    throw 'could not read REPAIR_COUNT_MARKER from src/platform/health.rs'
+}
+$RepairCount = Join-Path $LocalDataDir $Matches[1]
+
+# One orphan probe per bundled tree, at the root, plus one shaped like the
+# field failure: a component package deep in site-packages that no release
+# manifest names. The overlay preserves all of them; the wipe must not.
+$Probes = @()
+foreach ($resource in $conf.bundle.resources) {
+    $Probes += Join-Path $InstallDir (Join-Path $resource 'overlay_orphan_probe.txt')
+}
+$Probes += Join-Path $InstallDir `
+    "$BundledPythonDirName\Lib\site-packages\esphome\components\rp2040\overlay_orphan_probe.py"
+
+function Add-Orphans {
+    foreach ($probe in $Probes) {
+        New-Item -ItemType Directory -Force (Split-Path $probe) | Out-Null
+        Set-Content -Path $probe -Value 'planted by e2e_windows_overlay_wipe' -Encoding ascii
+    }
+}
+
+# --- fresh install, then pollute it the way the overlay does ----------------
+Install-Bundle
+Add-Orphans
+New-Item -ItemType Directory -Force $LocalDataDir | Out-Null
+# 2 = MAX_REPAIRS: the budget a machine stuck in the repair loop has spent.
+Set-Content -Path $RepairCount -Value '2' -Encoding ascii
+
+# --- reinstall over it: the overlay path every update takes -----------------
+Install-Bundle
+foreach ($probe in $Probes) {
+    if (Test-Path $probe) {
+        throw "the overlay install kept $probe; the preinstall wipe did not run"
+    }
+}
+if (-not (Test-Path $BundledPython)) {
+    throw "the wipe ran but the reinstall left no bundled interpreter at $BundledPython"
+}
+if (Test-Path $RepairCount) {
+    throw "the reinstall kept $RepairCount; a budget-spent machine would refuse the repair the reinstall was meant to enable"
+}
+Write-Host 'PASS: the overlay install wiped the planted orphans and reset the repair budget'
+
+# --- a real uninstall must not strand orphaned trees ------------------------
+# The uninstaller deletes manifest-listed files with plain RMDir on the
+# ancestors, so without the post-uninstall wipe the planted orphan keeps the
+# whole python tree — and $INSTDIR itself — on disk forever.
+Add-Orphans
+Uninstall-Bundle
+if (-not (Wait-Until { -not (Test-Path $InstallDir) } 30)) {
+    $leftover = (Get-ChildItem $InstallDir -Recurse -File |
+        Select-Object -First 5 -ExpandProperty FullName) -join ', '
+    throw "a real uninstall stranded $InstallDir (leftovers: $leftover)"
+}
+Write-Host 'PASS: the real uninstall removed the orphaned trees and the install dir'

--- a/.github/scripts/e2e_windows_overlay_wipe.ps1
+++ b/.github/scripts/e2e_windows_overlay_wipe.ps1
@@ -114,9 +114,14 @@ finally {
     # that key when the uninstall page's delete-app-data checkbox is
     # ticked, which a silent /S uninstall never shows). Left behind, the
     # next plain Install-Bundle would restore $INSTDIR to the deleted
-    # scratch path. The manufacturer is the identifier's domain segment,
-    # the same derivation the bundler uses when no publisher is set.
-    $manufacturer = $conf.identifier.Split('.')[1]
-    Remove-Item -Path "HKCU:\Software\$manufacturer\$($conf.productName)" `
-        -Recurse -Force -ErrorAction SilentlyContinue
+    # scratch path. Found by scanning for the product name rather than
+    # composing the manufacturer (the bundler derives it from the
+    # identifier when no publisher is set): a derivation that drifted
+    # would turn a composed path into exactly the silent no-op this
+    # cleanup exists to prevent.
+    foreach ($vendor in Get-ChildItem 'HKCU:\Software' -ErrorAction SilentlyContinue) {
+        if ($vendor.GetSubKeyNames() -contains $conf.productName) {
+            Remove-Item -Path (Join-Path $vendor.PSPath $conf.productName) -Recurse -Force
+        }
+    }
 }

--- a/.github/scripts/e2e_windows_overlay_wipe.ps1
+++ b/.github/scripts/e2e_windows_overlay_wipe.ps1
@@ -80,6 +80,24 @@ if (-not (Wait-Until { -not (Test-Path $InstallDir) } 30)) {
 }
 Write-Host 'PASS: the real uninstall removed the orphaned trees and the install dir'
 
+# --- the default-dir sentinel: the heal path for a stuck machine ------------
+# Uninstall-then-reinstall — the remedy a stuck user tries by hand — deletes
+# both file sentinels while an old uninstaller strands the orphaned trees.
+# Recreate only the orphan in the default location, with no uninstall.exe
+# and no main exe beside it: the third sentinel must fire the wipe anyway.
+# This gate fails closed and silently (a comparison typo just skips the
+# wipe and the installer still exits 0), so only this case evaluates it.
+$strandedOrphan = Join-Path $InstallDir `
+    "$BundledPythonDirName\Lib\site-packages\esphome\components\rp2040\overlay_orphan_probe.py"
+New-Item -ItemType Directory -Force (Split-Path $strandedOrphan) | Out-Null
+Set-Content -Path $strandedOrphan -Value 'stranded by an old uninstaller' -Encoding ascii
+Install-Bundle
+if (Test-Path $strandedOrphan) {
+    throw "the default-dir sentinel did not fire: $strandedOrphan survived a reinstall into an uninstalled default location"
+}
+Write-Host 'PASS: the default-location sentinel wiped orphans with no install files present'
+Uninstall-Bundle
+
 # --- the wipes must NOT fire on a directory that was never ours -------------
 # The negative half of the destructive contract. $INSTDIR is user-selectable
 # (/D=), so a merged directory can hold a python/ tree that predates the

--- a/.github/scripts/e2e_windows_overlay_wipe.ps1
+++ b/.github/scripts/e2e_windows_overlay_wipe.ps1
@@ -120,8 +120,19 @@ finally {
     # would turn a composed path into exactly the silent no-op this
     # cleanup exists to prevent.
     foreach ($vendor in Get-ChildItem 'HKCU:\Software' -ErrorAction SilentlyContinue) {
-        if ($vendor.GetSubKeyNames() -contains $conf.productName) {
-            Remove-Item -Path (Join-Path $vendor.PSPath $conf.productName) -Recurse -Force
+        # try/catch per vendor: GetSubKeyNames() is a .NET call that throws
+        # terminatingly on an ACL-restricted subkey regardless of preference,
+        # and a throw from inside finally would replace the try body's real
+        # failure. -LiteralPath so a name containing [] is not a wildcard.
+        try {
+            if ($vendor.GetSubKeyNames() -contains $conf.productName) {
+                $key = Join-Path $vendor.PSPath $conf.productName
+                Write-Host "Clearing recorded install location $key"
+                Remove-Item -LiteralPath $key -Recurse -Force
+            }
+        }
+        catch {
+            Write-Host "Skipping unreadable registry key $($vendor.PSPath): $_"
         }
     }
 }

--- a/.github/scripts/e2e_windows_overlay_wipe.ps1
+++ b/.github/scripts/e2e_windows_overlay_wipe.ps1
@@ -109,4 +109,14 @@ try {
 }
 finally {
     Remove-Item -Recurse -Force $scratch -ErrorAction SilentlyContinue
+    # The scratch install recorded its location under
+    # HKCU\Software\<manufacturer>\<productName> (the template only clears
+    # that key when the uninstall page's delete-app-data checkbox is
+    # ticked, which a silent /S uninstall never shows). Left behind, the
+    # next plain Install-Bundle would restore $INSTDIR to the deleted
+    # scratch path. The manufacturer is the identifier's domain segment,
+    # the same derivation the bundler uses when no publisher is set.
+    $manufacturer = $conf.identifier.Split('.')[1]
+    Remove-Item -Path "HKCU:\Software\$manufacturer\$($conf.productName)" `
+        -Recurse -Force -ErrorAction SilentlyContinue
 }

--- a/.github/scripts/e2e_windows_overlay_wipe.ps1
+++ b/.github/scripts/e2e_windows_overlay_wipe.ps1
@@ -119,6 +119,7 @@ finally {
     # identifier when no publisher is set): a derivation that drifted
     # would turn a composed path into exactly the silent no-op this
     # cleanup exists to prevent.
+    $cleared = $false
     foreach ($vendor in Get-ChildItem 'HKCU:\Software' -ErrorAction SilentlyContinue) {
         # try/catch per vendor: GetSubKeyNames() is a .NET call that throws
         # terminatingly on an ACL-restricted subkey regardless of preference,
@@ -129,10 +130,17 @@ finally {
                 $key = Join-Path $vendor.PSPath $conf.productName
                 Write-Host "Clearing recorded install location $key"
                 Remove-Item -LiteralPath $key -Recurse -Force
+                $cleared = $true
             }
         }
         catch {
             Write-Host "Skipping unreadable registry key $($vendor.PSPath): $_"
         }
+    }
+    if (-not $cleared) {
+        # Loud on purpose: a scan that finds nothing means the template moved
+        # the key (or writes it to HKLM), and the stale record this cleanup
+        # exists to remove is back to surviving silently.
+        Write-Warning "no recorded install location found under HKCU:\Software\*\$($conf.productName); the cleanup may no longer match where the installer writes it"
     }
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -621,6 +621,19 @@ jobs:
         shell: pwsh
         run: ./.github/scripts/e2e_windows_firewall.ps1
 
+      # The overlay wipe (#417): the installer lays files over $INSTDIR
+      # without deleting the previous release's, so the preinstall hook must
+      # wipe the bundled trees (a stranded esphome component shadowed its
+      # rename alias, failed every config read, and made the repair loop
+      # forever) and reset the repair budget, and a real uninstall must not
+      # strand orphaned trees. The drift tests prove the hook lines exist;
+      # only this proves them against the real installer. Runs after the
+      # firewall script, which leaves the runner uninstalled.
+      - name: E2E overlay wipe (Windows CI)
+        if: matrix.platform == 'windows' && github.event_name != 'workflow_run'
+        shell: pwsh
+        run: ./.github/scripts/e2e_windows_overlay_wipe.ps1
+
       - name: Upload NSIS updater signature
         if: contains(matrix.bundles, 'nsis') && github.event_name == 'workflow_run'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/src-tauri/installer-hooks.nsi
+++ b/src-tauri/installer-hooks.nsi
@@ -42,10 +42,16 @@
   ; leftover lock is unexpected; if one survives anyway, RMDir /r is
   ; best-effort, which is no worse than today's overlay.
   ;
-  ; Gated on the previous install's uninstaller, not just the trees: a user
+  ; Gated on evidence the directory is ours, not just on the trees: a user
   ; pointing an interactive install at some unrelated non-empty directory
   ; must not lose a python/, git/ or ccache/ folder that was never ours.
+  ; This RMDir /r is the only recursive delete this installer performs (the
+  ; stock template's uninstall deletes per manifest entry), so it must be
+  ; impossible to fire on a directory we did not create. Either sentinel
+  ; proves a previous install: uninstall.exe is written by every install,
+  ; and the main exe covers a tree whose uninstaller was manually removed.
   ${If} ${FileExists} "$INSTDIR\uninstall.exe"
+  ${OrIf} ${FileExists} "$INSTDIR\${MAINBINARYNAME}.exe"
     ${If} ${FileExists} "$INSTDIR\python\*.*"
     ${OrIf} ${FileExists} "$INSTDIR\git\*.*"
     ${OrIf} ${FileExists} "$INSTDIR\ccache\*.*"
@@ -62,11 +68,15 @@
   ; and only clears it once a probe passes — so on a machine whose budget was
   ; spent against the polluted bundle, reinstalling the *same* app version
   ; (no version-marker mismatch, so no refresh copy) would leave the broken
-  ; user tree in place with every repair refused. Must match
-  ; REPAIR_COUNT_MARKER in src/platform/health.rs (drift-tested in
-  ; src/platform/windows.rs).
-  Delete "$LOCALAPPDATA\io.esphome.builder\.repair-count"
+  ; user tree in place with every repair refused.
+  Delete "$LOCALAPPDATA\io.esphome.builder\${REPAIR_COUNT_MARKER}"
 !macroend
+
+; The app's counter bounding probe-triggered repairs; must match
+; REPAIR_COUNT_MARKER in src/platform/health.rs (drift-tested in
+; src/platform/windows.rs). Deleted on every install so a reinstall starts
+; with a fresh budget; a real uninstall removes the whole data dir anyway.
+!define REPAIR_COUNT_MARKER ".repair-count"
 
 ; On first run the app offers to add an inbound firewall rule for the managed
 ; Python interpreter so other dashboards can pair with this machine (issue

--- a/src-tauri/installer-hooks.nsi
+++ b/src-tauri/installer-hooks.nsi
@@ -45,9 +45,10 @@
   ; Gated on evidence the directory is ours, not just on the trees: a user
   ; pointing an interactive install at some unrelated non-empty directory
   ; must not lose a python/, git/ or ccache/ folder that was never ours.
-  ; The stock template performs no recursive deletes of its own (its
-  ; uninstall is manifest-entry Deletes plus plain RMDir), so these hooks
-  ; own every recursive delete in the installer — and this one must be
+  ; The stock template never recurses under $INSTDIR (its uninstall is
+  ; manifest-entry Deletes plus plain RMDir there; its only recursive
+  ; deletes target the app-data dirs on a real uninstall), so these hooks
+  ; own every recursive delete under the install dir — and this one must be
   ; impossible to fire on a directory we did not create. Either sentinel
   ; proves a previous install: uninstall.exe is written by every install,
   ; and the main exe covers a tree whose uninstaller was manually removed.

--- a/src-tauri/installer-hooks.nsi
+++ b/src-tauri/installer-hooks.nsi
@@ -19,6 +19,47 @@
   ${EndIf}
   Delete "$SMPROGRAMS\ESPHome Builder.lnk"
   Delete "$DESKTOP\ESPHome Builder.lnk"
+
+  ; The generated installer lays resources down file by file over $INSTDIR
+  ; without deleting the previous release's files, so the bundled Python's
+  ; site-packages accumulates every past release's dist-info dirs and any
+  ; module the new release no longer ships. Those orphans are not inert:
+  ; after esphome renamed the rp2040 component to rp2, the stranded
+  ; components/rp2040/ package made every config read fail ("Component alias
+  ; 'rp2040' ... shadows an existing component package"), and the app's
+  ; wipe-and-recopy repair could never converge because the copy source
+  ; itself carried the orphan. Wipe the previous resource trees so every
+  ; install lays down a pristine copy. git and ccache are overlaid the same
+  ; way; their leftovers are only inert bloat (self-contained tools, nothing
+  ; scans their trees), but the same wipe closes the whole class. The app
+  ; never writes into these trees, so nothing user-mutable is lost.
+  ;
+  ; CheckIfAppIsRunning is inserted before the wipe even though the template
+  ; repeats it right after this hook (the second pass is then a no-op): on an
+  ; interactive install the user can still cancel at that prompt, and a
+  ; cancel after the wipe would leave a gutted install behind. The in-app
+  ; updater stops the Python daemon before launching this installer, so a
+  ; leftover lock is unexpected; if one survives anyway, RMDir /r is
+  ; best-effort, which is no worse than today's overlay.
+  ${If} ${FileExists} "$INSTDIR\python\*.*"
+  ${OrIf} ${FileExists} "$INSTDIR\git\*.*"
+  ${OrIf} ${FileExists} "$INSTDIR\ccache\*.*"
+    !insertmacro CheckIfAppIsRunning "${MAINBINARYNAME}.exe" "${PRODUCTNAME}"
+    DetailPrint "Removing the previous release's bundled tools..."
+    RMDir /r "$INSTDIR\python"
+    RMDir /r "$INSTDIR\git"
+    RMDir /r "$INSTDIR\ccache"
+  ${EndIf}
+
+  ; A fresh install lays down a pristine bundle, so it deserves a fresh
+  ; repair budget. The app bounds probe-triggered repairs with this counter
+  ; and only clears it once a probe passes — so on a machine whose budget was
+  ; spent against the polluted bundle, reinstalling the *same* app version
+  ; (no version-marker mismatch, so no refresh copy) would leave the broken
+  ; user tree in place with every repair refused. Must match
+  ; REPAIR_COUNT_MARKER in src/platform/health.rs (drift-tested in
+  ; src/platform/windows.rs).
+  Delete "$LOCALAPPDATA\io.esphome.builder\.repair-count"
 !macroend
 
 ; On first run the app offers to add an inbound firewall rule for the managed

--- a/src-tauri/installer-hooks.nsi
+++ b/src-tauri/installer-hooks.nsi
@@ -41,14 +41,20 @@
   ; updater stops the Python daemon before launching this installer, so a
   ; leftover lock is unexpected; if one survives anyway, RMDir /r is
   ; best-effort, which is no worse than today's overlay.
-  ${If} ${FileExists} "$INSTDIR\python\*.*"
-  ${OrIf} ${FileExists} "$INSTDIR\git\*.*"
-  ${OrIf} ${FileExists} "$INSTDIR\ccache\*.*"
-    !insertmacro CheckIfAppIsRunning "${MAINBINARYNAME}.exe" "${PRODUCTNAME}"
-    DetailPrint "Removing the previous release's bundled tools..."
-    RMDir /r "$INSTDIR\python"
-    RMDir /r "$INSTDIR\git"
-    RMDir /r "$INSTDIR\ccache"
+  ;
+  ; Gated on the previous install's uninstaller, not just the trees: a user
+  ; pointing an interactive install at some unrelated non-empty directory
+  ; must not lose a python/, git/ or ccache/ folder that was never ours.
+  ${If} ${FileExists} "$INSTDIR\uninstall.exe"
+    ${If} ${FileExists} "$INSTDIR\python\*.*"
+    ${OrIf} ${FileExists} "$INSTDIR\git\*.*"
+    ${OrIf} ${FileExists} "$INSTDIR\ccache\*.*"
+      !insertmacro CheckIfAppIsRunning "${MAINBINARYNAME}.exe" "${PRODUCTNAME}"
+      DetailPrint "Removing the previous release's bundled tools..."
+      RMDir /r "$INSTDIR\python"
+      RMDir /r "$INSTDIR\git"
+      RMDir /r "$INSTDIR\ccache"
+    ${EndIf}
   ${EndIf}
 
   ; A fresh install lays down a pristine bundle, so it deserves a fresh

--- a/src-tauri/installer-hooks.nsi
+++ b/src-tauri/installer-hooks.nsi
@@ -52,8 +52,15 @@
   ; impossible to fire on a directory we did not create. Either sentinel
   ; proves a previous install: uninstall.exe is written by every install,
   ; and the main exe covers a tree whose uninstaller was manually removed.
+  ; The default install dir is a third sentinel: a real uninstall deletes
+  ; the other two while (before this PR's post-uninstall wipe, or from a
+  ; custom dir) stranding the orphaned trees — and uninstall-then-reinstall
+  ; is exactly the remedy a stuck user tries by hand. In our own default
+  ; location the trees are ours by the same argument the post-uninstall
+  ; gate stands on.
   ${If} ${FileExists} "$INSTDIR\uninstall.exe"
   ${OrIf} ${FileExists} "$INSTDIR\${MAINBINARYNAME}.exe"
+  ${OrIf} $INSTDIR == "$LOCALAPPDATA\${PRODUCTNAME}"
     ${If} ${FileExists} "$INSTDIR\python\*.*"
     ${OrIf} ${FileExists} "$INSTDIR\git\*.*"
     ${OrIf} ${FileExists} "$INSTDIR\ccache\*.*"

--- a/src-tauri/installer-hooks.nsi
+++ b/src-tauri/installer-hooks.nsi
@@ -45,8 +45,9 @@
   ; Gated on evidence the directory is ours, not just on the trees: a user
   ; pointing an interactive install at some unrelated non-empty directory
   ; must not lose a python/, git/ or ccache/ folder that was never ours.
-  ; This RMDir /r is the only recursive delete this installer performs (the
-  ; stock template's uninstall deletes per manifest entry), so it must be
+  ; The stock template performs no recursive deletes of its own (its
+  ; uninstall is manifest-entry Deletes plus plain RMDir), so these hooks
+  ; own every recursive delete in the installer — and this one must be
   ; impossible to fire on a directory we did not create. Either sentinel
   ; proves a previous install: uninstall.exe is written by every install,
   ; and the main exe covers a tree whose uninstaller was manually removed.
@@ -109,6 +110,12 @@
     RMDir /r "$INSTDIR\python"
     RMDir /r "$INSTDIR\git"
     RMDir /r "$INSTDIR\ccache"
+    ; The template's own RMDir "$INSTDIR" runs before this hook is inserted
+    ; and fails while the orphaned trees are still non-empty; retry now that
+    ; they are gone. Non-recursive on purpose — anything still in here is
+    ; not ours to delete — and a no-op in the _?= in-place mode, which
+    ; deliberately leaves uninstall.exe behind.
+    RMDir "$INSTDIR"
     Delete "$LOCALAPPDATA\io.esphome.builder\${FIREWALL_PROMPT_MARKER}"
     nsExec::ExecToStack '"$SYSDIR\netsh.exe" advfirewall firewall show rule name="${FIREWALL_RULE_NAME}"'
     Pop $0

--- a/src-tauri/installer-hooks.nsi
+++ b/src-tauri/installer-hooks.nsi
@@ -99,6 +99,16 @@
 ; user-writable directory into that elevation.
 !macro NSIS_HOOK_POSTUNINSTALL
   ${If} $UpdateMode <> 1
+    ; The uninstaller only deletes manifest-listed files and uses plain
+    ; RMDir, so any file the overlay stranded (a previous release's module
+    ; that this release's manifest no longer names) keeps its whole tree —
+    ; and $INSTDIR itself — behind after a real uninstall. Finish the job
+    ; here. Safe by construction: the uninstaller runs from our own install
+    ; dir. Update-mode uninstalls keep the trees; the preinstall wipe owns
+    ; that path.
+    RMDir /r "$INSTDIR\python"
+    RMDir /r "$INSTDIR\git"
+    RMDir /r "$INSTDIR\ccache"
     Delete "$LOCALAPPDATA\io.esphome.builder\${FIREWALL_PROMPT_MARKER}"
     nsExec::ExecToStack '"$SYSDIR\netsh.exe" advfirewall firewall show rule name="${FIREWALL_RULE_NAME}"'
     Pop $0

--- a/src-tauri/installer-hooks.nsi
+++ b/src-tauri/installer-hooks.nsi
@@ -105,18 +105,24 @@
     ; RMDir, so any file the overlay stranded (a previous release's module
     ; that this release's manifest no longer names) keeps its whole tree —
     ; and $INSTDIR itself — behind after a real uninstall. Finish the job
-    ; here. Safe by construction: the uninstaller runs from our own install
-    ; dir. Update-mode uninstalls keep the trees; the preinstall wipe owns
-    ; that path.
-    RMDir /r "$INSTDIR\python"
-    RMDir /r "$INSTDIR\git"
-    RMDir /r "$INSTDIR\ccache"
-    ; The template's own RMDir "$INSTDIR" runs before this hook is inserted
-    ; and fails while the orphaned trees are still non-empty; retry now that
-    ; they are gone. Non-recursive on purpose — anything still in here is
-    ; not ours to delete — and a no-op in the _?= in-place mode, which
-    ; deliberately leaves uninstall.exe behind.
-    RMDir "$INSTDIR"
+    ; here — but only in the default install location. $INSTDIR is
+    ; user-selectable, and "the uninstaller runs from our install dir"
+    ; proves $INSTDIR is ours, not that a python/ subtree in a merged
+    ; directory (an install pointed at C:\Tools that already had one) is;
+    ; there a custom-dir uninstall keeps today's stranded-tree behavior
+    ; rather than gaining a data-loss path. Update-mode uninstalls keep the
+    ; trees everywhere; the preinstall wipe owns that path.
+    ${If} $INSTDIR == "$LOCALAPPDATA\${PRODUCTNAME}"
+      RMDir /r "$INSTDIR\python"
+      RMDir /r "$INSTDIR\git"
+      RMDir /r "$INSTDIR\ccache"
+      ; The template's own RMDir "$INSTDIR" runs before this hook is
+      ; inserted and fails while the orphaned trees are still non-empty;
+      ; retry now that they are gone. Non-recursive on purpose — anything
+      ; still in here is not ours to delete — and a no-op in the _?=
+      ; in-place mode, which deliberately leaves uninstall.exe behind.
+      RMDir "$INSTDIR"
+    ${EndIf}
     Delete "$LOCALAPPDATA\io.esphome.builder\${FIREWALL_PROMPT_MARKER}"
     nsExec::ExecToStack '"$SYSDIR\netsh.exe" advfirewall firewall show rule name="${FIREWALL_RULE_NAME}"'
     Pop $0

--- a/src-tauri/src/platform/health.rs
+++ b/src-tauri/src/platform/health.rs
@@ -82,7 +82,11 @@ fn make_probe_dir() -> Result<PathBuf> {
 /// very repair it exists to bound: every launch would read zero, wipe,
 /// re-copy, and do it again forever — exactly the loop [`MAX_REPAIRS`] is
 /// here to stop.
-const REPAIR_COUNT_MARKER: &str = ".repair-count";
+/// Also deleted by the installer (`installer-hooks.nsi`, drift-tested in
+/// `windows.rs`): a fresh install lays down a pristine bundle, so it deserves
+/// a fresh budget — without that, "reinstall the app" leaves a budget-spent
+/// machine refusing the very repair the reinstall was meant to enable.
+pub(crate) const REPAIR_COUNT_MARKER: &str = ".repair-count";
 
 /// Maximum repairs triggered by a failing health probe before giving up.
 ///

--- a/src-tauri/src/platform/windows.rs
+++ b/src-tauri/src/platform/windows.rs
@@ -261,17 +261,21 @@ mod tests {
     /// wipe-and-recopy repair loop forever because the copy source itself
     /// carried the orphan. The wipe lives in `installer-hooks.nsi`; this
     /// pins it there for every bundled tree the app ships.
-    #[test]
-    fn installer_hook_wipes_the_previous_bundled_trees() {
-        // Comment lines are filtered before every match below: the prose
-        // around the hooks quotes the same statements, and matching raw text
-        // would keep the test green with a statement deleted (or redden it
-        // over a comment edit).
-        let code: String = include_str!("../../installer-hooks.nsi")
+    /// `installer-hooks.nsi` with its comment lines removed. Every drift
+    /// assertion matches against this: the prose around the hooks quotes the
+    /// same statements, and matching raw text would keep a test green with a
+    /// statement deleted (or redden it over a comment edit).
+    fn installer_hook_code() -> String {
+        include_str!("../../installer-hooks.nsi")
             .lines()
             .filter(|line| !line.trim_start().starts_with(';'))
             .collect::<Vec<_>>()
-            .join("\n");
+            .join("\n")
+    }
+
+    #[test]
+    fn installer_hook_wipes_the_previous_bundled_trees() {
+        let code = installer_hook_code();
         let hooks = code.as_str();
         // The authoritative list of overlaid trees is `bundle.resources`: a
         // resource dir added there without a matching wipe would quietly
@@ -343,7 +347,8 @@ mod tests {
     /// triggers no refresh copy that would let one pass).
     #[test]
     fn installer_hook_resets_the_repair_budget() {
-        let hooks = include_str!("../../installer-hooks.nsi");
+        let code = installer_hook_code();
+        let hooks = code.as_str();
         assert!(
             hooks.contains(&format!(
                 "!define REPAIR_COUNT_MARKER \"{}\"",

--- a/src-tauri/src/platform/windows.rs
+++ b/src-tauri/src/platform/windows.rs
@@ -252,4 +252,41 @@ mod tests {
             "installer-hooks.nsi must delete the marker under the bundle identifier's local data dir"
         );
     }
+
+    /// Each install must lay down pristine resource trees. The generated
+    /// installer overlays `$INSTDIR` without deleting the previous release's
+    /// files, and a polluted bundled site-packages breaks esphome outright:
+    /// the stranded `components/rp2040/` package shadowed the `rp2` alias
+    /// after the rename, failed every config read, and made the
+    /// wipe-and-recopy repair loop forever because the copy source itself
+    /// carried the orphan. The wipe lives in `installer-hooks.nsi`; this
+    /// pins it there for every bundled tree the app ships.
+    #[test]
+    fn installer_hook_wipes_the_previous_bundled_trees() {
+        let hooks = include_str!("../../installer-hooks.nsi");
+        for dir in ["python", "git", "ccache"] {
+            assert!(
+                hooks.contains(&format!("RMDir /r \"$INSTDIR\\{dir}\"")),
+                "installer-hooks.nsi must wipe the previous bundled {dir} tree before the overlay"
+            );
+        }
+    }
+
+    /// A fresh install lays down a pristine bundle, so the installer grants a
+    /// fresh repair budget; without it, reinstalling the same app version on
+    /// a budget-spent machine leaves every repair refused (the app only
+    /// clears the counter once a probe passes, and a same-version reinstall
+    /// triggers no refresh copy that would let one pass).
+    #[test]
+    fn installer_hook_resets_the_repair_budget() {
+        let hooks = include_str!("../../installer-hooks.nsi");
+        assert!(
+            hooks.contains(&format!(
+                "Delete \"$LOCALAPPDATA\\{}\\{}\"",
+                super::super::BUNDLE_IDENTIFIER,
+                super::super::health::REPAIR_COUNT_MARKER
+            )),
+            "installer-hooks.nsi must delete the repair counter so a reinstall gets a fresh budget"
+        );
+    }
 }

--- a/src-tauri/src/platform/windows.rs
+++ b/src-tauri/src/platform/windows.rs
@@ -253,14 +253,6 @@ mod tests {
         );
     }
 
-    /// Each install must lay down pristine resource trees. The generated
-    /// installer overlays `$INSTDIR` without deleting the previous release's
-    /// files, and a polluted bundled site-packages breaks esphome outright:
-    /// the stranded `components/rp2040/` package shadowed the `rp2` alias
-    /// after the rename, failed every config read, and made the
-    /// wipe-and-recopy repair loop forever because the copy source itself
-    /// carried the orphan. The wipe lives in `installer-hooks.nsi`; this
-    /// pins it there for every bundled tree the app ships.
     /// `installer-hooks.nsi` with its comment lines removed. Every drift
     /// assertion matches against this: the prose around the hooks quotes the
     /// same statements, and matching raw text would keep a test green with a
@@ -273,6 +265,14 @@ mod tests {
             .join("\n")
     }
 
+    /// Each install must lay down pristine resource trees. The generated
+    /// installer overlays `$INSTDIR` without deleting the previous release's
+    /// files, and a polluted bundled site-packages breaks esphome outright:
+    /// the stranded `components/rp2040/` package shadowed the `rp2` alias
+    /// after the rename, failed every config read, and made the
+    /// wipe-and-recopy repair loop forever because the copy source itself
+    /// carried the orphan. The wipe lives in `installer-hooks.nsi`; this
+    /// pins it there for every bundled tree the app ships.
     #[test]
     fn installer_hook_wipes_the_previous_bundled_trees() {
         let code = installer_hook_code();

--- a/src-tauri/src/platform/windows.rs
+++ b/src-tauri/src/platform/windows.rs
@@ -270,6 +270,14 @@ mod tests {
                 "installer-hooks.nsi must wipe the previous bundled {dir} tree before the overlay"
             );
         }
+        // The wipe must only fire on a directory that provably holds a
+        // previous install: an interactive install pointed at an unrelated
+        // non-empty directory must not delete a python/, git/ or ccache/
+        // folder that was never ours.
+        assert!(
+            hooks.contains("${If} ${FileExists} \"$INSTDIR\\uninstall.exe\""),
+            "installer-hooks.nsi must gate the wipe on the previous install's uninstaller"
+        );
     }
 
     /// A fresh install lays down a pristine bundle, so the installer grants a

--- a/src-tauri/src/platform/windows.rs
+++ b/src-tauri/src/platform/windows.rs
@@ -298,9 +298,15 @@ mod tests {
         }
         // The template's own RMDir "$INSTDIR" runs before the post-uninstall
         // hook, so the hook must retry it after emptying the trees or a real
-        // uninstall strands an empty install dir forever.
+        // uninstall strands an empty install dir forever. Comment lines are
+        // filtered first: the prose explaining the retry spells the same
+        // statement, and a contains() over the whole file would stay green
+        // with the statement itself deleted.
         assert!(
-            hooks.contains("RMDir \"$INSTDIR\""),
+            hooks
+                .lines()
+                .filter(|line| !line.trim_start().starts_with(';'))
+                .any(|line| line.trim() == "RMDir \"$INSTDIR\""),
             "installer-hooks.nsi must retry removing $INSTDIR after the post-uninstall wipe"
         );
         // The wipe must only fire on a directory that provably holds a

--- a/src-tauri/src/platform/windows.rs
+++ b/src-tauri/src/platform/windows.rs
@@ -264,7 +264,26 @@ mod tests {
     #[test]
     fn installer_hook_wipes_the_previous_bundled_trees() {
         let hooks = include_str!("../../installer-hooks.nsi");
-        for dir in ["python", "git", "ccache"] {
+        // The authoritative list of overlaid trees is `bundle.resources`: a
+        // resource dir added there without a matching wipe would quietly
+        // start accumulating the previous release's files again — the exact
+        // class of rot the wipe exists to stop.
+        let conf: serde_json::Value = serde_json::from_str(include_str!("../../tauri.conf.json"))
+            .expect("tauri.conf.json must parse");
+        let resources: Vec<&str> = conf["bundle"]["resources"]
+            .as_array()
+            .expect("bundle.resources must be an array")
+            .iter()
+            .map(|r| {
+                r.as_str()
+                    .expect("bundle.resources entries must be plain dir names")
+            })
+            .collect();
+        assert!(
+            !resources.is_empty(),
+            "bundle.resources is empty; the wipe drift test has nothing to pin"
+        );
+        for dir in &resources {
             assert!(
                 hooks.contains(&format!("RMDir /r \"$INSTDIR\\{dir}\"")),
                 "installer-hooks.nsi must wipe the previous bundled {dir} tree before the overlay"
@@ -274,10 +293,15 @@ mod tests {
         // previous install: an interactive install pointed at an unrelated
         // non-empty directory must not delete a python/, git/ or ccache/
         // folder that was never ours.
-        assert!(
-            hooks.contains("${If} ${FileExists} \"$INSTDIR\\uninstall.exe\""),
-            "installer-hooks.nsi must gate the wipe on the previous install's uninstaller"
-        );
+        for sentinel in [
+            "${If} ${FileExists} \"$INSTDIR\\uninstall.exe\"",
+            "${OrIf} ${FileExists} \"$INSTDIR\\${MAINBINARYNAME}.exe\"",
+        ] {
+            assert!(
+                hooks.contains(sentinel),
+                "installer-hooks.nsi must gate the wipe on a previous-install sentinel: {sentinel}"
+            );
+        }
     }
 
     /// A fresh install lays down a pristine bundle, so the installer grants a
@@ -290,9 +314,15 @@ mod tests {
         let hooks = include_str!("../../installer-hooks.nsi");
         assert!(
             hooks.contains(&format!(
-                "Delete \"$LOCALAPPDATA\\{}\\{}\"",
-                super::super::BUNDLE_IDENTIFIER,
+                "!define REPAIR_COUNT_MARKER \"{}\"",
                 super::super::health::REPAIR_COUNT_MARKER
+            )),
+            "installer-hooks.nsi must define the same repair-count marker name"
+        );
+        assert!(
+            hooks.contains(&format!(
+                "Delete \"$LOCALAPPDATA\\{}\\${{REPAIR_COUNT_MARKER}}\"",
+                super::super::BUNDLE_IDENTIFIER
             )),
             "installer-hooks.nsi must delete the repair counter so a reinstall gets a fresh budget"
         );

--- a/src-tauri/src/platform/windows.rs
+++ b/src-tauri/src/platform/windows.rs
@@ -296,6 +296,13 @@ mod tests {
                  and after a real uninstall"
             );
         }
+        // The template's own RMDir "$INSTDIR" runs before the post-uninstall
+        // hook, so the hook must retry it after emptying the trees or a real
+        // uninstall strands an empty install dir forever.
+        assert!(
+            hooks.contains("RMDir \"$INSTDIR\""),
+            "installer-hooks.nsi must retry removing $INSTDIR after the post-uninstall wipe"
+        );
         // The wipe must only fire on a directory that provably holds a
         // previous install: an interactive install pointed at an unrelated
         // non-empty directory must not delete a python/, git/ or ccache/

--- a/src-tauri/src/platform/windows.rs
+++ b/src-tauri/src/platform/windows.rs
@@ -284,9 +284,16 @@ mod tests {
             "bundle.resources is empty; the wipe drift test has nothing to pin"
         );
         for dir in &resources {
-            assert!(
-                hooks.contains(&format!("RMDir /r \"$INSTDIR\\{dir}\"")),
-                "installer-hooks.nsi must wipe the previous bundled {dir} tree before the overlay"
+            // Twice: the preinstall wipe (before the overlay) and the
+            // post-uninstall wipe (the manifest-only uninstall strands
+            // orphaned files, keeping the tree and $INSTDIR behind).
+            assert_eq!(
+                hooks
+                    .matches(&format!("RMDir /r \"$INSTDIR\\{dir}\""))
+                    .count(),
+                2,
+                "installer-hooks.nsi must wipe the bundled {dir} tree both before the overlay \
+                 and after a real uninstall"
             );
         }
         // The wipe must only fire on a directory that provably holds a

--- a/src-tauri/src/platform/windows.rs
+++ b/src-tauri/src/platform/windows.rs
@@ -263,7 +263,16 @@ mod tests {
     /// pins it there for every bundled tree the app ships.
     #[test]
     fn installer_hook_wipes_the_previous_bundled_trees() {
-        let hooks = include_str!("../../installer-hooks.nsi");
+        // Comment lines are filtered before every match below: the prose
+        // around the hooks quotes the same statements, and matching raw text
+        // would keep the test green with a statement deleted (or redden it
+        // over a comment edit).
+        let code: String = include_str!("../../installer-hooks.nsi")
+            .lines()
+            .filter(|line| !line.trim_start().starts_with(';'))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let hooks = code.as_str();
         // The authoritative list of overlaid trees is `bundle.resources`: a
         // resource dir added there without a matching wipe would quietly
         // start accumulating the previous release's files again — the exact
@@ -298,16 +307,19 @@ mod tests {
         }
         // The template's own RMDir "$INSTDIR" runs before the post-uninstall
         // hook, so the hook must retry it after emptying the trees or a real
-        // uninstall strands an empty install dir forever. Comment lines are
-        // filtered first: the prose explaining the retry spells the same
-        // statement, and a contains() over the whole file would stay green
-        // with the statement itself deleted.
+        // uninstall strands an empty install dir forever.
         assert!(
             hooks
                 .lines()
-                .filter(|line| !line.trim_start().starts_with(';'))
                 .any(|line| line.trim() == "RMDir \"$INSTDIR\""),
             "installer-hooks.nsi must retry removing $INSTDIR after the post-uninstall wipe"
+        );
+        // The post-uninstall wipe must stay confined to the default install
+        // location: $INSTDIR is user-selectable, and a merged directory can
+        // hold a python/ tree that predates us.
+        assert!(
+            hooks.contains(r#"${If} $INSTDIR == "$LOCALAPPDATA\${PRODUCTNAME}""#),
+            "installer-hooks.nsi must gate the post-uninstall wipe to the default install dir"
         );
         // The wipe must only fire on a directory that provably holds a
         // previous install: an interactive install pointed at an unrelated

--- a/src-tauri/src/platform/windows.rs
+++ b/src-tauri/src/platform/windows.rs
@@ -332,6 +332,10 @@ mod tests {
         for sentinel in [
             "${If} ${FileExists} \"$INSTDIR\\uninstall.exe\"",
             "${OrIf} ${FileExists} \"$INSTDIR\\${MAINBINARYNAME}.exe\"",
+            // The default location counts as ours even with both files gone:
+            // uninstall-then-reinstall (the remedy a stuck user tries first)
+            // deletes them while an old uninstaller strands the orphans.
+            "${OrIf} $INSTDIR == \"$LOCALAPPDATA\\${PRODUCTNAME}\"",
         ] {
             assert!(
                 hooks.contains(sentinel),


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

On Windows, the app can get stuck in a startup "install is broken → repair → still broken" loop until the repair budget is spent, with every config read and compile failing on:

```
Component alias 'rp2040' (declared by 'rp2') shadows an existing component package of the same name.
```

**Root cause** (verified on an affected machine): the generated NSIS installer lays resources down file by file over `$INSTDIR` without deleting the previous release's files. The bundled Python's `site-packages` on the affected machine had accumulated dist-info dirs for esphome 2026.6.1, 2026.6.2, 2026.6.3, 2026.6.4 *and* 2026.7.3, plus every module those releases shipped. After esphome renamed the `rp2040` component to `rp2` (keeping `rp2040` as an alias), the stranded `esphome/components/rp2040/` package from 2026.6.x kept failing every config read. The app's repair correctly wipes the user tree and re-copies the bundle — but the copy source itself carries the orphan, so the repair can never converge, and after `MAX_REPAIRS` the budget is spent and the install stays broken. The post-copy `dedupe-all` prune doesn't help either: it removes stale dist-info *dirs*, not the module files they left behind.

**Why this only happens on Windows:** macOS updates replace the entire `.app` bundle, and Linux ships a single self-contained AppImage that is replaced atomically (and a deb upgrade lets dpkg delete files that vanished from the package). Only the Windows NSIS installer overlays the install dir in place without deleting the previous release's files.

**The fix**, entirely in the installer hooks:

- `NSIS_HOOK_PREINSTALL` wipes the previous `python`, `git` and `ccache` resource trees so every install lays down a pristine bundle. The wipe is gated on a previous-install sentinel (`uninstall.exe` or the main exe) so it can never fire on a directory we did not create, and `CheckIfAppIsRunning` is inserted before it (the template repeats it right after the hook, where the second pass becomes a no-op) so a running app is killed first — the Windows job object from #320/#321/#359 takes the Python backend and its children down with it — and an interactive cancel can't leave a gutted install behind.
- The hook also deletes the `.repair-count` marker: a fresh install lays down a pristine bundle and deserves a fresh repair budget. Without this, reinstalling the *same* app version on a budget-spent machine (no version-marker mismatch, so no refresh copy) would keep refusing the very repair the reinstall was meant to enable.
- `NSIS_HOOK_POSTUNINSTALL` runs the same wipe on a real (non-update) uninstall — the uninstaller only deletes manifest-listed files, so an orphan stranded the whole tree — and then retries the plain `RMDir "$INSTDIR"`, because the template's own attempt runs before the hook and fails while the trees are still non-empty. This wipe is confined to the default install location: `$INSTDIR` is user-selectable, so a custom-dir uninstall deliberately keeps today's stranded-tree behavior rather than gaining a recursive delete in a merged directory that may hold a pre-existing `python/`.
- Drift tests in `src/platform/windows.rs` pin the hooks against the Rust constants and derive the wiped-tree list from `bundle.resources` in `tauri.conf.json`, so a future resource dir cannot silently escape the wipe.
- A behavioral e2e (`.github/scripts/e2e_windows_overlay_wipe.ps1`, wired into the Windows CI leg on the existing `Install-Bundle` harness) proves it against the real installer: fresh install, orphan probes planted in every bundled tree (one shaped like the field failure) plus a spent `.repair-count`, overlay reinstall must clear them all, and a real uninstall must leave no install dir behind.

Existing broken installs heal automatically on the first update that ships this: the new installer wipes the polluted bundle, the app-version marker mismatch triggers a fresh user-tree copy regardless of the spent budget, the startup probe passes, and `clear_repair_count` resets the counter.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes https://github.com/esphome/esphome-desktop/issues/330

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tested on the relevant platform(s) (macOS, Windows, Linux).
