### PR TITLE
Resolve a real CPython for the Windows reaper tests

### DIFF
--- a/src-tauri/src/platform/process/mod.rs
+++ b/src-tauri/src/platform/process/mod.rs
@@ -1131,11 +1131,12 @@ mod tests {
     }
 
     /// Any *real* interpreter will do for the bounded-capture tests: they
-    /// exercise the process plumbing, not the bundled tree. Named rather than
-    /// probed for, so a host without it fails these tests loudly instead of
-    /// skipping them — a timeout test that quietly reports green is worse than
-    /// no timeout test. Every platform we build on has `python3` (the Python
-    /// jobs install it, and `prepare_bundle.sh` needs one regardless).
+    /// exercise the process plumbing, not the bundled tree. On Unix it is
+    /// named rather than probed for, so a host without it fails these tests
+    /// loudly instead of skipping them — a timeout test that quietly reports
+    /// green is worse than no timeout test. Every platform we build on has
+    /// `python3` (the Python jobs install it, and `prepare_bundle.sh` needs
+    /// one regardless). Windows needs the probing resolver below instead.
     #[cfg(not(target_os = "windows"))]
     fn test_python() -> std::path::PathBuf {
         std::path::PathBuf::from("python3")
@@ -1234,11 +1235,11 @@ mod tests {
                     return std::path::PathBuf::from(exe);
                 }
                 panic!(
-                    "no usable CPython found for the reaper tests ({}). The Microsoft \
+                    "no usable Python found for the reaper tests ({}). The Microsoft \
                      Store interpreter is rejected on purpose: its MSIX packaging creates \
                      child processes outside the parent's job hierarchy, which defeats the \
                      job-based reaping these tests assert on (#418). Install any \
-                     non-Store CPython (python.org, conda, MSYS2, ...) to run them.",
+                     non-Store Python (python.org, conda, MSYS2, ...) to run them.",
                     evidence.join("; ")
                 )
             })

