### PR TITLE
Probe-fail the repair e2e with damage ESPHome 2026.8 still rejects

### DIFF
--- a/.github/workflows/python-tree-repair.yml
+++ b/.github/workflows/python-tree-repair.yml
@@ -9,9 +9,11 @@ name: Python Tree Repair
 # ship — on every OS we ship it on.
 #
 # What it proves, in one pass: the first-run copy of a freshly built bundle is
-# self-contained and healthy; an orphaned component directory (exactly what the
-# removed `--ignore-installed` fallback left behind, and what broke every
-# compile on 2026.7) fails the health probe; the repair re-copy removes it with
+# self-contained and healthy; metadata-invisible damage in the class the
+# removed `--ignore-installed` fallback left behind (a truncated component
+# module the probe's config loads; the 2026.7 rp2040 orphan collision is
+# tolerated since ESPHome 2026.8's checked-in alias registry) fails the health
+# probe; the repair re-copy removes it, orphan directory included, with
 # no network; a tree carrying a RECORD-less frontend dist-info makes the real
 # updater pip command abort with uninstall-no-record-file and a repair from a
 # source carrying the same corruption recovers it (the "Cannot uninstall

--- a/src-tauri/src/platform/health.rs
+++ b/src-tauri/src/platform/health.rs
@@ -193,10 +193,10 @@ pub fn is_managed_python_tree(python_bin: &Path) -> bool {
 /// class survives: stale or truncated module files from a mixed-version tree
 /// still break real commands while metadata stays green.)
 ///
-/// `config` is the cheapest command that gets there: the alias map is built at
-/// the top of config validation, and a trivial config validates in ~0.2s.
-/// `esphome version` never loads the component tree and reports a broken install
-/// as fine.
+/// `config` is the cheapest command that gets there: validation imports and
+/// schema-checks every component the config names, and a trivial config
+/// validates in ~0.2s. `esphome version` never loads the component tree and
+/// reports a broken install as fine.
 pub fn esphome_config_probe(python_bin: &Path) -> Result<Option<String>> {
     use std::fs;
 

--- a/src-tauri/src/platform/health.rs
+++ b/src-tauri/src/platform/health.rs
@@ -186,11 +186,12 @@ pub fn is_managed_python_tree(python_bin: &Path) -> bool {
 ///
 /// Runs the actual CLI rather than inspecting package metadata, because the
 /// damage is invisible to metadata. The orphaned `components/rp2040/` directory
-/// behind #330 is named by no `RECORD`, carries no `.dist-info`, and leaves
+/// behind #330 was named by no `RECORD`, carried no `.dist-info`, and left
 /// `importlib.metadata` reporting a perfectly healthy `esphome 2026.7.0` — while
-/// every single compile fails. ESPHome builds its component alias map by
-/// AST-scanning the components *directory*, so only code that reads that
-/// directory can see the conflict.
+/// every single compile failed. (ESPHome 2026.8 moved its alias map to a
+/// checked-in registry, so that particular orphan is tolerated now, but the
+/// class survives: stale or truncated module files from a mixed-version tree
+/// still break real commands while metadata stays green.)
 ///
 /// `config` is the cheapest command that gets there: the alias map is built at
 /// the top of config validation, and a trivial config validates in ~0.2s.

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -560,9 +560,10 @@ mod tests {
     ];
 
     /// The whole repair lifecycle against a real bundled Python tree: the
-    /// first-run copy, detect the orphan, wipe and re-copy from the pristine
-    /// bundle, prove it is fixed, then prove a refresh from an older bundle
-    /// restores the newer version the user tree already had.
+    /// first-run copy, detect metadata-invisible damage (a truncated
+    /// component module), wipe and re-copy from the pristine bundle, prove it
+    /// is fixed, then prove a refresh from an older bundle restores the newer
+    /// version the user tree already had.
     ///
     /// Ignored by default because it needs the genuine article — the
     /// python-build-standalone tree with esphome in it that
@@ -687,9 +688,15 @@ mod tests {
         let detail = esphome_config_probe(&python)
             .expect("probe could not run")
             .expect("the truncated esp32 component must fail the health probe");
+        // A weak discriminator by necessity: the probe config itself names
+        // `esp32`, so most validation failures would mention it too. The exact
+        // wording for an empty component module is ESPHome's to change (today
+        // it is an AttributeError in the import chain), so nothing stronger is
+        // stable to match on. Step 3's clean probe of the undamaged copy is
+        // what actually pins the failure on the fabricated damage.
         assert!(
             detail.contains("esp32"),
-            "probe failed for some other reason: {detail}"
+            "probe failure does not mention esp32: {detail}"
         );
 
         // 6. The repair: wipe the damaged copy and re-copy the pristine

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -703,7 +703,11 @@ mod tests {
         //    still answering from the copy.
         assert!(!orphan.exists(), "the orphan survived the repair");
         assert!(
-            std::fs::metadata(&esp32_init).map_or(0, |m| m.len()) > 0,
+            esp32_init.is_file(),
+            "the repair did not restore the esp32 component at {esp32_init:?}"
+        );
+        assert!(
+            std::fs::metadata(&esp32_init).unwrap().len() > 0,
             "the repair left the truncated esp32 component empty"
         );
         assert_eq!(

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -650,22 +650,45 @@ mod tests {
             "a fresh copy of the bundle must pass the health probe"
         );
 
-        // 4. Orphan a component directory exactly the way --ignore-installed
-        //    did: `rp2` declares `rp2040` as a legacy alias, so a leftover
-        //    `rp2040` package from the previous version collides with it.
+        // 4. Damage the tree the way a mixed-version install does, twice over,
+        //    both invisible to metadata:
+        //
+        //    a. Orphan a component directory exactly the way --ignore-installed
+        //       did. On ESPHome 2026.7 this alone broke every compile: the
+        //       loader AST-scanned the components directory and the leftover
+        //       `rp2040` collided with `rp2`'s legacy alias (#330). 2026.8
+        //       moved aliases to a checked-in registry with an import-compat
+        //       finder, so the orphan is now *tolerated by design* — it no
+        //       longer fails anything, but a stale tree still carries it, and
+        //       step 7 asserts the repair removes it.
         let orphan = purelib.join("esphome").join("components").join("rp2040");
         std::fs::create_dir_all(&orphan).unwrap();
         std::fs::write(orphan.join("__init__.py"), "").unwrap();
 
+        //    b. Truncate a component module the probe's own config loads —
+        //       the stale-file half of the same damage class, and one no
+        //       registry can absorb: validating an `esp32:` config must read
+        //       this module's schema on any ESPHome version.
+        let esp32_init = purelib
+            .join("esphome")
+            .join("components")
+            .join("esp32")
+            .join("__init__.py");
+        assert!(
+            esp32_init.is_file(),
+            "the bundle has no esp32 component at {esp32_init:?}"
+        );
+        std::fs::write(&esp32_init, "").unwrap();
+
         // 5. The probe must catch it. This is the assertion the whole design
-        //    rests on: no metadata check sees this, because the orphan has no
-        //    RECORD and no dist-info, and importlib still reports a healthy
+        //    rests on: no metadata check sees this — the RECORD is not
+        //    consulted at run time, and importlib still reports a healthy
         //    esphome. Only running a real command finds it.
         let detail = esphome_config_probe(&python)
             .expect("probe could not run")
-            .expect("the orphaned rp2040 component must fail the health probe");
+            .expect("the truncated esp32 component must fail the health probe");
         assert!(
-            detail.contains("rp2040"),
+            detail.contains("esp32"),
             "probe failed for some other reason: {detail}"
         );
 
@@ -676,8 +699,13 @@ mod tests {
         python_env::refresh_python_tree(&user_tree, || Ok(bundle.clone()), RefreshReason::Repair)
             .expect("repair failed");
 
-        // 7. Healthy again, orphan gone, and still answering from the copy.
+        // 7. Healthy again: orphan gone, the truncated module restored, and
+        //    still answering from the copy.
         assert!(!orphan.exists(), "the orphan survived the repair");
+        assert!(
+            std::fs::metadata(&esp32_init).map_or(0, |m| m.len()) > 0,
+            "the repair left the truncated esp32 component empty"
+        );
         assert_eq!(
             esphome_config_probe(&python).expect("probe could not run"),
             None,


### PR DESCRIPTION
# What does this implement/fix?

The repair cycle e2e has failed on every platform since ESPHome 2026.8.0 hit PyPI. That release moved component alias resolution to a checked in registry with an import compat finder, so the leftover `rp2040` directory the test fabricates is tolerated by design and `esphome config` no longer fails; the probe leg's assertion broke (prepare_bundle.sh installs unpinned latest).

The orphan stays for the repair removes extras assertion; the probe leg now truncates the esp32 component module the probe's own config loads, which is the same metadata invisible damage class and cannot be absorbed by any registry. Verified against a real 2026.8.0 install: the orphan alone passes config, the truncated module fails it naming esp32, and importlib.metadata still reports the tree healthy.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes <link to issue>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).
