### PR TITLE
Strip the \\?\ prefix from the bundled resource dir on Windows

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1161,6 +1161,7 @@ dependencies = [
  "clap",
  "cocoa",
  "dirs 6.0.0",
+ "dunce",
  "libloading 0.9.0",
  "log",
  "nix",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -57,6 +57,9 @@ open = "5"
 # Home directory detection
 dirs = "6"
 
+# Strips the Windows \\?\ prefix from Tauri's resource dir (no-op elsewhere)
+dunce = "1"
+
 # System locale detection for UI translations
 sys-locale = "0.3"
 
@@ -71,9 +74,6 @@ tauri = { version = "2.11.2", features = ["image-png"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.62", features = ["Win32_System_Threading", "Win32_Foundation", "Win32_System_Console", "Win32_System_JobObjects", "Win32_Security", "Win32_System_SystemInformation"] }
-# Strips the \\?\ extended-length prefix from paths Tauri hands us; cmd.exe cannot
-# run such paths, see `platform::without_verbatim_prefix`.
-dunce = "1"
 
 # "Win32_System_Diagnostics_ToolHelp" is only needed to walk to the grandchild in
 # the job object test, so it stays out of the shipping binary's feature set.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -71,6 +71,9 @@ tauri = { version = "2.11.2", features = ["image-png"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.62", features = ["Win32_System_Threading", "Win32_Foundation", "Win32_System_Console", "Win32_System_JobObjects", "Win32_Security", "Win32_System_SystemInformation"] }
+# Strips the \\?\ extended-length prefix from paths Tauri hands us; cmd.exe cannot
+# run such paths, see `platform::without_verbatim_prefix`.
+dunce = "1"
 
 # "Win32_System_Diagnostics_ToolHelp" is only needed to walk to the grandchild in
 # the job object test, so it stays out of the shipping binary's feature set.

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -140,7 +140,9 @@ fn interpreter_in_tree(root: &Path) -> PathBuf {
 /// env var that sharun always sets, and fall back to exe-relative
 /// resolution for deb/AUR installs where `APPDIR` is absent.
 ///
-/// On macOS and Windows, Tauri's `resource_dir()` works correctly.
+/// On macOS and Windows, Tauri's `resource_dir()` points at the right place,
+/// but on Windows it comes back with the `\\?\` extended-length prefix (Tauri
+/// canonicalizes `current_exe()`), which [`without_verbatim_prefix`] removes.
 fn get_bundled_resource_dir(app_handle: &AppHandle) -> Result<PathBuf> {
     #[cfg(target_os = "linux")]
     {
@@ -178,12 +180,40 @@ fn get_bundled_resource_dir(app_handle: &AppHandle) -> Result<PathBuf> {
 
     #[cfg(not(target_os = "linux"))]
     {
-        let resource_dir = app_handle
-            .path()
-            .resource_dir()
-            .context("Failed to get resource directory")?;
+        let resource_dir = without_verbatim_prefix(
+            app_handle
+                .path()
+                .resource_dir()
+                .context("Failed to get resource directory")?,
+        );
         debug!("Bundled resource dir: {:?}", resource_dir);
         Ok(resource_dir)
+    }
+}
+
+/// Strip the Windows extended-length (`\\?\`) prefix from `path`.
+///
+/// Tauri's `resource_dir()` is derived from a canonicalized `current_exe()`,
+/// and `std::fs::canonicalize` on Windows returns verbatim paths such as
+/// `\\?\C:\Users\...\ESPHome Device Builder`. Everything we derive from the
+/// resource dir (the bundled Python, MinGit, ccache) is handed to the ESPHome
+/// backend either as an executable path or through `PATH`, and while
+/// `CreateProcess` accepts verbatim paths, `cmd.exe` does not: PlatformIO/SCons
+/// runs every build step through `cmd.exe`, so a `\\?\` ccache found on `PATH`
+/// fails each ESP8266 compile with "The system cannot find the path specified"
+/// (esphome/esphome#18399). Simplifying here keeps every derived path plain.
+///
+/// No-op on other platforms, and on Windows for paths without the prefix or
+/// ones `dunce` cannot safely express without it (verbatim UNC paths, reserved
+/// names, over-long paths); those are returned unchanged.
+fn without_verbatim_prefix(path: PathBuf) -> PathBuf {
+    #[cfg(target_os = "windows")]
+    {
+        dunce::simplified(&path).to_path_buf()
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        path
     }
 }
 
@@ -403,6 +433,22 @@ pub fn is_tray_supported() -> bool {
 mod tests {
     use super::*;
     use crate::util::unique_temp_dir;
+
+    #[test]
+    fn without_verbatim_prefix_leaves_plain_paths_alone() {
+        let plain = PathBuf::from("plain").join("resource dir");
+        assert_eq!(without_verbatim_prefix(plain.clone()), plain);
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn without_verbatim_prefix_strips_extended_length_prefix() {
+        let verbatim = PathBuf::from(r"\\?\C:\Program Files\ESPHome Device Builder");
+        assert_eq!(
+            without_verbatim_prefix(verbatim),
+            PathBuf::from(r"C:\Program Files\ESPHome Device Builder")
+        );
+    }
 
     /// Env var naming the real bundled Python tree the e2e test runs against.
     const E2E_TREE_ENV: &str = "ESPHOME_E2E_PYTHON_TREE";

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -140,11 +140,9 @@ fn interpreter_in_tree(root: &Path) -> PathBuf {
 /// env var that sharun always sets, and fall back to exe-relative
 /// resolution for deb/AUR installs where `APPDIR` is absent.
 ///
-/// On macOS and Windows, Tauri's `resource_dir()` points at the right place.
-/// On Windows the result is additionally normalized to a non-verbatim path
-/// where the plain form round-trips (see [`simplified_resource_dir`] for the
-/// shapes it cannot strip); the `env_path` callers that put derived dirs on
-/// `PATH` or into `GIT_SSL_CAINFO` rely on that normalization.
+/// On macOS and Windows, Tauri's `resource_dir()` points at the right place;
+/// on Windows the verbatim prefix is stripped where possible (see
+/// [`simplified_resource_dir`]), which the `env_path` callers rely on.
 fn get_bundled_resource_dir(app_handle: &AppHandle) -> Result<PathBuf> {
     #[cfg(target_os = "linux")]
     {
@@ -193,23 +191,16 @@ fn get_bundled_resource_dir(app_handle: &AppHandle) -> Result<PathBuf> {
     }
 }
 
-/// Strip the Windows `\\?\` extended-length prefix from the resource dir.
-///
-/// Tauri canonicalizes `current_exe()`, so on Windows `resource_dir()` is a
-/// verbatim `\\?\C:\...` path. Everything derived from it (bundled Python,
-/// MinGit, ccache) reaches the ESPHome backend as an executable path or
-/// through `PATH`; `CreateProcess` accepts verbatim paths but `cmd.exe`, which
-/// PlatformIO/SCons uses for every build step, does not, so a `\\?\` ccache on
-/// `PATH` fails every ESP8266 compile (esphome/esphome#18399). Stripping here
-/// keeps every derived path plain; no-op on macOS and for plain paths.
-///
-/// `dunce` declines to strip when the plain form would not round-trip
-/// (verbatim UNC shares, over-`MAX_PATH` totals, reserved names, non-Unicode);
-/// those paths pass through unchanged with a warning, since `cmd.exe` build
-/// steps are then likely to fail with the same opaque error as #18399.
-// Split out of the `AppHandle` resolution so it can be unit-tested, like the
-// env_path helpers; only the non-Linux branch calls it (the Linux resource dir
-// never comes from Tauri).
+/// Strip the Windows `\\?\` prefix Tauri's canonicalized `resource_dir()`
+/// carries: everything derived from it (bundled Python, MinGit, ccache)
+/// reaches the ESPHome backend through `PATH`, and `cmd.exe`, which
+/// PlatformIO/SCons uses for every build step, cannot run `\\?\` paths, so
+/// leaving it in fails every ESP8266 compile (esphome/esphome#18399).
+/// No-op on macOS and for plain paths. Shapes `dunce` cannot round-trip
+/// (verbatim UNC, over-`MAX_PATH`, reserved names, non-Unicode) pass through
+/// unchanged with a warning.
+// Split out of the `AppHandle` resolution so it can be unit-tested; only the
+// non-Linux branch calls it.
 #[cfg_attr(target_os = "linux", allow(dead_code))]
 fn simplified_resource_dir(dir: PathBuf) -> PathBuf {
     let simplified = dunce::simplified(&dir).to_path_buf();
@@ -224,10 +215,8 @@ fn simplified_resource_dir(dir: PathBuf) -> PathBuf {
 }
 
 /// True when `path` still carries the Windows `\\?\` verbatim prefix.
-///
-/// A plain byte comparison so the predicate is testable on every platform;
-/// the warning branch it guards is log-only, so an inert predicate would
-/// break nothing a compiler or the strip tests could notice.
+/// Byte comparison so the log-only warning branch is testable on every
+/// platform.
 #[cfg_attr(not(target_os = "windows"), allow(dead_code))]
 fn is_verbatim(path: &Path) -> bool {
     path.as_os_str().as_encoded_bytes().starts_with(br"\\?\")
@@ -450,18 +439,16 @@ mod tests {
     use super::*;
     use crate::util::unique_temp_dir;
 
-    /// Identity on plain paths, on every platform; also guards the helper's
-    /// existence, so dropping the call from the resolver shows up in review as
-    /// a dead function rather than silently.
+    /// Identity on plain paths, on every platform; dropping the resolver's
+    /// call then surfaces as dead code under `-D warnings`.
     #[test]
     fn simplified_resource_dir_leaves_plain_paths_alone() {
         let plain = PathBuf::from("plain").join("resource dir");
         assert_eq!(simplified_resource_dir(plain.clone()), plain);
     }
 
-    /// Byte-level check of the warning predicate; the branch it guards is
-    /// log-only, so this test is the only thing that fails when the pattern
-    /// stops matching real verbatim paths.
+    /// The warning branch is log-only, so only this test fails when the
+    /// predicate stops matching real verbatim paths.
     #[test]
     fn is_verbatim_detects_the_verbatim_prefix() {
         assert!(is_verbatim(Path::new(r"\\?\C:\Program Files\x")));
@@ -470,8 +457,8 @@ mod tests {
         assert!(!is_verbatim(Path::new(r"\\server\share\x")));
     }
 
-    /// A shape `dunce` declines to strip (verbatim UNC) passes through
-    /// unchanged and is still flagged verbatim, i.e. the warning would fire.
+    /// A shape `dunce` cannot strip (verbatim UNC) passes through unchanged
+    /// and still flags verbatim, so the warning would fire.
     #[cfg(target_os = "windows")]
     #[test]
     fn simplified_resource_dir_keeps_verbatim_unc_and_flags_it() {
@@ -481,8 +468,7 @@ mod tests {
         assert!(is_verbatim(&out));
     }
 
-    /// The shape Tauri produces on Windows (verbatim drive letter, spaces in
-    /// the name) comes back plain.
+    /// The shape Tauri produces on Windows comes back plain.
     #[cfg(target_os = "windows")]
     #[test]
     fn simplified_resource_dir_strips_verbatim_prefix() {

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -141,6 +141,9 @@ fn interpreter_in_tree(root: &Path) -> PathBuf {
 /// resolution for deb/AUR installs where `APPDIR` is absent.
 ///
 /// On macOS and Windows, Tauri's `resource_dir()` points at the right place.
+/// On Windows the result is additionally normalized to a non-verbatim path
+/// (see [`simplified_resource_dir`]); the `env_path` callers that put derived
+/// dirs on `PATH` or into `GIT_SSL_CAINFO` rely on that guarantee.
 fn get_bundled_resource_dir(app_handle: &AppHandle) -> Result<PathBuf> {
     #[cfg(target_os = "linux")]
     {
@@ -178,21 +181,49 @@ fn get_bundled_resource_dir(app_handle: &AppHandle) -> Result<PathBuf> {
 
     #[cfg(not(target_os = "linux"))]
     {
-        let resource_dir = app_handle
-            .path()
-            .resource_dir()
-            .context("Failed to get resource directory")?;
-        // Tauri canonicalizes `current_exe()`, so on Windows this is a `\\?\`
-        // extended-length path. Everything derived from it (bundled Python,
-        // MinGit, ccache) reaches the ESPHome backend as an executable path or
-        // through `PATH`; `CreateProcess` accepts such paths but `cmd.exe`, which
-        // PlatformIO/SCons uses for every build step, does not, so a `\\?\` ccache
-        // on `PATH` fails every ESP8266 compile (esphome/esphome#18399). Strip
-        // it here so every derived path is plain; no-op on macOS.
-        let resource_dir = dunce::simplified(&resource_dir).to_path_buf();
+        let resource_dir = simplified_resource_dir(
+            app_handle
+                .path()
+                .resource_dir()
+                .context("Failed to get resource directory")?,
+        );
         debug!("Bundled resource dir: {:?}", resource_dir);
         Ok(resource_dir)
     }
+}
+
+/// Strip the Windows `\\?\` extended-length prefix from the resource dir.
+///
+/// Tauri canonicalizes `current_exe()`, so on Windows `resource_dir()` is a
+/// verbatim `\\?\C:\...` path. Everything derived from it (bundled Python,
+/// MinGit, ccache) reaches the ESPHome backend as an executable path or
+/// through `PATH`; `CreateProcess` accepts verbatim paths but `cmd.exe`, which
+/// PlatformIO/SCons uses for every build step, does not, so a `\\?\` ccache on
+/// `PATH` fails every ESP8266 compile (esphome/esphome#18399). Stripping here
+/// keeps every derived path plain; no-op on macOS and for plain paths.
+///
+/// `dunce` declines to strip when the plain form would not round-trip
+/// (verbatim UNC shares, over-`MAX_PATH` totals, reserved names, non-Unicode);
+/// those paths pass through unchanged with a warning, since `cmd.exe` build
+/// steps are then likely to fail with the same opaque error as #18399.
+// Split out of the `AppHandle` resolution so it can be unit-tested, like the
+// env_path helpers; only the non-Linux branch calls it (the Linux resource dir
+// never comes from Tauri).
+#[cfg_attr(target_os = "linux", allow(dead_code))]
+fn simplified_resource_dir(dir: PathBuf) -> PathBuf {
+    let simplified = dunce::simplified(&dir).to_path_buf();
+    #[cfg(target_os = "windows")]
+    if simplified
+        .as_os_str()
+        .as_encoded_bytes()
+        .starts_with(br"\?")
+    {
+        tracing::warn!(
+            "Resource dir stayed verbatim: {:?}; cmd.exe build steps may fail",
+            simplified
+        );
+    }
+    simplified
 }
 
 /// Root of the pristine Python tree inside the bundled resources.
@@ -412,15 +443,25 @@ mod tests {
     use super::*;
     use crate::util::unique_temp_dir;
 
-    /// Pins the `dunce` behaviour `get_bundled_resource_dir` relies on for the
-    /// shape Tauri produces on Windows (drive letter, spaces in the name).
+    /// Identity on plain paths, on every platform; also guards the helper's
+    /// existence, so dropping the call from the resolver shows up in review as
+    /// a dead function rather than silently.
+    #[test]
+    fn simplified_resource_dir_leaves_plain_paths_alone() {
+        let plain = PathBuf::from("plain").join("resource dir");
+        assert_eq!(simplified_resource_dir(plain.clone()), plain);
+    }
+
+    /// The shape Tauri produces on Windows (verbatim drive letter, spaces in
+    /// the name) comes back plain.
     #[cfg(target_os = "windows")]
     #[test]
-    fn resource_dir_verbatim_prefix_is_stripped() {
-        let verbatim = Path::new(r"\\?\C:\Program Files\ESPHome Device Builder");
+    fn simplified_resource_dir_strips_verbatim_prefix() {
         assert_eq!(
-            dunce::simplified(verbatim),
-            Path::new(r"C:\Program Files\ESPHome Device Builder")
+            simplified_resource_dir(PathBuf::from(
+                r"\\?\C:\Program Files\ESPHome Device Builder"
+            )),
+            PathBuf::from(r"C:\Program Files\ESPHome Device Builder")
         );
     }
 

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -140,9 +140,7 @@ fn interpreter_in_tree(root: &Path) -> PathBuf {
 /// env var that sharun always sets, and fall back to exe-relative
 /// resolution for deb/AUR installs where `APPDIR` is absent.
 ///
-/// On macOS and Windows, Tauri's `resource_dir()` points at the right place,
-/// but on Windows it comes back with the `\\?\` extended-length prefix (Tauri
-/// canonicalizes `current_exe()`), which [`without_verbatim_prefix`] removes.
+/// On macOS and Windows, Tauri's `resource_dir()` points at the right place.
 fn get_bundled_resource_dir(app_handle: &AppHandle) -> Result<PathBuf> {
     #[cfg(target_os = "linux")]
     {
@@ -180,40 +178,20 @@ fn get_bundled_resource_dir(app_handle: &AppHandle) -> Result<PathBuf> {
 
     #[cfg(not(target_os = "linux"))]
     {
-        let resource_dir = without_verbatim_prefix(
-            app_handle
-                .path()
-                .resource_dir()
-                .context("Failed to get resource directory")?,
-        );
+        let resource_dir = app_handle
+            .path()
+            .resource_dir()
+            .context("Failed to get resource directory")?;
+        // Tauri canonicalizes `current_exe()`, so on Windows this is a `\\?\`
+        // extended-length path. Everything derived from it (bundled Python,
+        // MinGit, ccache) reaches the ESPHome backend as an executable path or
+        // through `PATH`; `CreateProcess` accepts such paths but `cmd.exe`, which
+        // PlatformIO/SCons uses for every build step, does not, so a `\\?\` ccache
+        // on `PATH` fails every ESP8266 compile (esphome/esphome#18399). Strip
+        // it here so every derived path is plain; no-op on macOS.
+        let resource_dir = dunce::simplified(&resource_dir).to_path_buf();
         debug!("Bundled resource dir: {:?}", resource_dir);
         Ok(resource_dir)
-    }
-}
-
-/// Strip the Windows extended-length (`\\?\`) prefix from `path`.
-///
-/// Tauri's `resource_dir()` is derived from a canonicalized `current_exe()`,
-/// and `std::fs::canonicalize` on Windows returns verbatim paths such as
-/// `\\?\C:\Users\...\ESPHome Device Builder`. Everything we derive from the
-/// resource dir (the bundled Python, MinGit, ccache) is handed to the ESPHome
-/// backend either as an executable path or through `PATH`, and while
-/// `CreateProcess` accepts verbatim paths, `cmd.exe` does not: PlatformIO/SCons
-/// runs every build step through `cmd.exe`, so a `\\?\` ccache found on `PATH`
-/// fails each ESP8266 compile with "The system cannot find the path specified"
-/// (esphome/esphome#18399). Simplifying here keeps every derived path plain.
-///
-/// No-op on other platforms, and on Windows for paths without the prefix or
-/// ones `dunce` cannot safely express without it (verbatim UNC paths, reserved
-/// names, over-long paths); those are returned unchanged.
-fn without_verbatim_prefix(path: PathBuf) -> PathBuf {
-    #[cfg(target_os = "windows")]
-    {
-        dunce::simplified(&path).to_path_buf()
-    }
-    #[cfg(not(target_os = "windows"))]
-    {
-        path
     }
 }
 
@@ -434,19 +412,15 @@ mod tests {
     use super::*;
     use crate::util::unique_temp_dir;
 
-    #[test]
-    fn without_verbatim_prefix_leaves_plain_paths_alone() {
-        let plain = PathBuf::from("plain").join("resource dir");
-        assert_eq!(without_verbatim_prefix(plain.clone()), plain);
-    }
-
+    /// Pins the `dunce` behaviour `get_bundled_resource_dir` relies on for the
+    /// shape Tauri produces on Windows (drive letter, spaces in the name).
     #[cfg(target_os = "windows")]
     #[test]
-    fn without_verbatim_prefix_strips_extended_length_prefix() {
-        let verbatim = PathBuf::from(r"\\?\C:\Program Files\ESPHome Device Builder");
+    fn resource_dir_verbatim_prefix_is_stripped() {
+        let verbatim = Path::new(r"\\?\C:\Program Files\ESPHome Device Builder");
         assert_eq!(
-            without_verbatim_prefix(verbatim),
-            PathBuf::from(r"C:\Program Files\ESPHome Device Builder")
+            dunce::simplified(verbatim),
+            Path::new(r"C:\Program Files\ESPHome Device Builder")
         );
     }
 

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -142,8 +142,9 @@ fn interpreter_in_tree(root: &Path) -> PathBuf {
 ///
 /// On macOS and Windows, Tauri's `resource_dir()` points at the right place.
 /// On Windows the result is additionally normalized to a non-verbatim path
-/// (see [`simplified_resource_dir`]); the `env_path` callers that put derived
-/// dirs on `PATH` or into `GIT_SSL_CAINFO` rely on that guarantee.
+/// where the plain form round-trips (see [`simplified_resource_dir`] for the
+/// shapes it cannot strip); the `env_path` callers that put derived dirs on
+/// `PATH` or into `GIT_SSL_CAINFO` rely on that normalization.
 fn get_bundled_resource_dir(app_handle: &AppHandle) -> Result<PathBuf> {
     #[cfg(target_os = "linux")]
     {
@@ -213,17 +214,23 @@ fn get_bundled_resource_dir(app_handle: &AppHandle) -> Result<PathBuf> {
 fn simplified_resource_dir(dir: PathBuf) -> PathBuf {
     let simplified = dunce::simplified(&dir).to_path_buf();
     #[cfg(target_os = "windows")]
-    if simplified
-        .as_os_str()
-        .as_encoded_bytes()
-        .starts_with(br"\?")
-    {
+    if is_verbatim(&simplified) {
         tracing::warn!(
             "Resource dir stayed verbatim: {:?}; cmd.exe build steps may fail",
             simplified
         );
     }
     simplified
+}
+
+/// True when `path` still carries the Windows `\\?\` verbatim prefix.
+///
+/// A plain byte comparison so the predicate is testable on every platform;
+/// the warning branch it guards is log-only, so an inert predicate would
+/// break nothing a compiler or the strip tests could notice.
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+fn is_verbatim(path: &Path) -> bool {
+    path.as_os_str().as_encoded_bytes().starts_with(br"\\?\")
 }
 
 /// Root of the pristine Python tree inside the bundled resources.
@@ -450,6 +457,28 @@ mod tests {
     fn simplified_resource_dir_leaves_plain_paths_alone() {
         let plain = PathBuf::from("plain").join("resource dir");
         assert_eq!(simplified_resource_dir(plain.clone()), plain);
+    }
+
+    /// Byte-level check of the warning predicate; the branch it guards is
+    /// log-only, so this test is the only thing that fails when the pattern
+    /// stops matching real verbatim paths.
+    #[test]
+    fn is_verbatim_detects_the_verbatim_prefix() {
+        assert!(is_verbatim(Path::new(r"\\?\C:\Program Files\x")));
+        assert!(is_verbatim(Path::new(r"\\?\UNC\server\share\x")));
+        assert!(!is_verbatim(Path::new(r"C:\Program Files\x")));
+        assert!(!is_verbatim(Path::new(r"\\server\share\x")));
+    }
+
+    /// A shape `dunce` declines to strip (verbatim UNC) passes through
+    /// unchanged and is still flagged verbatim, i.e. the warning would fire.
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn simplified_resource_dir_keeps_verbatim_unc_and_flags_it() {
+        let unc = PathBuf::from(r"\\?\UNC\server\share\ESPHome Device Builder");
+        let out = simplified_resource_dir(unc.clone());
+        assert_eq!(out, unc);
+        assert!(is_verbatim(&out));
     }
 
     /// The shape Tauri produces on Windows (verbatim drive letter, spaces in


### PR DESCRIPTION
# What does this implement/fix?

On Windows, Tauri's `resource_dir()` comes back with the `\\?\` extended-length prefix because Tauri canonicalizes `current_exe()`. Everything we derive from it (the bundled Python, MinGit, and the ccache dir we prepend to `PATH`) therefore carries that prefix too. `CreateProcess` accepts such paths, `cmd.exe` does not; PlatformIO/SCons runs every build step through `cmd.exe`, so once ESPHome started wrapping ESP8266 compiles with the ccache it finds on `PATH`, every compile step failed with "The system cannot find the path specified" (esphome/esphome#18399).

This runs the resource dir through `dunce::simplified` on Windows so all derived paths are plain `C:\...` paths. Windows only; macOS and Linux are untouched. ESPHome is also getting a change to strip the prefix on its side (esphome/esphome#18495); this fixes it at the source so it cannot resurface through another tool.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes https://github.com/esphome/esphome/issues/18399

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).
