### PR TITLE
Skip the self-update when the install's package tool is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,10 +225,9 @@ Linux `.deb` / `.rpm` installs self-update through the system package tool
 (`dpkg` / `rpm`, with an elevation prompt). Those tools install the downloaded
 package without resolving dependencies, so a release that changes the deb/rpm
 `Depends` set needs a "reinstall from the package" note in its release notes.
-AUR installs cannot self-update; the AUR binary is repackaged from the `.deb`,
-so until the AUR packaging grows its own updater story the in-app update
-downloads a `.deb` and fails on Arch, and those users should update through
-their system package manager.
+AUR installs cannot self-update; the AUR binary is repackaged from the `.deb`
+and Arch has no `dpkg`, so the app detects the missing tool, skips the
+download, and points those users at their system package manager instead.
 
 ## Configuration
 

--- a/src-tauri/src/app_update/mod.rs
+++ b/src-tauri/src/app_update/mod.rs
@@ -13,6 +13,7 @@
 
 use std::time::Duration;
 
+use tauri::utils::config::BundleType;
 use tauri::{AppHandle, Manager};
 use tauri_plugin_dialog::MessageDialogKind;
 use tauri_plugin_updater::UpdaterExt;
@@ -31,6 +32,41 @@ pub enum NextStep {
     /// a Python-package update right now would just get overwritten by the new
     /// bundled Python on the next launch.
     Skip,
+}
+
+/// The package tool a deb/rpm-typed install needs for the updater's install
+/// step, when that tool is missing from `PATH` — i.e. the reason this binary
+/// must not attempt a self-update.
+///
+/// tauri-plugin-updater dispatches its install by the bundle type baked into
+/// the binary at packaging time: a deb runs `dpkg -i`, an rpm runs `rpm -U`,
+/// each behind a pkexec/zenity/sudo elevation chain. A binary repackaged onto
+/// a system without that tool — the AUR package extracts our amd64 `.deb`, and
+/// Arch has no `dpkg` — would download the full update and then fail every
+/// rung of that chain, showing an elevation prompt on the way down. Split from
+/// [`self_update_blocked`] so the decision is testable on every host.
+fn self_update_blocked_tool(
+    bundle: Option<BundleType>,
+    tool_present: impl Fn(&str) -> bool,
+) -> Option<&'static str> {
+    let tool = match bundle {
+        Some(BundleType::Deb) => "dpkg",
+        Some(BundleType::Rpm) => "rpm",
+        // AppImage/Msi/Nsis/App install without a package tool, and `None`
+        // (an unpackaged dev build) keeps today's behavior.
+        _ => return None,
+    };
+    (!tool_present(tool)).then_some(tool)
+}
+
+/// [`self_update_blocked_tool`] for the running binary and the real `PATH`:
+/// `Some(tool)` names the missing package tool when a self-update must not be
+/// attempted, `None` means the updater may proceed.
+pub(crate) fn self_update_blocked() -> Option<&'static str> {
+    self_update_blocked_tool(
+        tauri::utils::platform::bundle_type(),
+        crate::platform::executable_on_path,
+    )
 }
 
 /// User-initiated app-update check. Always shows the "update available" dialog;
@@ -60,6 +96,27 @@ pub async fn check_for_user(app_handle: &AppHandle, show_no_update_dialog: bool)
                 "Desktop update available: {} (current: {})",
                 update.version, update.current_version
             );
+
+            if let Some(tool) = self_update_blocked() {
+                info!(
+                    "Not offering to install {}: this install has no `{}`",
+                    update.version, tool
+                );
+                crate::dialog::notice(
+                    app_handle,
+                    &t("app_update.available_title"),
+                    t_with(
+                        "app_update.package_manager_only",
+                        &[("new", &update.version), ("tool", tool)],
+                    ),
+                    MessageDialogKind::Info,
+                )
+                .await;
+                // The update exists but cannot be installed from here, so the
+                // bundled Python is not about to roll — keep going to the
+                // ESPHome checks, same as a declined update.
+                return NextStep::Continue;
+            }
 
             let new_version = update.version.clone();
             let current_version = update.current_version.clone();
@@ -148,7 +205,16 @@ pub async fn check_and_notify(app_handle: &AppHandle, tray_available: bool) -> N
             ) {
                 error!("Failed to show desktop-update notification: {}", e);
             }