--- a/src-tauri/src/platform/process/mod.rs
+++ b/src-tauri/src/platform/process/mod.rs
@@ -1088,10 +1088,12 @@ mod tests {
         // grandchild died with its job. Only the last attempt's missing pid is
         // a failure, so a slow runner gets headroom while the failure mode
         // stays loud.
+        // Resolved once, outside the retry loop, matching the timed sites.
+        let python = test_python();
         let mut last_err = None;
         for secs in [5, 10, 20] {
             let out = run_python_capture_bounded(
-                &test_python(),
+                &python,
                 [
                     "-c",
                     "import subprocess,sys,time; \

--- a/src-tauri/src/platform/process/mod.rs
+++ b/src-tauri/src/platform/process/mod.rs
@@ -949,11 +949,9 @@ mod tests {
     fn run_python_capture_bounded_kills_a_child_that_will_not_exit() {
         // The probe runs in front of daemon.start(); an unbounded child there
         // means the backend never starts and nothing says why.
-        let python = test_python();
-        let python = python.as_path();
         let started = std::time::Instant::now();
         let err = run_python_capture_bounded(
-            python,
+            &test_python(),
             ["-c", "import time; time.sleep(600)"],
             std::time::Duration::from_millis(300),
         )
@@ -1151,6 +1149,12 @@ mod tests {
         static PYTHON: std::sync::OnceLock<std::path::PathBuf> = std::sync::OnceLock::new();
         PYTHON
             .get_or_init(|| {
+                // Each candidate's fate is recorded so the panic reports what
+                // was actually observed: an absent `python` and a Store-alias
+                // `python` are different problems, and a message asserting a
+                // cause it never saw would misdirect exactly the way the
+                // original failure did.
+                let mut evidence: Vec<String> = Vec::new();
                 for (program, version_args) in [("python", &[][..]), ("py", &["-3"][..])] {
                     // Bounded with the module's own primitive: a hung
                     // candidate (a misbehaving shim) must not stall the
@@ -1161,24 +1165,35 @@ mod tests {
                     // UnicodeEncodeError for an install path under a
                     // non-ASCII user profile — either way a valid
                     // interpreter would be skipped or garbled.
-                    let Ok(out) = run_python_capture_bounded(
+                    let out = match run_python_capture_bounded(
                         std::path::Path::new(program),
                         version_args.iter().copied().chain([
                             "-c",
                             "import sys; sys.stdout.buffer.write(sys.executable.encode('utf-8'))",
                         ]),
                         std::time::Duration::from_secs(30),
-                    ) else {
-                        continue;
+                    ) {
+                        Ok(out) => out,
+                        Err(e) => {
+                            evidence.push(format!("`{program}` did not run: {e}"));
+                            continue;
+                        }
                     };
                     if !out.status.success() {
+                        evidence.push(format!(
+                            "`{program}` exited with {}: {}",
+                            out.status,
+                            tail_for_log(&String::from_utf8_lossy(&out.stderr))
+                        ));
                         continue;
                     }
                     let Ok(path) = std::str::from_utf8(&out.stdout) else {
+                        evidence.push(format!("`{program}` printed a non-UTF-8 sys.executable"));
                         continue;
                     };
                     let path = std::path::PathBuf::from(path.trim());
                     if path.as_os_str().is_empty() {
+                        evidence.push(format!("`{program}` printed an empty sys.executable"));
                         continue;
                     }
                     // A component check, not a substring one: a user dir
@@ -1187,16 +1202,21 @@ mod tests {
                         .components()
                         .any(|c| c.as_os_str().eq_ignore_ascii_case("WindowsApps"))
                     {
+                        evidence.push(format!(
+                            "`{program}` is the Microsoft Store interpreter at {}",
+                            path.display()
+                        ));
                         continue;
                     }
                     return path;
                 }
                 panic!(
-                    "no real CPython found: `python` resolves to the Microsoft Store alias \
-                     (or nothing) and the `py` launcher found no install. The Store Python's \
-                     MSIX packaging creates child processes outside the parent's job \
-                     hierarchy, which defeats the job-based reaping these tests assert on \
-                     (#418); install a python.org CPython to run them."
+                    "no usable CPython found for the reaper tests ({}). The Microsoft \
+                     Store interpreter is rejected on purpose: its MSIX packaging creates \
+                     child processes outside the parent's job hierarchy, which defeats the \
+                     job-based reaping these tests assert on (#418). Install a python.org \
+                     CPython to run them.",
+                    evidence.join("; ")
                 )
             })
             .clone()

--- a/src-tauri/src/platform/process/mod.rs
+++ b/src-tauri/src/platform/process/mod.rs
@@ -1153,18 +1153,36 @@ mod tests {
             .get_or_init(|| {
                 for (program, version_args) in [("python", &[][..]), ("py", &["-3"][..])] {
                     let mut cmd = std::process::Command::new(program);
-                    cmd.args(version_args)
-                        .args(["-c", "import sys; print(sys.executable)"]);
+                    // UTF-8 bytes straight to the pipe: `print()` would
+                    // encode with the console codepage when stdout is a
+                    // pipe, and can even raise UnicodeEncodeError for an
+                    // install path under a non-ASCII user profile — either
+                    // way a valid interpreter would be skipped or garbled.
+                    cmd.args(version_args).args([
+                        "-c",
+                        "import sys; sys.stdout.buffer.write(sys.executable.encode('utf-8'))",
+                    ]);
                     configure_no_window_command(&mut cmd);
                     let Ok(out) = cmd.output() else { continue };
                     if !out.status.success() {
                         continue;
                     }
-                    let path = String::from_utf8_lossy(&out.stdout).trim().to_string();
-                    if path.is_empty() || path.to_ascii_lowercase().contains("windowsapps") {
+                    let Ok(path) = std::str::from_utf8(&out.stdout) else {
+                        continue;
+                    };
+                    let path = std::path::PathBuf::from(path.trim());
+                    if path.as_os_str().is_empty() {
                         continue;
                     }
-                    return std::path::PathBuf::from(path);
+                    // A component check, not a substring one: a user dir
+                    // that merely contains the word must not be rejected.
+                    if path
+                        .components()
+                        .any(|c| c.as_os_str().eq_ignore_ascii_case("WindowsApps"))
+                    {
+                        continue;
+                    }
+                    return path;
                 }
                 panic!(
                     "no real CPython found: `python` resolves to the Microsoft Store alias \

--- a/src-tauri/src/platform/process/mod.rs
+++ b/src-tauri/src/platform/process/mod.rs
@@ -949,7 +949,8 @@ mod tests {
     fn run_python_capture_bounded_kills_a_child_that_will_not_exit() {
         // The probe runs in front of daemon.start(); an unbounded child there
         // means the backend never starts and nothing says why.
-        let python = Path::new(TEST_PYTHON);
+        let python = test_python();
+        let python = python.as_path();
         let started = std::time::Instant::now();
         let err = run_python_capture_bounded(
             python,
@@ -1035,7 +1036,7 @@ mod tests {
         // -- the point of #344 -- the grandchild must be dead afterwards.
         let started = std::time::Instant::now();
         let out = run_python_capture_bounded(
-            Path::new(TEST_PYTHON),
+            &test_python(),
             [
                 "-c",
                 "import subprocess,sys; sys.stderr.write('before\\n'); sys.stderr.flush(); \
@@ -1085,7 +1086,7 @@ mod tests {
         let mut last_err = None;
         for secs in [5, 10, 20] {
             let out = run_python_capture_bounded(
-                Path::new(TEST_PYTHON),
+                &test_python(),
                 [
                     "-c",
                     "import subprocess,sys,time; \
@@ -1113,7 +1114,7 @@ mod tests {
     #[test]
     fn run_python_capture_bounded_returns_output_within_the_deadline() {
         let out = run_python_capture_bounded(
-            Path::new(TEST_PYTHON),
+            &test_python(),
             ["-c", "print('hi')"],
             std::time::Duration::from_secs(60),
         )
@@ -1122,17 +1123,59 @@ mod tests {
         assert!(String::from_utf8_lossy(&out.stdout).contains("hi"));
     }
 
-    /// Any interpreter will do for the bounded-capture tests: they exercise the
-    /// process plumbing, not the bundled tree. Named rather than probed for, so a
-    /// host without it fails these tests loudly instead of skipping them — a
-    /// timeout test that quietly reports green is worse than no timeout test.
-    /// Every platform we build on has `python3` (the Python jobs install it, and
-    /// `prepare_bundle.sh` needs one regardless).
+    /// Any *real* interpreter will do for the bounded-capture tests: they
+    /// exercise the process plumbing, not the bundled tree. Named rather than
+    /// probed for, so a host without it fails these tests loudly instead of
+    /// skipping them — a timeout test that quietly reports green is worse than
+    /// no timeout test. Every platform we build on has `python3` (the Python
+    /// jobs install it, and `prepare_bundle.sh` needs one regardless).
     #[cfg(not(target_os = "windows"))]
-    const TEST_PYTHON: &str = "python3";
+    fn test_python() -> std::path::PathBuf {
+        std::path::PathBuf::from("python3")
+    }
 
+    /// On Windows, "any interpreter" has one exception: the first `python` on
+    /// PATH may be the Microsoft Store app-execution alias. That interpreter
+    /// is MSIX-packaged, and a packaged process's children are created
+    /// *outside* the parent's job hierarchy — so the grandchild silently
+    /// escapes the very job the reaper tests assert on, and they fail for a
+    /// reason that has nothing to do with the code under test (#418; the
+    /// direct child is still assigned fine, which is what made this
+    /// misleading). Ask each candidate for its `sys.executable` and reject
+    /// anything living under `WindowsApps`; the `py` launcher is the
+    /// fallback because it only ever resolves real CPython installs. A host
+    /// with only the Store Python still fails loudly — but now naming the
+    /// actual cause instead of blaming the reaper.
     #[cfg(target_os = "windows")]
-    const TEST_PYTHON: &str = "python";
+    fn test_python() -> std::path::PathBuf {
+        static PYTHON: std::sync::OnceLock<std::path::PathBuf> = std::sync::OnceLock::new();
+        PYTHON
+            .get_or_init(|| {
+                for (program, version_args) in [("python", &[][..]), ("py", &["-3"][..])] {
+                    let mut cmd = std::process::Command::new(program);
+                    cmd.args(version_args)
+                        .args(["-c", "import sys; print(sys.executable)"]);
+                    configure_no_window_command(&mut cmd);
+                    let Ok(out) = cmd.output() else { continue };
+                    if !out.status.success() {
+                        continue;
+                    }
+                    let path = String::from_utf8_lossy(&out.stdout).trim().to_string();
+                    if path.is_empty() || path.to_ascii_lowercase().contains("windowsapps") {
+                        continue;
+                    }
+                    return std::path::PathBuf::from(path);
+                }
+                panic!(
+                    "no real CPython found: `python` resolves to the Microsoft Store alias \
+                     (or nothing) and the `py` launcher found no install. The Store Python's \
+                     MSIX packaging creates child processes outside the parent's job \
+                     hierarchy, which defeats the job-based reaping these tests assert on \
+                     (#418); install a python.org CPython to run them."
+                )
+            })
+            .clone()
+    }
 
     #[test]
     fn head_for_log_does_not_split_a_multibyte_char() {

--- a/src-tauri/src/platform/process/mod.rs
+++ b/src-tauri/src/platform/process/mod.rs
@@ -1214,8 +1214,8 @@ mod tests {
                     "no usable CPython found for the reaper tests ({}). The Microsoft \
                      Store interpreter is rejected on purpose: its MSIX packaging creates \
                      child processes outside the parent's job hierarchy, which defeats the \
-                     job-based reaping these tests assert on (#418). Install a python.org \
-                     CPython to run them.",
+                     job-based reaping these tests assert on (#418). Install any \
+                     non-Store CPython (python.org, conda, MSYS2, ...) to run them.",
                     evidence.join("; ")
                 )
             })

--- a/src-tauri/src/platform/process/mod.rs
+++ b/src-tauri/src/platform/process/mod.rs
@@ -1178,7 +1178,9 @@ mod tests {
                         std::path::Path::new(program),
                         version_args.iter().copied().chain([
                             "-c",
-                            "import sys; sys.stdout.buffer.write(sys.executable.encode('utf-8'))",
+                            "import sys; sys.stdout.buffer.write('\\n'.join([sys.executable, \
+                             getattr(sys, '_base_executable', '') or '', sys.base_prefix])\
+                             .encode('utf-8'))",
                         ]),
                         std::time::Duration::from_secs(30),
                     ) {
@@ -1196,28 +1198,40 @@ mod tests {
                         ));
                         continue;
                     }
-                    let Ok(path) = std::str::from_utf8(&out.stdout) else {
+                    let Ok(report) = std::str::from_utf8(&out.stdout) else {
                         evidence.push(format!("`{program}` printed a non-UTF-8 sys.executable"));
                         continue;
                     };
-                    let path = std::path::PathBuf::from(path.trim());
-                    if path.as_os_str().is_empty() {
+                    let mut paths = report.lines().map(str::trim);
+                    let exe = paths.next().unwrap_or("");
+                    if exe.is_empty() {
                         evidence.push(format!("`{program}` printed an empty sys.executable"));
                         continue;
                     }
                     // A component check, not a substring one: a user dir
                     // that merely contains the word must not be rejected.
-                    if path
-                        .components()
-                        .any(|c| c.as_os_str().eq_ignore_ascii_case("WindowsApps"))
+                    let in_windows_apps = |p: &str| {
+                        std::path::Path::new(p)
+                            .components()
+                            .any(|c| c.as_os_str().eq_ignore_ascii_case("WindowsApps"))
+                    };
+                    // The base paths matter too: inside a venv,
+                    // sys.executable is the venv's own exe, so a venv
+                    // created from the packaged interpreter would slip a
+                    // WindowsApps-free path past a sys.executable-only
+                    // check while its base still carries the packaged
+                    // identity.
+                    if let Some(packaged) = std::iter::once(exe)
+                        .chain(paths)
+                        .find(|p| !p.is_empty() && in_windows_apps(p))
                     {
                         evidence.push(format!(
-                            "`{program}` is the Microsoft Store interpreter at {}",
-                            path.display()
+                            "`{program}` is (or wraps) the Microsoft Store interpreter at \
+                             {packaged}"
                         ));
                         continue;
                     }
-                    return path;
+                    return std::path::PathBuf::from(exe);
                 }
                 panic!(
                     "no usable CPython found for the reaper tests ({}). The Microsoft \

--- a/src-tauri/src/platform/process/mod.rs
+++ b/src-tauri/src/platform/process/mod.rs
@@ -949,9 +949,14 @@ mod tests {
     fn run_python_capture_bounded_kills_a_child_that_will_not_exit() {
         // The probe runs in front of daemon.start(); an unbounded child there
         // means the backend never starts and nothing says why.
+        // Resolved before the stopwatch: on Windows the first resolution can
+        // pay a candidate probe's full timeout, and that cost landing inside
+        // the elapsed assertion would blame the reaper for an interpreter
+        // problem — the misattribution class this resolver exists to remove.
+        let python = test_python();
         let started = std::time::Instant::now();
         let err = run_python_capture_bounded(
-            &test_python(),
+            &python,
             ["-c", "import time; time.sleep(600)"],
             std::time::Duration::from_millis(300),
         )
@@ -1032,9 +1037,11 @@ mod tests {
         // 0. The deadline must not stall (a grandchild on the pipe is why the
         // reader wait is bounded), the child's partial stderr must survive, and
         // -- the point of #344 -- the grandchild must be dead afterwards.
+        // Resolved before the stopwatch; see the sibling deadline test.
+        let python = test_python();
         let started = std::time::Instant::now();
         let out = run_python_capture_bounded(
-            &test_python(),
+            &python,
             [
                 "-c",
                 "import subprocess,sys; sys.stderr.write('before\\n'); sys.stderr.flush(); \

--- a/src-tauri/src/platform/process/mod.rs
+++ b/src-tauri/src/platform/process/mod.rs
@@ -1152,18 +1152,25 @@ mod tests {
         PYTHON
             .get_or_init(|| {
                 for (program, version_args) in [("python", &[][..]), ("py", &["-3"][..])] {
-                    let mut cmd = std::process::Command::new(program);
-                    // UTF-8 bytes straight to the pipe: `print()` would
-                    // encode with the console codepage when stdout is a
-                    // pipe, and can even raise UnicodeEncodeError for an
-                    // install path under a non-ASCII user profile — either
-                    // way a valid interpreter would be skipped or garbled.
-                    cmd.args(version_args).args([
-                        "-c",
-                        "import sys; sys.stdout.buffer.write(sys.executable.encode('utf-8'))",
-                    ]);
-                    configure_no_window_command(&mut cmd);
-                    let Ok(out) = cmd.output() else { continue };
+                    // Bounded with the module's own primitive: a hung
+                    // candidate (a misbehaving shim) must not stall the
+                    // whole suite before any bounded machinery is even
+                    // under test. UTF-8 bytes straight to the pipe:
+                    // `print()` would encode with the console codepage
+                    // when stdout is a pipe, and can even raise
+                    // UnicodeEncodeError for an install path under a
+                    // non-ASCII user profile — either way a valid
+                    // interpreter would be skipped or garbled.
+                    let Ok(out) = run_python_capture_bounded(
+                        std::path::Path::new(program),
+                        version_args.iter().copied().chain([
+                            "-c",
+                            "import sys; sys.stdout.buffer.write(sys.executable.encode('utf-8'))",
+                        ]),
+                        std::time::Duration::from_secs(30),
+                    ) else {
+                        continue;
+                    };
                     if !out.status.success() {
                         continue;
                     }


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

On a Windows machine where the first `python` on PATH is the **Microsoft Store app-execution alias**, `run_bounded_reaps_a_grandchild_on_timeout` and `run_bounded_reaps_a_grandchild_after_the_child_exits` fail deterministically with `grandchild pid N survived the bounded call; the tree was not reaped` (`WAIT_TIMEOUT`), while CI — whose setup-python installs real CPython — stays green.

**Root cause** (isolated with a standalone reproduction, per-hop `IsProcessInJob` probes, details in #418): the Store Python is MSIX-packaged, and a packaged process's children are created *outside* the parent's job hierarchy. `AssignProcessToJobObject` on the direct child succeeds and the child is in the job — but the grandchild it spawns silently escapes, so `TerminateJobObject` cannot reach it. The identical scenario against a real CPython reaps the whole tree. The reaper under test is correct; the interpreter the test resolved was the problem.

**The fix**: replace the Windows `TEST_PYTHON` constant with a resolver that asks each candidate for its `sys.executable` and rejects anything with a `WindowsApps` path component (case-insensitive), falling back to the `py` launcher (which only ever resolves real CPython installs). A host with only the Store Python still fails loudly — preserving the suite's deliberate "never silently green" property — but the panic now names the actual cause instead of blaming the reaper. Unix keeps the plain `python3` constant.

Review hardening on top of the initial resolver: candidate probes run through the module's own `run_python_capture_bounded` (30s bound, plus the isolation and no-window setup every other spawn here gets), `sys.executable` is written as UTF-8 bytes and decoded strictly so a console-codepage encode or a non-ASCII profile can't skip or garble a valid install, the panic carries per-candidate evidence (spawn failure, timeout, non-zero exit with stderr tail, Store path) so an unrelated failure is never misattributed, and the resolver is evaluated outside the tests' elapsed-time windows so a slow first resolution can't fail a timing assertion in the reaper's name.

**Production impact of the underlying quirk**: none for shipped builds — the daemon and every bounded call spawn the bundled CPython, whose descendants inherit job membership normally. The one exposure is the dev-build fallback that takes a bare `python` off PATH; on a Store-alias machine, job-based reaping would silently not cover that backend's descendants. Left as-is here since it is dev-only, but worth knowing.

Verified on the machine from #418: both tests go from deterministic failure to passing (resolver picks the `py` launcher's CPython), and the full suite is green (`cargo fmt --all --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-features`: 207 passed).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes https://github.com/esphome/esphome-desktop/issues/418

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tested on the relevant platform(s) (macOS, Windows, Linux).