-            NextStep::Skip
+            if self_update_blocked().is_some() {
+                // The user was told an update exists, but it cannot be
+                // installed from this binary (a deb/rpm repackage without its
+                // package tool — the AUR case). The pip updates below won't be
+                // overwritten by an app install that can't happen here, so the
+                // loop must keep checking them rather than skipping forever.
+                NextStep::Continue
+            } else {
+                NextStep::Skip
+            }
         }
         Ok(None) => {
             debug!("Desktop app is up to date (background check)");
@@ -211,6 +277,16 @@ pub(crate) async fn apply_update_noninteractive(
     progress: crate::control::ops::Progress<'_>,
 ) -> Result<(), String> {
     let version = update.version.clone();
+
+    // Backstop behind the caller-side checks: nothing may reach the download
+    // when the install step's package tool is missing (see
+    // [`self_update_blocked`]) — the plugin would fetch the full payload and
+    // then fail its pkexec/sudo install chain.
+    if let Some(tool) = self_update_blocked() {
+        return Err(format!(
+            "this install updates through the system package manager ({tool} is not available)"
+        ));
+    }
 
     progress("desktop", &format!("downloading desktop update {version}"));
     let bytes = download_update_bytes(&update)
@@ -335,6 +411,51 @@ fn format_update_prompt(current: &str, new: &str, notes: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn deb_and_rpm_without_their_tool_are_blocked_and_name_it() {
+        assert_eq!(
+            self_update_blocked_tool(Some(BundleType::Deb), |_| false),
+            Some("dpkg")
+        );
+        assert_eq!(
+            self_update_blocked_tool(Some(BundleType::Rpm), |_| false),
+            Some("rpm")
+        );
+    }
+
+    #[test]
+    fn deb_and_rpm_with_their_tool_are_allowed() {
+        assert_eq!(
+            self_update_blocked_tool(Some(BundleType::Deb), |t| t == "dpkg"),
+            None
+        );
+        assert_eq!(
+            self_update_blocked_tool(Some(BundleType::Rpm), |t| t == "rpm"),
+            None
+        );
+    }
+
+    #[test]
+    fn non_package_bundles_never_consult_path() {
+        // AppImage/Msi/Nsis/App/Dmg install without a package tool, and `None`
+        // is an unpackaged dev build; the panicking closure proves the PATH
+        // question is never even asked for these, so the guard cannot change
+        // their behavior.
+        for bundle in [
+            None,
+            Some(BundleType::AppImage),
+            Some(BundleType::Msi),
+            Some(BundleType::Nsis),
+            Some(BundleType::App),
+            Some(BundleType::Dmg),
+        ] {
+            assert_eq!(
+                self_update_blocked_tool(bundle, |tool| panic!("asked PATH about {tool}")),
+                None
+            );
+        }
+    }
 
     #[test]
     fn includes_both_versions() {

--- a/src-tauri/src/app_update/mod.rs
+++ b/src-tauri/src/app_update/mod.rs
@@ -190,6 +190,18 @@ pub async fn check_and_notify(app_handle: &AppHandle, tray_available: bool) -> N
                 "Desktop update available in background: {} (current: {})",
                 update.version, update.current_version
             );
+            // A blocked update (a deb/rpm repackage without its package tool —
+            // the AUR case) cannot be installed from this binary: the
+            // notification's hint must point at the package manager rather
+            // than an in-app flow that cannot perform the update, and the pip
+            // updates won't be overwritten by it, so the loop must keep
+            // checking them rather than skipping forever.
+            let blocked = self_update_blocked().is_some();
+            let hint = if blocked {
+                crate::update::NotificationHint::PackageManager
+            } else {
+                crate::update::NotificationHint::InApp { tray_available }
+            };
             if let Err(e) = crate::update::notify_update_available(
                 app_handle,
                 &t_with(
@@ -201,17 +213,14 @@ pub async fn check_and_notify(app_handle: &AppHandle, tray_available: bool) -> N
                     &[("version", &update.version)],
                 ),
                 &update.current_version,
-                tray_available,
+                hint,
             ) {
                 error!("Failed to show desktop-update notification: {}", e);
             }
-            // A blocked update (a deb/rpm repackage without its package tool —
-            // the AUR case) cannot be installed from this binary, so the pip
-            // updates won't be overwritten by it; the loop must keep checking
-            // them rather than skipping forever.
-            match self_update_blocked() {
-                Some(_) => NextStep::Continue,
-                None => NextStep::Skip,
+            if blocked {
+                NextStep::Continue
+            } else {
+                NextStep::Skip
             }
         }
         Ok(None) => {

--- a/src-tauri/src/app_update/mod.rs
+++ b/src-tauri/src/app_update/mod.rs
@@ -62,7 +62,7 @@ fn self_update_blocked_tool(
 /// [`self_update_blocked_tool`] for the running binary and the real `PATH`:
 /// `Some(tool)` names the missing package tool when a self-update must not be
 /// attempted, `None` means the updater may proceed.
-pub(crate) fn self_update_blocked() -> Option<&'static str> {
+fn self_update_blocked() -> Option<&'static str> {
     self_update_blocked_tool(
         tauri::utils::platform::bundle_type(),
         crate::platform::executable_on_path,
@@ -205,15 +205,13 @@ pub async fn check_and_notify(app_handle: &AppHandle, tray_available: bool) -> N
             ) {
                 error!("Failed to show desktop-update notification: {}", e);
             }
-            if self_update_blocked().is_some() {
-                // The user was told an update exists, but it cannot be
-                // installed from this binary (a deb/rpm repackage without its
-                // package tool — the AUR case). The pip updates below won't be
-                // overwritten by an app install that can't happen here, so the
-                // loop must keep checking them rather than skipping forever.
-                NextStep::Continue
-            } else {
-                NextStep::Skip
+            // A blocked update (a deb/rpm repackage without its package tool —
+            // the AUR case) cannot be installed from this binary, so the pip
+            // updates won't be overwritten by it; the loop must keep checking
+            // them rather than skipping forever.
+            match self_update_blocked() {
+                Some(_) => NextStep::Continue,
+                None => NextStep::Skip,
             }
         }
         Ok(None) => {
@@ -235,7 +233,7 @@ async fn apply_update(app_handle: &AppHandle, update: tauri_plugin_updater::Upda
     let new_version = update.version.clone();
 
     match apply_update_noninteractive(app_handle, update, &|_, _| {}).await {
-        Ok(()) => {
+        Ok(AppUpdateOutcome::Installed) => {
             // Always relaunch after a successful install rather than offering to
             // defer: the install replaced the .app bundle, and the running
             // process must be replaced by a fresh instance of it. On macOS the
@@ -255,6 +253,22 @@ async fn apply_update(app_handle: &AppHandle, update: tauri_plugin_updater::Upda
             info!("Relaunching to apply desktop update");
             crate::platform::relaunch_for_update(app_handle);
         }
+        Ok(AppUpdateOutcome::ExternallyManaged(tool)) => {
+            // Only reachable when the tool disappeared between
+            // `check_for_user`'s guard and the user confirming — still a
+            // normal condition, so the same informational notice as the
+            // guard, never the red failure dialog.
+            crate::dialog::notice(
+                app_handle,
+                &t("app_update.available_title"),
+                t_with(
+                    "app_update.package_manager_only",
+                    &[("new", &new_version), ("tool", tool)],
+                ),
+                MessageDialogKind::Info,
+            )
+            .await;
+        }
         Err(e) => {
             show_error(
                 app_handle,
@@ -263,6 +277,22 @@ async fn apply_update(app_handle: &AppHandle, update: tauri_plugin_updater::Upda
             .await;
         }
     }
+}
+
+/// How [`apply_update_noninteractive`] finished, short of an actual failure.
+///
+/// `ExternallyManaged` is a normal condition, not an error — carrying it in
+/// `Err` would force every caller to parse a failure back into a note, and
+/// would render a red "Failed to update" dialog for something that is merely
+/// "not ours to install". `Err` stays reserved for downloads and installs
+/// that actually broke.
+pub(crate) enum AppUpdateOutcome {
+    /// Downloaded and installed; the caller must relaunch the app.
+    Installed,
+    /// Not attempted: this install updates through the system package manager
+    /// and the named tool is missing ([`self_update_blocked`]). Nothing was
+    /// downloaded and the backend was never stopped.
+    ExternallyManaged(&'static str),
 }
 
 /// Non-interactive variant for the CLI `update` flow: the same
@@ -275,17 +305,15 @@ pub(crate) async fn apply_update_noninteractive(
     app_handle: &AppHandle,
     update: tauri_plugin_updater::Update,
     progress: crate::control::ops::Progress<'_>,
-) -> Result<(), String> {
+) -> Result<AppUpdateOutcome, String> {
     let version = update.version.clone();
 
-    // Backstop behind the caller-side checks: nothing may reach the download
-    // when the install step's package tool is missing (see
-    // [`self_update_blocked`]) — the plugin would fetch the full payload and
-    // then fail its pkexec/sudo install chain.
+    // The one decision point for "can this binary install its own update":
+    // nothing may reach the download when the install step's package tool is
+    // missing (see [`self_update_blocked`]) — the plugin would fetch the full
+    // payload and then fail its pkexec/sudo install chain.
     if let Some(tool) = self_update_blocked() {
-        return Err(format!(
-            "this install updates through the system package manager ({tool} is not available)"
-        ));
+        return Ok(AppUpdateOutcome::ExternallyManaged(tool));
     }
 
     progress("desktop", &format!("downloading desktop update {version}"));
@@ -300,7 +328,7 @@ pub(crate) async fn apply_update_noninteractive(
     match install_update_bytes(update, bytes).await {
         Ok(()) => {
             info!("Desktop update {} installed", version);
-            Ok(())
+            Ok(AppUpdateOutcome::Installed)
         }
         Err(e) => {
             error!("Desktop update install failed: {}", e);

--- a/src-tauri/src/app_update/mod.rs
+++ b/src-tauri/src/app_update/mod.rs
@@ -59,6 +59,29 @@ fn self_update_blocked_tool(
     (!tool_present(tool)).then_some(tool)
 }
 
+/// Pure decision for [`check_and_notify`]'s update-available arm: which hint
+/// the notification carries and whether the loop may skip the Python-package
+/// checks afterwards. One function so the two cannot drift apart — a blocked
+/// update must never pair the in-app hint with `Skip`: the hint would
+/// instruct a flow that cannot install, and the skip would starve the pip
+/// checks forever behind an app install that is not coming.
+fn background_notify_plan(
+    blocked: bool,
+    tray_available: bool,
+) -> (crate::update::NotificationHint, NextStep) {
+    if blocked {
+        (
+            crate::update::NotificationHint::PackageManager,
+            NextStep::Continue,
+        )
+    } else {
+        (
+            crate::update::NotificationHint::InApp { tray_available },
+            NextStep::Skip,
+        )
+    }
+}
+
 /// [`self_update_blocked_tool`] for the running binary and the real `PATH`:
 /// `Some(tool)` names the missing package tool when a self-update must not be
 /// attempted, `None` means the updater may proceed.
@@ -190,18 +213,8 @@ pub async fn check_and_notify(app_handle: &AppHandle, tray_available: bool) -> N
                 "Desktop update available in background: {} (current: {})",
                 update.version, update.current_version
             );
-            // A blocked update (a deb/rpm repackage without its package tool —
-            // the AUR case) cannot be installed from this binary: the
-            // notification's hint must point at the package manager rather
-            // than an in-app flow that cannot perform the update, and the pip
-            // updates won't be overwritten by it, so the loop must keep
-            // checking them rather than skipping forever.
-            let blocked = self_update_blocked().is_some();
-            let hint = if blocked {
-                crate::update::NotificationHint::PackageManager
-            } else {
-                crate::update::NotificationHint::InApp { tray_available }
-            };
+            let (hint, next) =
+                background_notify_plan(self_update_blocked().is_some(), tray_available);
             if let Err(e) = crate::update::notify_update_available(
                 app_handle,
                 &t_with(
@@ -217,11 +230,7 @@ pub async fn check_and_notify(app_handle: &AppHandle, tray_available: bool) -> N
             ) {
                 error!("Failed to show desktop-update notification: {}", e);
             }
-            if blocked {
-                NextStep::Continue
-            } else {
-                NextStep::Skip
-            }
+            next
         }
         Ok(None) => {
             debug!("Desktop app is up to date (background check)");
@@ -491,6 +500,26 @@ mod tests {
                 self_update_blocked_tool(bundle, |tool| panic!("asked PATH about {tool}")),
                 None
             );
+        }
+    }
+
+    /// The pairing invariant [`background_notify_plan`] exists for: a blocked
+    /// update carries the package-manager hint AND keeps the loop checking the
+    /// Python packages; a normal update carries the in-app hint (preserving
+    /// the tray state) AND may skip them until it installs.
+    #[test]
+    fn background_plan_pairs_hint_and_next_step() {
+        use crate::update::NotificationHint;
+        for tray in [true, false] {
+            let (hint, next) = background_notify_plan(true, tray);
+            assert!(matches!(hint, NotificationHint::PackageManager));
+            assert_eq!(next, NextStep::Continue);
+
+            let (hint, next) = background_notify_plan(false, tray);
+            assert!(
+                matches!(hint, NotificationHint::InApp { tray_available } if tray_available == tray)
+            );
+            assert_eq!(next, NextStep::Skip);
         }
     }
 

--- a/src-tauri/src/control/ops/full_update.rs
+++ b/src-tauri/src/control/ops/full_update.rs
@@ -10,6 +10,7 @@ use tauri::AppHandle;
 use tauri_plugin_updater::UpdaterExt;
 
 use super::{stop_install_start, InstallOutcome, Progress, UpdateGuard};
+use crate::app_update::AppUpdateOutcome;
 use crate::control::update_check::{
     device_builder_update_available, esphome_install_action, esphome_update_available,
     install_action, InstallAction,
@@ -65,27 +66,25 @@ pub(crate) async fn run_full_update(
         Ok(updater) => match updater.check().await {
             Ok(Some(update)) => {
                 let version = update.version.clone();
-                if let Some(tool) = crate::app_update::self_update_blocked() {
-                    // A deb/rpm-typed binary without its package tool (the AUR
-                    // repackage) cannot install this. Say so and fall through
-                    // to the package phases: the pip updates won't be
-                    // overwritten by an app install that can't happen here.
-                    report.note(package_manager_note(&version, tool));
-                } else {
-                    match crate::app_update::apply_update_noninteractive(app, update, progress)
-                        .await
-                    {
-                        Ok(()) => {
-                            report.note(format!("desktop app updated to {version}"));
-                            report.app_update_installed = true;
-                        }
-                        Err(e) => {
-                            // Don't compound a failed self-update with pip
-                            // activity.
-                            report.fail(format!("desktop app update to {version} failed: {e}"));
-                        }
+                match crate::app_update::apply_update_noninteractive(app, update, progress).await {
+                    Ok(AppUpdateOutcome::Installed) => {
+                        report.note(format!("desktop app updated to {version}"));
+                        report.app_update_installed = true;
+                        return report;
                     }
-                    return report;
+                    // A deb/rpm-typed binary without its package tool (the
+                    // AUR repackage) cannot install this. A note, not a fail
+                    // — and fall through to the package phases: the pip
+                    // updates won't be overwritten by an app install that
+                    // can't happen here.
+                    Ok(AppUpdateOutcome::ExternallyManaged(tool)) => {
+                        report.note(package_manager_note(&version, tool));
+                    }
+                    Err(e) => {
+                        // Don't compound a failed self-update with pip activity.
+                        report.fail(format!("desktop app update to {version} failed: {e}"));
+                        return report;
+                    }
                 }
             }
             Ok(None) => report.note(format!(

--- a/src-tauri/src/control/ops/full_update.rs
+++ b/src-tauri/src/control/ops/full_update.rs
@@ -66,25 +66,11 @@ pub(crate) async fn run_full_update(
         Ok(updater) => match updater.check().await {
             Ok(Some(update)) => {
                 let version = update.version.clone();
-                match crate::app_update::apply_update_noninteractive(app, update, progress).await {
-                    Ok(AppUpdateOutcome::Installed) => {
-                        report.note(format!("desktop app updated to {version}"));
-                        report.app_update_installed = true;
-                        return report;
-                    }
-                    // A deb/rpm-typed binary without its package tool (the
-                    // AUR repackage) cannot install this. A note, not a fail
-                    // — and fall through to the package phases: the pip
-                    // updates won't be overwritten by an app install that
-                    // can't happen here.
-                    Ok(AppUpdateOutcome::ExternallyManaged(tool)) => {
-                        report.note(package_manager_note(&version, tool));
-                    }
-                    Err(e) => {
-                        // Don't compound a failed self-update with pip activity.
-                        report.fail(format!("desktop app update to {version} failed: {e}"));
-                        return report;
-                    }
+                let outcome =
+                    crate::app_update::apply_update_noninteractive(app, update, progress).await;
+                match record_desktop_outcome(&mut report, &version, outcome) {
+                    DesktopPhase::Done => return report,
+                    DesktopPhase::ContinueToPackages => {}
                 }
             }
             Ok(None) => report.note(format!(
@@ -275,6 +261,45 @@ fn package_manager_note(version: &str, tool: &str) -> String {
     )
 }
 
+/// What the desktop phase decided about the rest of [`run_full_update`].
+#[derive(Debug, PartialEq, Eq)]
+enum DesktopPhase {
+    /// The update flow is over — an install succeeded (relaunch pending) or
+    /// failed (don't compound with pip activity); return the report as-is.
+    Done,
+    /// No install happened or will happen here; the package phases still run.
+    ContinueToPackages,
+}
+
+/// Record the desktop phase's outcome on the report and say whether the
+/// package phases still run.
+///
+/// Split out like [`record_outcome`]: which outcomes end the flow and which
+/// fall through — an externally managed update is a *note* (exit 0) and the
+/// pip updates still happen, since no app install is coming to overwrite
+/// them — is the CLI's contract, so it is unit-testable without an updater.
+fn record_desktop_outcome(
+    report: &mut UpdateReport,
+    version: &str,
+    outcome: Result<AppUpdateOutcome, String>,
+) -> DesktopPhase {
+    match outcome {
+        Ok(AppUpdateOutcome::Installed) => {
+            report.note(format!("desktop app updated to {version}"));
+            report.app_update_installed = true;
+            DesktopPhase::Done
+        }
+        Ok(AppUpdateOutcome::ExternallyManaged(tool)) => {
+            report.note(package_manager_note(version, tool));
+            DesktopPhase::ContinueToPackages
+        }
+        Err(e) => {
+            report.fail(format!("desktop app update to {version} failed: {e}"));
+            DesktopPhase::Done
+        }
+    }
+}
+
 /// Record `outcome` as the report line for `component` updating to `label`.
 ///
 /// Split out of [`run_package_phase`] so the wording — which is the CLI's
@@ -326,15 +351,71 @@ mod tests {
         (report.lines.remove(0), report.any_failed)
     }
 
-    /// Not a failure: the CLI must exit 0 when the only "problem" is that the
-    /// desktop update belongs to the system package manager, otherwise every
-    /// AUR user's `esphome-desktop update` reads as broken forever.
+    /// The desktop phase through the real recorder: the report line, the
+    /// failed flag, the relaunch-pending flag, and whether the package
+    /// phases still run.
+    fn desktop_recorded(
+        outcome: Result<AppUpdateOutcome, String>,
+    ) -> (String, bool, bool, DesktopPhase) {
+        let mut report = UpdateReport {
+            app_update_installed: false,
+            lines: Vec::new(),
+            any_failed: false,
+        };
+        let phase = record_desktop_outcome(&mut report, "1.2.0", outcome);
+        assert_eq!(report.lines.len(), 1, "exactly one desktop line");
+        (
+            report.lines.remove(0),
+            report.any_failed,
+            report.app_update_installed,
+            phase,
+        )
+    }
+
     #[test]
-    fn a_package_manager_update_is_a_note_naming_the_missing_tool() {
+    fn an_installed_desktop_update_ends_the_flow_pending_relaunch() {
         assert_eq!(
-            package_manager_note("1.2.0", "dpkg"),
-            "desktop app 1.2.0 is available; this install has no dpkg, \
-             update it through your system package manager"
+            desktop_recorded(Ok(AppUpdateOutcome::Installed)),
+            (
+                "desktop app updated to 1.2.0".to_string(),
+                false,
+                true,
+                DesktopPhase::Done
+            )
+        );
+    }
+
+    /// Not a failure, and not the end of the flow: the CLI must exit 0 and
+    /// still run the pip phases when the only "problem" is that the desktop
+    /// update belongs to the system package manager — otherwise every AUR
+    /// user's `esphome-desktop update` reads as broken forever and their
+    /// ESPHome never updates.
+    #[test]
+    fn an_externally_managed_update_notes_and_continues_to_packages() {
+        assert_eq!(
+            desktop_recorded(Ok(AppUpdateOutcome::ExternallyManaged("dpkg"))),
+            (
+                "desktop app 1.2.0 is available; this install has no dpkg, \
+                 update it through your system package manager"
+                    .to_string(),
+                false,
+                false,
+                DesktopPhase::ContinueToPackages
+            )
+        );
+    }
+
+    /// A failed install ends the flow: don't compound it with pip activity.
+    #[test]
+    fn a_failed_desktop_update_ends_the_flow() {
+        assert_eq!(
+            desktop_recorded(Err("download failed: boom".into())),
+            (
+                "desktop app update to 1.2.0 failed: download failed: boom".to_string(),
+                true,
+                false,
+                DesktopPhase::Done
+            )
         );
     }
 

--- a/src-tauri/src/control/ops/full_update.rs
+++ b/src-tauri/src/control/ops/full_update.rs
@@ -65,17 +65,28 @@ pub(crate) async fn run_full_update(
         Ok(updater) => match updater.check().await {
             Ok(Some(update)) => {
                 let version = update.version.clone();
-                match crate::app_update::apply_update_noninteractive(app, update, progress).await {
-                    Ok(()) => {
-                        report.note(format!("desktop app updated to {version}"));
-                        report.app_update_installed = true;
+                if let Some(tool) = crate::app_update::self_update_blocked() {
+                    // A deb/rpm-typed binary without its package tool (the AUR
+                    // repackage) cannot install this. Say so and fall through
+                    // to the package phases: the pip updates won't be
+                    // overwritten by an app install that can't happen here.
+                    report.note(package_manager_note(&version, tool));
+                } else {
+                    match crate::app_update::apply_update_noninteractive(app, update, progress)
+                        .await
+                    {
+                        Ok(()) => {
+                            report.note(format!("desktop app updated to {version}"));
+                            report.app_update_installed = true;
+                        }
+                        Err(e) => {
+                            // Don't compound a failed self-update with pip
+                            // activity.
+                            report.fail(format!("desktop app update to {version} failed: {e}"));
+                        }
                     }
-                    Err(e) => {
-                        // Don't compound a failed self-update with pip activity.
-                        report.fail(format!("desktop app update to {version} failed: {e}"));
-                    }
+                    return report;
                 }
-                return report;
             }
             Ok(None) => report.note(format!(
                 "desktop app {} is up to date",
@@ -252,6 +263,19 @@ async fn run_package_phase<D, F, Fut, R, RFut>(
     record_outcome(report, component, &label, outcome);
 }
 
+/// Report line for a desktop update that exists but cannot be installed from
+/// this binary (`app_update::self_update_blocked` — a deb/rpm repackage
+/// without its package tool, e.g. the AUR package on Arch).
+///
+/// Split out like [`record_outcome`]: the wording is the CLI's user-facing
+/// contract, so it is unit-testable without an updater in the loop.
+fn package_manager_note(version: &str, tool: &str) -> String {
+    format!(
+        "desktop app {version} is available; this install has no {tool}, \
+         update it through your system package manager"
+    )
+}
+
 /// Record `outcome` as the report line for `component` updating to `label`.
 ///
 /// Split out of [`run_package_phase`] so the wording — which is the CLI's
@@ -301,6 +325,18 @@ mod tests {
         record_outcome(&mut report, "esphome", "2026.8.0", outcome);
         assert_eq!(report.lines.len(), 1, "exactly one line per component");
         (report.lines.remove(0), report.any_failed)
+    }
+
+    /// Not a failure: the CLI must exit 0 when the only "problem" is that the
+    /// desktop update belongs to the system package manager, otherwise every
+    /// AUR user's `esphome-desktop update` reads as broken forever.
+    #[test]
+    fn a_package_manager_update_is_a_note_naming_the_missing_tool() {
+        assert_eq!(
+            package_manager_note("1.2.0", "dpkg"),
+            "desktop app 1.2.0 is available; this install has no dpkg, \
+             update it through your system package manager"
+        );
     }
 
     #[test]

--- a/src-tauri/src/control/update_check.rs
+++ b/src-tauri/src/control/update_check.rs
@@ -51,9 +51,15 @@ where
 /// [`ComponentUpdate`] the check reply carries. The install sequences derive
 /// their decision from this same result via [`install_action`], so on the
 /// stable and beta channels the `available` flag never disagrees with what an
-/// actual `update` installs. The one deliberate exception is the ESPHome dev
+/// actual `update` installs. Two deliberate exceptions: the ESPHome dev
 /// channel, where the check reports "current" but `update` always reinstalls
-/// (see [`esphome_install_action`]).
+/// (see [`esphome_install_action`]); and an externally managed desktop
+/// install (a deb/rpm repackage without its package tool — the AUR case),
+/// where the check reports "upgradable" but `update` records a
+/// use-your-package-manager note instead of installing. The update genuinely
+/// exists, the reply just cannot yet say who installs it — carrying that
+/// through [`ComponentUpdate`] is an additive `API_SCHEMA_VERSION` change
+/// deferred to its own PR.
 fn compare(installed: String, latest: String) -> ComponentUpdate {
     if crate::update::is_newer_version(&latest, &installed) {
         ComponentUpdate::upgradable(installed, latest)

--- a/src-tauri/src/git_check/mod.rs
+++ b/src-tauri/src/git_check/mod.rs
@@ -30,53 +30,14 @@ const GIT_EXECUTABLES: &[&str] = &["git.exe", "git.cmd"];
 const GIT_EXECUTABLES: &[&str] = &["git"];
 
 /// Iterate over every git executable found on a PATH-style value, in
-/// left-to-right order.
-///
-/// `path_var` is the raw value of the `PATH` environment variable, with
-/// entries separated by the platform path separator (`:` on Unix, `;` on
-/// Windows). It is an `OsStr` rather than a `str` so a non-Unicode `PATH`
-/// (legal on both Unix and Windows) is handled instead of being treated as
-/// "git missing".
-///
-/// All candidates are yielded (rather than stopping at the first match) so
+/// left-to-right order: the crate-wide PATH scan
+/// (`platform::executables_in_path`, which owns the empty-entry and
+/// executability rules) applied to this module's candidate names. All
+/// candidates are yielded (rather than stopping at the first match) so
 /// callers can keep scanning past an unusable one — e.g. the macOS
 /// `/usr/bin/git` stub shadowing a later real git.
-///
-/// This is intentionally pure apart from filesystem existence checks, so it
-/// can be unit-tested by passing a synthetic PATH rather than mutating the
-/// process environment.
 fn git_executables_in_path(path_var: &OsStr) -> impl Iterator<Item = PathBuf> + '_ {
-    std::env::split_paths(path_var)
-        // Skip empty entries (e.g. a trailing separator), which would
-        // otherwise resolve to the current working directory.
-        .filter(|dir| !dir.as_os_str().is_empty())
-        .flat_map(|dir| GIT_EXECUTABLES.iter().map(move |name| dir.join(name)))
-        .filter(|candidate| is_git_executable(candidate))
-}
-
-/// Whether `path` is a usable git executable.
-///
-/// `is_file()` is false for a directory, so a directory named `git` (or
-/// `git.exe`) is correctly rejected. On Unix we additionally require an
-/// execute bit: a non-executable regular file named `git` on `PATH` is not a
-/// binary ESPHome could actually run, so it shouldn't suppress the warning. On
-/// Windows the file extension (`git.exe` / `git.cmd`) is the executability
-/// signal, so presence is enough.
-fn is_git_executable(path: &Path) -> bool {
-    if !path.is_file() {
-        return false;
-    }
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        path.metadata()
-            .map(|m| m.permissions().mode() & 0o111 != 0)
-            .unwrap_or(false)
-    }
-    #[cfg(not(unix))]
-    {
-        true
-    }
+    crate::platform::executables_in_path(path_var, GIT_EXECUTABLES)
 }
 
 /// Whether a usable `git` executable can be found on the current `PATH`.
@@ -96,7 +57,7 @@ fn is_git_available() -> bool {
 /// Whether a git executable found on `PATH` is actually runnable.
 ///
 /// On most platforms, presence on `PATH` (with an execute bit, checked by
-/// [`is_git_executable`]) is sufficient. macOS is the exception: a Mac without
+/// `platform::executables_in_path`) is sufficient. macOS is the exception: a Mac without
 /// the Xcode Command Line Tools still ships `/usr/bin/git` as a **stub** whose
 /// only job is to pop the CLT installer when invoked. That stub is a real,
 /// executable file, so it satisfies the PATH + execute-bit checks and makes

--- a/src-tauri/src/platform/env_path.rs
+++ b/src-tauri/src/platform/env_path.rs
@@ -91,6 +91,55 @@ fn get_bundled_ccache_dir(app_handle: &AppHandle) -> Result<PathBuf> {
     Ok(resource_dir.join("ccache"))
 }
 
+/// Whether `name` resolves to an executable regular file on the given
+/// PATH-style value.
+///
+/// The self-update backstop asks this about `dpkg`/`rpm` before letting the
+/// updater dispatch to them (`app_update::self_update_blocked`), mirroring the
+/// spawn tauri-plugin-updater's install step will actually attempt. Pure apart
+/// from filesystem checks — the PATH value is a parameter, the same
+/// split-the-logic pattern as `git_check::git_executables_in_path`, so the
+/// lookup is unit-testable with a synthetic value and a tempdir.
+fn executable_in_path(path_var: &OsStr, name: &str) -> bool {
+    std::env::split_paths(path_var)
+        // Skip empty entries (e.g. a trailing separator), which would
+        // otherwise resolve to the current working directory.
+        .filter(|dir| !dir.as_os_str().is_empty())
+        .any(|dir| is_executable_file(&dir.join(name)))
+}
+
+/// Whether `path` is a regular file this process could execute.
+///
+/// `is_file()` rejects a directory of the same name. On Unix an execute bit is
+/// additionally required: a non-executable file named `dpkg` is not a tool the
+/// updater could actually run, so it must not read as "present". On Windows
+/// presence is the signal (the extension conveys executability), matching
+/// `git_check::is_git_executable`.
+fn is_executable_file(path: &Path) -> bool {
+    if !path.is_file() {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        path.metadata()
+            .map(|m| m.permissions().mode() & 0o111 != 0)
+            .unwrap_or(false)
+    }
+    #[cfg(not(unix))]
+    {
+        true
+    }
+}
+
+/// [`executable_in_path`] against this process's real `PATH`.
+///
+/// `var_os` (not `var`) so a non-Unicode `PATH` is searched rather than read
+/// as "tool missing".
+pub fn executable_on_path(name: &str) -> bool {
+    std::env::var_os("PATH").is_some_and(|path| executable_in_path(&path, name))
+}
+
 /// Build a `PATH` value with `dir` prepended to `existing`.
 ///
 /// Pure (no environment mutation) so the prepend ordering, separator
@@ -392,6 +441,49 @@ pub fn ensure_ccache_on_path(app_handle: &AppHandle) -> Result<()> {
 mod tests {
     use super::*;
     use crate::util::unique_temp_dir;
+
+    /// Create `name` as an executable file in `dir` (mode 0755 on Unix, where
+    /// the execute bit is what [`is_executable_file`] requires).
+    fn create_executable(dir: &Path, name: &str) {
+        let path = dir.join(name);
+        std::fs::write(&path, b"").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+    }
+
+    #[test]
+    fn executable_in_path_finds_the_tool_and_skips_empty_entries() {
+        let dir = unique_temp_dir("exe-on-path");
+        create_executable(&dir, "dpkg");
+        // A leading empty entry (a stray separator) must be skipped, not
+        // resolved against the current directory; the real entry still hits.
+        let joined = std::env::join_paths([PathBuf::new(), dir]).unwrap();
+        assert!(executable_in_path(&joined, "dpkg"));
+        assert!(!executable_in_path(&joined, "rpm"), "absent tool found");
+    }
+
+    #[test]
+    fn executable_in_path_rejects_a_directory_of_the_same_name() {
+        let dir = unique_temp_dir("exe-dir-shadow");
+        std::fs::create_dir_all(dir.join("dpkg")).unwrap();
+        let joined = std::env::join_paths([dir]).unwrap();
+        assert!(!executable_in_path(&joined, "dpkg"));
+    }
+
+    /// A non-executable file named like the tool is not something the updater
+    /// could spawn, so it must not read as "present" (Unix only — on Windows
+    /// the extension is the executability signal).
+    #[cfg(unix)]
+    #[test]
+    fn executable_in_path_requires_the_execute_bit() {
+        let dir = unique_temp_dir("exe-no-x-bit");
+        std::fs::write(dir.join("dpkg"), b"").unwrap();
+        let joined = std::env::join_paths([dir]).unwrap();
+        assert!(!executable_in_path(&joined, "dpkg"));
+    }
 
     #[test]
     fn path_with_prepended_puts_dir_first() {

--- a/src-tauri/src/platform/env_path.rs
+++ b/src-tauri/src/platform/env_path.rs
@@ -4,7 +4,9 @@
 //! so every tool it shells out to (git, patch, ccache) has to be reachable from
 //! the `PATH` this process carries. This module owns the resource-dir lookups
 //! for the tools we bundle, the pure `PATH` string builders, the single place
-//! that mutates the environment, and the `ensure_*_on_path` entry points
+//! that mutates the environment, the crate's one `PATH` *search*
+//! ([`executables_in_path`] / [`executable_on_path`], consumed by `git_check`
+//! and the self-update backstop), and the `ensure_*_on_path` entry points
 //! `startup/mod.rs` calls at startup.
 
 use anyhow::{Context, Result};

--- a/src-tauri/src/platform/env_path.rs
+++ b/src-tauri/src/platform/env_path.rs
@@ -91,40 +91,55 @@ fn get_bundled_ccache_dir(app_handle: &AppHandle) -> Result<PathBuf> {
     Ok(resource_dir.join("ccache"))
 }
 
-/// Whether `name` resolves to an executable regular file on the given
-/// PATH-style value.
+/// Iterate over every executable named in `names` found on a PATH-style
+/// value, in left-to-right order.
 ///
-/// The self-update backstop asks this about `dpkg`/`rpm` before letting the
-/// updater dispatch to them (`app_update::self_update_blocked`), mirroring the
-/// spawn tauri-plugin-updater's install step will actually attempt. Pure apart
-/// from filesystem checks — the PATH value is a parameter, the same
-/// split-the-logic pattern as `git_check::git_executables_in_path`, so the
-/// lookup is unit-testable with a synthetic value and a tempdir.
-fn executable_in_path(path_var: &OsStr, name: &str) -> bool {
+/// The crate's one PATH-search mechanism. `git_check` scans with it — all
+/// candidates are yielded rather than stopping at the first match, so a
+/// caller can keep looking past an unusable one (the macOS `/usr/bin/git`
+/// stub shadowing a later real git) — and the self-update backstop asks it
+/// about `dpkg`/`rpm` (`app_update::self_update_blocked`), mirroring the
+/// spawn tauri-plugin-updater's install step will actually attempt. Pure
+/// apart from filesystem checks — the PATH value is a parameter, so the scan
+/// is unit-testable with a synthetic value and a tempdir.
+pub fn executables_in_path<'a>(
+    path_var: &'a OsStr,
+    names: &'a [&'a str],
+) -> impl Iterator<Item = PathBuf> + 'a {
     std::env::split_paths(path_var)
         // Skip empty entries (e.g. a trailing separator), which would
         // otherwise resolve to the current working directory.
         .filter(|dir| !dir.as_os_str().is_empty())
-        .any(|dir| is_executable_file(&dir.join(name)))
+        .flat_map(move |dir| names.iter().map(move |name| dir.join(name)))
+        .filter(|candidate| is_executable_file(candidate))
+}
+
+/// Whether `name` resolves to an executable regular file on the given
+/// PATH-style value.
+fn executable_in_path(path_var: &OsStr, name: &str) -> bool {
+    executables_in_path(path_var, std::slice::from_ref(&name))
+        .next()
+        .is_some()
 }
 
 /// Whether `path` is a regular file this process could execute.
 ///
-/// `is_file()` rejects a directory of the same name. On Unix an execute bit is
-/// additionally required: a non-executable file named `dpkg` is not a tool the
-/// updater could actually run, so it must not read as "present". On Windows
-/// presence is the signal (the extension conveys executability), matching
-/// `git_check::is_git_executable`.
+/// One `metadata` call answers both questions: a directory of the same name
+/// is rejected, and on Unix an execute bit is additionally required — a
+/// non-executable file named `dpkg` (or `git`) is not a tool anything here
+/// could actually run, so it must not read as "present". On Windows presence
+/// is the signal; the extension conveys executability.
 fn is_executable_file(path: &Path) -> bool {
-    if !path.is_file() {
+    let Ok(meta) = std::fs::metadata(path) else {
+        return false;
+    };
+    if !meta.is_file() {
         return false;
     }
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        path.metadata()
-            .map(|m| m.permissions().mode() & 0o111 != 0)
-            .unwrap_or(false)
+        meta.permissions().mode() & 0o111 != 0
     }
     #[cfg(not(unix))]
     {

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -21,6 +21,7 @@ mod windows;
 
 pub use env_path::{
     ensure_ccache_on_path, ensure_git_on_path, ensure_homebrew_on_path, executable_on_path,
+    executables_in_path,
 };
 pub use health::{
     clear_repair_count, esphome_config_probe, is_managed_python_tree, may_repair_tree,

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -19,7 +19,9 @@ mod python_env;
 #[cfg(target_os = "windows")]
 mod windows;
 
-pub use env_path::{ensure_ccache_on_path, ensure_git_on_path, ensure_homebrew_on_path};
+pub use env_path::{
+    ensure_ccache_on_path, ensure_git_on_path, ensure_homebrew_on_path, executable_on_path,
+};
 pub use health::{
     clear_repair_count, esphome_config_probe, is_managed_python_tree, may_repair_tree,
     repair_budget_left,

--- a/src-tauri/src/update/mod.rs
+++ b/src-tauri/src/update/mod.rs
@@ -27,7 +27,7 @@ mod version;
 #[cfg(test)]
 pub(crate) use install::is_missing_record_error;
 pub use install::{get_installed_device_builder_version, installed_esphome_version};
-pub(crate) use notify::notify_update_available;
+pub(crate) use notify::{notify_update_available, NotificationHint};
 pub(crate) use version::is_newer_version;
 
 /// PyPI package info response (used for stable channel)

--- a/src-tauri/src/update/notify.rs
+++ b/src-tauri/src/update/notify.rs
@@ -88,39 +88,64 @@ pub(super) fn notify_if_newer(
         &wording.notification_title(),
         &wording.subject(latest),
         installed,
-        tray_available,
+        NotificationHint::InApp { tray_available },
     ) {
         error!("Failed to show notification: {}", e);
     }
 }
 
+/// Which follow-through the "update available" notification's trailing hint
+/// points at. The hint exists so the notification never instructs a route
+/// that cannot perform the update: no tray means "open the tray menu" is
+/// pointing at nothing (issue #87), and an externally managed desktop update
+/// means the in-app flow — tray or CLI — cannot install it either.
+#[derive(Clone, Copy)]
+pub(crate) enum NotificationHint {
+    /// The in-app flow: the tray's Check for Updates, or the CLI when no
+    /// tray is available.
+    InApp { tray_available: bool },
+    /// Only the system package manager can install this update — a deb/rpm
+    /// repackage without its package tool (`app_update`'s externally-managed
+    /// case).
+    PackageManager,
+}
+
+impl NotificationHint {
+    fn text(self) -> String {
+        match self {
+            NotificationHint::InApp { tray_available } => crate::updates_menu_hint(tray_available),
+            NotificationHint::PackageManager => crate::i18n::t("hint.updates_package_manager"),
+        }
+    }
+}
+
 /// Build and show the standard "update available" notification:
-/// "<subject> is available (you have <installed>). <updates menu hint>".
+/// "<subject> is available (you have <installed>). <hint>".
 /// Returns the show error so each caller keeps its own failure log wording.
 pub(crate) fn notify_update_available(
     app_handle: &AppHandle,
     title: &str,
     subject: &str,
     installed: &str,
-    tray_available: bool,
+    hint: NotificationHint,
 ) -> tauri_plugin_notification::Result<()> {
     app_handle
         .notification()
         .builder()
         .title(title)
-        .body(update_notification_body(subject, installed, tray_available))
+        .body(update_notification_body(subject, installed, hint))
         .show()
 }
 
 /// Body of the standard "update available" notification, shared by every
 /// caller of [`notify_update_available`].
-fn update_notification_body(subject: &str, installed: &str, tray_available: bool) -> String {
+fn update_notification_body(subject: &str, installed: &str, hint: NotificationHint) -> String {
     t_with(
         "update.notification_body",
         &[
             ("subject", subject),
             ("installed", installed),
-            ("hint", &crate::updates_menu_hint(tray_available)),
+            ("hint", &hint.text()),
         ],
     )
 }
@@ -179,29 +204,52 @@ mod tests {
 
     #[test]
     fn notification_body_pins_exact_text_for_both_tray_states() {
+        let with_tray = NotificationHint::InApp {
+            tray_available: true,
+        };
+        let no_tray = NotificationHint::InApp {
+            tray_available: false,
+        };
         // With a tray, the hint points at the tray menu.
         assert_eq!(
-            update_notification_body(&esphome_wording().subject("2025.1.0"), "2024.12.2", true),
+            update_notification_body(
+                &esphome_wording().subject("2025.1.0"),
+                "2024.12.2",
+                with_tray
+            ),
             "ESPHome 2025.1.0 (stable) is available (you have 2024.12.2). \
              Open the tray menu and choose \"Check for Updates\" to update."
         );
         assert_eq!(
-            update_notification_body(&DEVICE_BUILDER_WORDING.subject("1.2.3"), "1.2.2", true),
+            update_notification_body(&DEVICE_BUILDER_WORDING.subject("1.2.3"), "1.2.2", with_tray),
             "ESPHome Device Builder 1.2.3 is available (you have 1.2.2). \
              Open the tray menu and choose \"Check for Updates\" to update."
         );
         // Without a tray, the hint falls back to the CLI.
         assert_eq!(
-            update_notification_body(&esphome_wording().subject("2025.1.0"), "2024.12.2", false),
+            update_notification_body(&esphome_wording().subject("2025.1.0"), "2024.12.2", no_tray),
             "ESPHome 2025.1.0 (stable) is available (you have 2024.12.2). \
              No system tray was detected. Run `esphome-desktop update` from a \
              terminal to update."
         );
         assert_eq!(
-            update_notification_body(&DEVICE_BUILDER_WORDING.subject("1.2.3"), "1.2.2", false),
+            update_notification_body(&DEVICE_BUILDER_WORDING.subject("1.2.3"), "1.2.2", no_tray),
             "ESPHome Device Builder 1.2.3 is available (you have 1.2.2). \
              No system tray was detected. Run `esphome-desktop update` from a \
              terminal to update."
+        );
+    }
+
+    /// The externally-managed hint must never point at the in-app flow: for a
+    /// deb/rpm repackage without its package tool, neither the tray's Check
+    /// for Updates nor the CLI can install the desktop update, so the daily
+    /// notification instructs the package manager instead.
+    #[test]
+    fn notification_body_pins_package_manager_hint() {
+        assert_eq!(
+            update_notification_body("Version 1.2.0", "1.1.2", NotificationHint::PackageManager),
+            "Version 1.2.0 is available (you have 1.1.2). \
+             Update it through your system package manager."
         );
     }
 }

--- a/src-tauri/translations/en.json
+++ b/src-tauri/translations/en.json
@@ -122,6 +122,7 @@
   },
   "hint": {
     "updates_menu": "Open the tray menu and choose \"Check for Updates\" to update.",
-    "updates_cli": "No system tray was detected. Run `esphome-desktop update` from a terminal to update."
+    "updates_cli": "No system tray was detected. Run `esphome-desktop update` from a terminal to update.",
+    "updates_package_manager": "Update it through your system package manager."
   }
 }

--- a/src-tauri/translations/en.json
+++ b/src-tauri/translations/en.json
@@ -69,6 +69,7 @@
     "available_title": "Desktop Update Available",
     "prompt": "ESPHome Device Builder {new} is available.\n\nYou currently have version {current}.\n\nWould you like to download and install it now?",
     "prompt_with_notes": "ESPHome Device Builder {new} is available.\n\nYou currently have version {current}.\n\nRelease notes:\n{notes}\n\nWould you like to download and install it now?",
+    "package_manager_only": "ESPHome Device Builder {new} is available.\n\nThis install cannot update itself because {tool} is not available on this system.\n\nPlease update it through your system package manager.",
     "latest": "ESPHome Device Builder {version} is the latest version.",
     "updater_unavailable": "Updater not available: {error}",
     "update_failed": "Failed to update: {error}",


### PR DESCRIPTION
# What does this implement/fix?

Follow up to #450 for AUR installs. The AUR package repackages the amd64 `.deb`, so the binary carries the deb bundle type while Arch has no `dpkg`; since v1.1.2 the updater resolves the deb target, downloads the full payload, then fails every rung of the plugin's install chain (`pkexec dpkg`, zenity/kdialog password prompt, `sudo dpkg`), showing an elevation prompt on the way down. Reproduced against the real v1.1.2 release in an archlinux container.

The app now checks that the baked bundle type's install tool (`dpkg` for deb, `rpm` for rpm) is on PATH before offering or applying a self-update; this mirrors exactly the dispatch the updater plugin uses. When missing, the tray flow shows a "update through your system package manager" notice instead of the install prompt, the background check keeps the ESPHome and device builder checks running instead of skipping them forever, the CLI `update` notes the situation and continues to the package phases with exit 0, and the noninteractive apply refuses before the download as a backstop. Covers AUR and any future repackager; AppImage, nsis, dmg, and dev builds are untouched.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue (if applicable):**

- fixes <link to issue>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tested on the relevant platform(s) (macOS, Windows, Linux).
